### PR TITLE
[21048] Reset cache changes to avoid data fragmentation issues

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp
@@ -57,6 +57,9 @@ protected:
     //! Override the UnboundedPool::create_element method to create a RouterCacheChange object.
     virtual fastrtps::rtps::CacheChange_t* new_element_() override;
 
+    //! Override the IPool::reset_element_ method to reset the CacheChange as a new obj.
+    virtual void reset_element_(
+            fastrtps::rtps::CacheChange_t* change) override;
 };
 
 } /* namespace core */

--- a/ddspipe_participants/include/ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp
@@ -46,20 +46,20 @@ public:
             utils::PoolConfiguration configuration);
 
     //! Call UnboundedPool::reserve
-    virtual bool reserve_cache(
+    bool reserve_cache(
             fastrtps::rtps::CacheChange_t*& cache_change) override;
 
     //! Call UnboundedPool::release
-    virtual bool release_cache(
+    bool release_cache(
             fastrtps::rtps::CacheChange_t* cache_change) override;
 
 protected:
 
     //! Override the UnboundedPool::create_element method to create a RouterCacheChange object.
-    virtual fastrtps::rtps::CacheChange_t* new_element_() override;
+    fastrtps::rtps::CacheChange_t* new_element_() override;
 
-    //! Override the IPool::reset_element_ method to reset the CacheChange as a new obj.
-    virtual void reset_element_(
+    //! Override the IPool::reset_element_ method to reset the CacheChange as a new object.
+    void reset_element_(
             fastrtps::rtps::CacheChange_t* change) override;
 };
 

--- a/ddspipe_participants/include/ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <fastdds/rtps/common/CacheChange.h>
 #include <fastdds/rtps/history/IChangePool.h>
 
 #include <cpp_utils/pool/UnboundedPool.hpp>

--- a/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
+++ b/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
@@ -43,6 +43,24 @@ fastrtps::rtps::CacheChange_t* CacheChangePool::new_element_()
     return new types::RouterCacheChange();
 }
 
+void CacheChangePool::reset_element_(fastrtps::rtps::CacheChange_t* change)
+{
+    // NOTE: This could be done by =operator but it is deleted, so it must be done field by field
+    change->kind = eprosima::fastrtps::rtps::ALIVE;
+    change->sequenceNumber.high = 0;
+    change->sequenceNumber.low = 0;
+    change->writerGUID = eprosima::fastrtps::rtps::c_Guid_Unknown;
+    change->instanceHandle.clear();
+    change->isRead = 0;
+    change->sourceTimestamp.seconds(0);
+    change->sourceTimestamp.fraction(0);
+    change->writer_info.num_sent_submessages = 0;
+    change->setFragmentSize(0);
+    change->inline_qos.pos = 0;
+    change->inline_qos.length = 0;
+    // TODO check if serialized payload requires to be reset
+}
+
 } /* namespace core */
 } /* namespace ddspipe */
 } /* namespace eprosima */

--- a/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
+++ b/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <efficiency/cache_change/CacheChangePool.hpp>
-#include <types/dds/RouterCacheChange.hpp>
+#include <fastrtps/rtps/common/Guid.h>
+#include <fastdds/rtps/common/ChangeKind_t.hpp>
+
+#include <ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp>
+#include <ddspipe_participants/types/dds/RouterCacheChange.hpp>
 
 namespace eprosima {
 namespace ddspipe {

--- a/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
+++ b/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
@@ -46,19 +46,18 @@ fastrtps::rtps::CacheChange_t* CacheChangePool::new_element_()
 void CacheChangePool::reset_element_(fastrtps::rtps::CacheChange_t* change)
 {
     // NOTE: This could be done by =operator but it is deleted, so it must be done field by field
-    change->kind = eprosima::fastrtps::rtps::ALIVE;
+    change->kind = fastrtps::rtps::ALIVE;
     change->sequenceNumber.high = 0;
     change->sequenceNumber.low = 0;
-    change->writerGUID = eprosima::fastrtps::rtps::c_Guid_Unknown;
+    change->writerGUID = fastrtps::rtps::c_Guid_Unknown;
     change->instanceHandle.clear();
     change->isRead = 0;
     change->sourceTimestamp.seconds(0);
     change->sourceTimestamp.fraction(0);
     change->writer_info.num_sent_submessages = 0;
     change->setFragmentSize(0);
-    change->inline_qos.pos = 0;
-    change->inline_qos.length = 0;
-    // TODO check if serialized payload requires to be reset
+    change->serializedPayload.empty();
+    change->inline_qos.empty();
 }
 
 } /* namespace core */

--- a/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
+++ b/ddspipe_participants/src/cpp/efficiency/cache_change/CacheChangePool.cpp
@@ -43,7 +43,8 @@ fastrtps::rtps::CacheChange_t* CacheChangePool::new_element_()
     return new types::RouterCacheChange();
 }
 
-void CacheChangePool::reset_element_(fastrtps::rtps::CacheChange_t* change)
+void CacheChangePool::reset_element_(
+        fastrtps::rtps::CacheChange_t* change)
 {
     // NOTE: This could be done by =operator but it is deleted, so it must be done field by field
     change->kind = fastrtps::rtps::ALIVE;


### PR DESCRIPTION
This feature resets changes from the RTPS CacheChangePool before returning them to the pool, fixing the issue discovered in https://github.com/eProsima/DDS-Router/discussions/353. 