### PR TITLE
Make schemas ROS 2 compatible

### DIFF
--- a/ddspipe_core/src/cpp/types/dynamic_types/schema.cpp
+++ b/ddspipe_core/src/cpp/types/dynamic_types/schema.cpp
@@ -316,28 +316,31 @@ std::string generate_dyn_type_schema_from_tree(
     return ss.str();
 }
 
-std::string to_ros2_compatible_schema(const std::string& schema_text)
+std::string to_ros2_compatible_schema(
+        const std::string& schema_text)
 {
     std::string ros2_compatible_schema = schema_text;
 
     // Match type names internally generated for TypeLookupService
     std::regex regexp("type_[a-z0-9]+_[a-z0-9]+_[0-9]+");
     std::smatch m;
-    std::regex_search(schema_text, m, regexp);
 
-    for (auto x : m)
+    while (std::regex_search(ros2_compatible_schema, m, regexp))
     {
-        std::string current_type = std::string(x);
-        std::string new_type = current_type;
+        for (auto x : m)
+        {
+            std::string current_type = std::string(x);
+            std::string new_type = current_type;
 
-        // Make first letter uppercase
-        new_type = std::regex_replace(new_type, std::regex("type_"), "Type_");
+            // Make first letter uppercase
+            new_type = std::regex_replace(new_type, std::regex("type_"), "Type_");
 
-        // Remove all underscores
-        new_type = std::regex_replace(new_type, std::regex("_"), "");
+            // Remove all underscores
+            new_type = std::regex_replace(new_type, std::regex("_"), "");
 
-        // Substitute all occurrences by new type name
-        ros2_compatible_schema = std::regex_replace(ros2_compatible_schema, std::regex(current_type), new_type);
+            // Substitute all occurrences by new type name
+            ros2_compatible_schema = std::regex_replace(ros2_compatible_schema, std::regex(current_type), new_type);
+        }
     }
     return ros2_compatible_schema;
 }


### PR DESCRIPTION
Generated schemas containing type names internally generated for Fast DDS TypeLookupService (type_GuidPrefix_EntityId_SequenceNumber) are not compatible with some ROS 2 specific libraries (e.g. [mcap-ros2-support](https://pypi.org/project/mcap-ros2-support/) ).

Testing scenario:
- Publish a complex dynamic type (involving the use of TypeLookupService)
- Capture traffic with [DDS-Recorder](https://github.com/eProsima/DDS-Recorder)
- Read MCAP file from Python as in the following [example](https://mcap.dev/docs/python/ros2_noenv_example.html#reading-messages)

**Note**
Type/Schema names (i.e. name of .idl files and the structures there defined) should also be ROS 2 compatible (e.g. not contain underscores), but that would be user's responsibility.
