### PR TITLE
Fix DomainId ctor common mistake

### DIFF
--- a/ddspipe_core/include/ddspipe_core/types/dds/DomainId.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/DomainId.hpp
@@ -38,7 +38,7 @@ struct DomainId : public IConfiguration
 
     DDSPIPE_CORE_DllAPI
     DomainId (
-            const DomainIdType& domain_id) noexcept;
+            const DomainIdType& domain_id);
 
     DDSPIPE_CORE_DllAPI
     explicit DomainId (

--- a/ddspipe_core/include/ddspipe_core/types/dds/DomainId.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/DomainId.hpp
@@ -38,7 +38,11 @@ struct DomainId : public IConfiguration
 
     DDSPIPE_CORE_DllAPI
     DomainId (
-            bool discovery_server) noexcept;
+            const DomainIdType& domain_id) noexcept;
+
+    DDSPIPE_CORE_DllAPI
+    explicit DomainId (
+            const bool discovery_server) noexcept;
 
     DDSPIPE_CORE_DllAPI
     operator DomainIdType() const noexcept;

--- a/ddspipe_core/src/cpp/types/dds/DomainId.cpp
+++ b/ddspipe_core/src/cpp/types/dds/DomainId.cpp
@@ -22,7 +22,14 @@ namespace types {
 constexpr const DomainIdType DomainId::MAX_DOMAIN_ID;
 
 DomainId::DomainId (
-        bool discovery_server) noexcept
+        const DomainIdType& domain_id) noexcept
+    : domain_id(domain_id)
+{
+    // Do nothing
+}
+
+DomainId::DomainId (
+        const bool discovery_server) noexcept
     : domain_id(DEFAULT_DOMAIN_ID)
 {
     // Discovery Server case has a different default value

--- a/ddspipe_core/src/cpp/types/dds/DomainId.cpp
+++ b/ddspipe_core/src/cpp/types/dds/DomainId.cpp
@@ -24,7 +24,7 @@ namespace types {
 constexpr const DomainIdType DomainId::MAX_DOMAIN_ID;
 
 DomainId::DomainId (
-        const DomainIdType& domain_id) noexcept
+        const DomainIdType& domain_id)
     : domain_id(domain_id)
 {
     if (domain_id > MAX_DOMAIN_ID)

--- a/ddspipe_core/src/cpp/types/dds/DomainId.cpp
+++ b/ddspipe_core/src/cpp/types/dds/DomainId.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cpp_utils/exception/PreconditionNotMet.hpp>
+
 #include <ddspipe_core/types/dds/DomainId.hpp>
 
 namespace eprosima {
@@ -25,7 +27,10 @@ DomainId::DomainId (
         const DomainIdType& domain_id) noexcept
     : domain_id(domain_id)
 {
-    // Do nothing
+    if (domain_id > MAX_DOMAIN_ID)
+    {
+        throw utils::PreconditionNotMet(STR_ENTRY << "Domain id cannot be higher than " << MAX_DOMAIN_ID << ".");
+    }
 }
 
 DomainId::DomainId (


### PR DESCRIPTION
DomainId had a ctor with a boolean and anything else. Thus, trying to create it from an int (what makes much sense) does not give the expected domain because it is parsed as bool