### PR TITLE
Only create readers, writers, and tracks when they are going to be used [19421]

### DIFF
--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -58,7 +58,7 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const RoutesConfiguration& routes_config,
-            const types::ParticipantId& subscriber_id);
+            const types::ParticipantId& discoverer_id);
 
     DDSPIPE_CORE_DllAPI
     ~DdsBridge();
@@ -87,8 +87,8 @@ public:
      *
      * THREAD SAFE?
      */
-    utils::ReturnCode add_endpoint(
-            const types::ParticipantId& subscriber_id) noexcept;
+    utils::ReturnCode add_subscriber(
+            const types::ParticipantId& id) noexcept;
 
     /**
      * Remove the DW from all the Tracks in the bridge.
@@ -96,8 +96,8 @@ public:
      *
      * THREAD SAFE?
      */
-    utils::ReturnCode remove_endpoint(
-            const types::ParticipantId& subscriber_id) noexcept;
+    utils::ReturnCode remove_subscriber(
+            const types::ParticipantId& id) noexcept;
 
 protected:
 

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -58,7 +58,8 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const RoutesConfiguration& routes_config,
-            const types::ParticipantId& discoverer_participant_id);
+            const bool dynamic_tracks,
+            const types::ParticipantId& discoverer_participant_id = "");
 
     DDSPIPE_CORE_DllAPI
     ~DdsBridge();
@@ -82,12 +83,23 @@ public:
     void disable() noexcept override;
 
     /**
+     * Create the readers, writers, and tracks that are required by the routes.
+     *
+     * Thread safe
+     *
+     * @throw InitializationException in case \c IWriters or \c IReaders creation fails.
+     */
+    DDSPIPE_CORE_DllAPI
+    void create_all_tracks();
+
+    /**
      * Build the DataReaders and DataWriters inside the bridge for the new participant,
      * and add them to the Tracks.
      *
      * Thread safe
      *
-     * @param discoverer_participant_id: The id of the participant who has discovered that the subscriber has become inactive.
+     * @param discoverer_participant_id: The id of the participant who has discovered that the subscriber has become
+     * inactive.
      *
      * @throw InitializationException in case \c IWriters or \c IReaders creation fails.
      */
@@ -101,15 +113,29 @@ public:
      *
      * Thread safe
      *
-     * @param discoverer_participant_id: The id of the participant who has discovered that the subscriber has become inactive.
-     *
-     * @throw InitializationException in case \c IWriters or \c IReaders creation fails.
+     * @param discoverer_participant_id: The id of the participant who has discovered that the subscriber has become
+     * inactive.
      */
     DDSPIPE_CORE_DllAPI
     void remove_from_tracks(
             const types::ParticipantId& discoverer_participant_id) noexcept;
 
 protected:
+
+    /**
+     * Add each Participant's DataWriters to its Track.
+     * If the Participant's DataReader doesn't exist, create it.
+     * If the Participant's Track doesn't exist, create it.
+     *
+     * Thread safe
+     *
+     * @param writers: The map of ids to writers that are required for the tracks.
+     *
+     * @throw InitializationException in case \c IReaders creation fails.
+     */
+    DDSPIPE_CORE_DllAPI
+    void add_writers_to_tracks_(
+            std::map<types::ParticipantId, std::shared_ptr<IWriter>>& writers);
 
     utils::Heritable<types::DistributedTopic> topic_;
 

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -87,7 +87,8 @@ public:
      *
      * THREAD SAFE?
      */
-    utils::ReturnCode add_endpoint(const types::ParticipantId& subscriber_id) noexcept;
+    utils::ReturnCode add_endpoint(
+            const types::ParticipantId& subscriber_id) noexcept;
 
     /**
      * Remove the DW from all the Tracks in the bridge.
@@ -95,7 +96,8 @@ public:
      *
      * THREAD SAFE?
      */
-    utils::ReturnCode remove_endpoint(const types::ParticipantId& subscriber_id) noexcept;
+    utils::ReturnCode remove_endpoint(
+            const types::ParticipantId& subscriber_id) noexcept;
 
 protected:
 

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -87,8 +87,7 @@ public:
      *
      * Thread safe
      *
-     * @param participant_id: The id of the participant who has discovered that the subscriber has become
-     * inactive.
+     * @param participant_id: The id of the participant who is creating the writer.
      *
      * @throw InitializationException in case \c IWriters or \c IReaders creation fails.
      */
@@ -102,8 +101,7 @@ public:
      *
      * Thread safe
      *
-     * @param participant_id: The id of the participant who has discovered that the subscriber has become
-     * inactive.
+     * @param participant_id: The id of the participant who is removing the writer.
      */
     DDSPIPE_CORE_DllAPI
     void remove_writer(

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -58,7 +58,7 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const RoutesConfiguration& routes_config,
-            const types::ParticipantId& discoverer_id);
+            const types::ParticipantId& discoverer_participant_id);
 
     DDSPIPE_CORE_DllAPI
     ~DdsBridge();
@@ -82,22 +82,32 @@ public:
     void disable() noexcept override;
 
     /**
-     * Build the DRs and DWs inside the bridge for the new participant,
+     * Build the DataReaders and DataWriters inside the bridge for the new participant,
      * and add them to the Tracks.
      *
-     * THREAD SAFE?
+     * Thread safe
+     *
+     * @param discoverer_participant_id: The id of the participant who has discovered that the subscriber has become inactive.
+     *
+     * @throw InitializationException in case \c IWriters or \c IReaders creation fails.
      */
-    utils::ReturnCode add_subscriber(
-            const types::ParticipantId& id) noexcept;
+    DDSPIPE_CORE_DllAPI
+    void add_to_tracks(
+            const types::ParticipantId& discoverer_participant_id);
 
     /**
-     * Remove the DW from all the Tracks in the bridge.
-     * Remove the DRs and Tracks that don't have any DWs.
+     * Remove the DatWriter from all the Tracks in the bridge.
+     * Remove the DataReaders and Tracks that don't have any DataWriters.
      *
-     * THREAD SAFE?
+     * Thread safe
+     *
+     * @param discoverer_participant_id: The id of the participant who has discovered that the subscriber has become inactive.
+     *
+     * @throw InitializationException in case \c IWriters or \c IReaders creation fails.
      */
-    utils::ReturnCode remove_subscriber(
-            const types::ParticipantId& id) noexcept;
+    DDSPIPE_CORE_DllAPI
+    void remove_from_tracks(
+            const types::ParticipantId& discoverer_participant_id) noexcept;
 
 protected:
 

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -58,7 +58,7 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const RoutesConfiguration& routes_config,
-            const bool dynamic_tracks,
+            const bool remove_unused_entities,
             const types::ParticipantId& discoverer_participant_id = "");
 
     DDSPIPE_CORE_DllAPI

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -83,11 +83,19 @@ public:
 
     /**
      * Build the DRs and DWs inside the bridge for the new participant,
-     * and add them to the tracks.
+     * and add them to the Tracks.
      *
      * THREAD SAFE?
      */
     utils::ReturnCode add_endpoint(const types::ParticipantId& subscriber_id) noexcept;
+
+    /**
+     * Remove the DW from all the Tracks in the bridge.
+     * Remove the DRs and Tracks that don't have any DWs.
+     *
+     * THREAD SAFE?
+     */
+    utils::ReturnCode remove_endpoint(const types::ParticipantId& subscriber_id) noexcept;
 
 protected:
 

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -57,7 +57,8 @@ public:
             const std::shared_ptr<ParticipantsDatabase>& participants_database,
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
-            const RoutesConfiguration& routes_config);
+            const RoutesConfiguration& routes_config,
+            const types::ParticipantId& discoverer_participant_id);
 
     DDSPIPE_CORE_DllAPI
     ~DdsBridge();
@@ -80,9 +81,19 @@ public:
     DDSPIPE_CORE_DllAPI
     void disable() noexcept override;
 
+    /**
+     * Build the DRs and DWs inside the bridge for the new participant,
+     * and add them to the tracks.
+     *
+     * THREAD SAFE?
+     */
+    utils::ReturnCode add_endpoint(const types::ParticipantId& discoverer_participant_id) noexcept;
+
 protected:
 
     utils::Heritable<types::DistributedTopic> topic_;
+
+    RoutesConfiguration routes_config_;
 
     /**
      * Inside \c Tracks

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -58,7 +58,7 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const RoutesConfiguration& routes_config,
-            const types::ParticipantId& discoverer_participant_id);
+            const types::ParticipantId& subscriber_id);
 
     DDSPIPE_CORE_DllAPI
     ~DdsBridge();
@@ -87,13 +87,13 @@ public:
      *
      * THREAD SAFE?
      */
-    utils::ReturnCode add_endpoint(const types::ParticipantId& discoverer_participant_id) noexcept;
+    utils::ReturnCode add_endpoint(const types::ParticipantId& subscriber_id) noexcept;
 
 protected:
 
     utils::Heritable<types::DistributedTopic> topic_;
 
-    RoutesConfiguration routes_config_;
+    RoutesConfiguration::RoutesMap routes_;
 
     /**
      * Inside \c Tracks

--- a/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
@@ -127,12 +127,12 @@ public:
             const types::ParticipantId& id) noexcept;
 
     /**
-     * Count the number of writers inside the track.
+     * Check if a track has at least one writer.
      *
      * Tread safe
      */
     DDSPIPE_CORE_DllAPI
-    int count_writers() noexcept;
+    bool has_writers() noexcept;
 
 protected:
 

--- a/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
@@ -103,7 +103,9 @@ public:
      * THREAD SAFE?
      */
     DDSPIPE_CORE_DllAPI
-    void add_writer(const types::ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept;
+    void add_writer(
+            const types::ParticipantId& id,
+            const std::shared_ptr<IWriter>& writer) noexcept;
 
     /**
      * Remove a writer from the track.
@@ -112,7 +114,8 @@ public:
      * THREAD SAFE?
      */
     DDSPIPE_CORE_DllAPI
-    void remove_writer(const types::ParticipantId& id) noexcept;
+    void remove_writer(
+            const types::ParticipantId& id) noexcept;
 
     /**
      * Check if a writer is inside the track.
@@ -120,7 +123,8 @@ public:
      * THREAD SAFE?
      */
     DDSPIPE_CORE_DllAPI
-    bool has_writer(const types::ParticipantId& id) noexcept;
+    bool has_writer(
+            const types::ParticipantId& id) noexcept;
 
     /**
      * Count the number of writers inside the track.

--- a/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
@@ -100,7 +100,7 @@ public:
      * Add a writer to the track.
      * It doesn't do anything if the writer is already in it.
      *
-     * THREAD SAFE?
+     * Tread safe
      */
     DDSPIPE_CORE_DllAPI
     void add_writer(
@@ -111,7 +111,7 @@ public:
      * Remove a writer from the track.
      * It doesn't do anything if the writer isn't in the track.
      *
-     * THREAD SAFE?
+     * Tread safe
      */
     DDSPIPE_CORE_DllAPI
     void remove_writer(
@@ -120,7 +120,7 @@ public:
     /**
      * Check if a writer is inside the track.
      *
-     * THREAD SAFE?
+     * Tread safe
      */
     DDSPIPE_CORE_DllAPI
     bool has_writer(
@@ -129,7 +129,7 @@ public:
     /**
      * Count the number of writers inside the track.
      *
-     * THREAD SAFE?
+     * Tread safe
      */
     DDSPIPE_CORE_DllAPI
     int count_writers() noexcept;

--- a/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
@@ -96,8 +96,39 @@ public:
     DDSPIPE_CORE_DllAPI
     void disable() noexcept;
 
-
+    /**
+     * Add a writer to the track.
+     * It doesn't do anything if the writer is already in it.
+     *
+     * THREAD SAFE?
+     */
+    DDSPIPE_CORE_DllAPI
     void add_writer(const types::ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept;
+
+    /**
+     * Remove a writer from the track.
+     * It doesn't do anything if the writer isn't in the track.
+     *
+     * THREAD SAFE?
+     */
+    DDSPIPE_CORE_DllAPI
+    void remove_writer(const types::ParticipantId& id) noexcept;
+
+    /**
+     * Check if a writer is inside the track.
+     *
+     * THREAD SAFE?
+     */
+    DDSPIPE_CORE_DllAPI
+    bool has_writer(const types::ParticipantId& id) noexcept;
+
+    /**
+     * Count the number of writers inside the track.
+     *
+     * THREAD SAFE?
+     */
+    DDSPIPE_CORE_DllAPI
+    int count_writers() noexcept;
 
 protected:
 

--- a/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/Track.hpp
@@ -96,6 +96,9 @@ public:
     DDSPIPE_CORE_DllAPI
     void disable() noexcept;
 
+
+    void add_writer(const types::ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept;
+
 protected:
 
     /*

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -20,12 +20,13 @@
 #include <cpp_utils/Formatter.hpp>
 
 #include <ddspipe_core/configuration/IConfiguration.hpp>
-#include <ddspipe_core/types/participant/ParticipantId.hpp>
-#include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/configuration/RoutesConfiguration.hpp>
 #include <ddspipe_core/configuration/TopicRoutesConfiguration.hpp>
 
 #include <ddspipe_core/library/library_dll.h>
+
+#include <ddspipe_core/types/participant/ParticipantId.hpp>
+#include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 
 namespace eprosima {
 namespace ddspipe {
@@ -67,6 +68,7 @@ struct DdsPipeConfiguration : public IConfiguration
 
     TopicRoutesConfiguration topic_routes_config{};
 
+    //! Remove unused entities configuration. False by default.
     bool remove_unused_entities = false;
 };
 

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -56,8 +56,8 @@ struct DdsPipeConfiguration : public IConfiguration
     /**
      * @brief Check if a configuration is valid given a list of participants.
      *
-     * It calls its own \c is_valid method plus the \c is_valid
-     * in \c RoutesConfiguration and \c TopicRoutesConfiguratoin
+     * It calls its own \c is_valid method plus the \c is_valid method of the
+     * encapsulated configurations.
      */
     DDSPIPE_CORE_DllAPI
     bool is_valid(

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -22,11 +22,10 @@
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/configuration/RoutesConfiguration.hpp>
 #include <ddspipe_core/configuration/TopicRoutesConfiguration.hpp>
-
-#include <ddspipe_core/library/library_dll.h>
-
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
+
+#include <ddspipe_core/library/library_dll.h>
 
 namespace eprosima {
 namespace ddspipe {
@@ -47,15 +46,29 @@ struct DdsPipeConfiguration : public IConfiguration
     // METHODS
     /////////////////////////
 
+    /**
+     * @brief Override \c is_valid method.
+     */
     DDSPIPE_CORE_DllAPI
     virtual bool is_valid(
             utils::Formatter& error_msg) const noexcept override;
 
+    /**
+     * @brief Check if a configuration is valid given a list of participants.
+     *
+     * It calls its own \c is_valid method plus the \c is_valid
+     * in \c RoutesConfiguration and \c TopicRoutesConfiguratoin
+     */
     DDSPIPE_CORE_DllAPI
     bool is_valid(
             utils::Formatter& error_msg,
             std::map<types::ParticipantId, bool> participant_ids) const noexcept;
 
+    /**
+     * @brief Select the \c RoutesConfiguration for a topic.
+     *
+     * @return The route configuration for a specific topic.
+     */
     DDSPIPE_CORE_DllAPI
     RoutesConfiguration get_routes_config(
             const utils::Heritable<types::DistributedTopic> &topic) const noexcept;
@@ -64,11 +77,17 @@ struct DdsPipeConfiguration : public IConfiguration
     // VARIABLES
     /////////////////////////
 
+    //! Configuration of the generic routes
     RoutesConfiguration routes_config{};
 
+    //! Configuration of the routes specific to a topic
     TopicRoutesConfiguration topic_routes_config{};
 
-    //! Remove unused entities configuration. False by default.
+    /**
+     * @brief Whether entities should be removed when they have no writers connected to them.
+     *
+     * @note False by default.
+     */
     bool remove_unused_entities = false;
 };
 

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -62,7 +62,7 @@ struct DdsPipeConfiguration : public IConfiguration
     DDSPIPE_CORE_DllAPI
     bool is_valid(
             utils::Formatter& error_msg,
-            std::map<types::ParticipantId, bool> participant_ids) const noexcept;
+            const std::map<types::ParticipantId, bool>& participants) const noexcept;
 
     /**
      * @brief Select the \c RoutesConfiguration for a topic.

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -1,0 +1,75 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <set>
+
+#include <cpp_utils/Formatter.hpp>
+
+#include <ddspipe_core/configuration/IConfiguration.hpp>
+#include <ddspipe_core/types/participant/ParticipantId.hpp>
+#include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
+#include <ddspipe_core/configuration/RoutesConfiguration.hpp>
+#include <ddspipe_core/configuration/TopicRoutesConfiguration.hpp>
+
+#include <ddspipe_core/library/library_dll.h>
+
+namespace eprosima {
+namespace ddspipe {
+namespace core {
+
+/**
+ * Configuration structure encapsulating the configuration of a \c DdsPipe instance.
+ */
+struct DdsPipeConfiguration : public IConfiguration
+{
+    /////////////////////////
+    // CONSTRUCTORS
+    /////////////////////////
+
+    DDSPIPE_CORE_DllAPI DdsPipeConfiguration() = default;
+
+    /////////////////////////
+    // METHODS
+    /////////////////////////
+
+    DDSPIPE_CORE_DllAPI
+    virtual bool is_valid(
+            utils::Formatter& error_msg) const noexcept override;
+
+    DDSPIPE_CORE_DllAPI
+    bool is_valid(
+            utils::Formatter& error_msg,
+            std::map<types::ParticipantId, bool> participant_ids) const noexcept;
+
+    DDSPIPE_CORE_DllAPI
+    RoutesConfiguration get_routes_config(
+            const utils::Heritable<types::DistributedTopic> &topic) const noexcept;
+
+    /////////////////////////
+    // VARIABLES
+    /////////////////////////
+
+    RoutesConfiguration routes_config{};
+
+    TopicRoutesConfiguration topic_routes_config{};
+
+    bool remove_unused_entities = false;
+};
+
+} /* namespace core */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -77,17 +77,13 @@ struct DdsPipeConfiguration : public IConfiguration
     // VARIABLES
     /////////////////////////
 
-    //! Configuration of the generic routes
-    RoutesConfiguration routes_config{};
+    //! Configuration of the generic routes.
+    RoutesConfiguration routes{};
 
-    //! Configuration of the routes specific to a topic
-    TopicRoutesConfiguration topic_routes_config{};
+    //! Configuration of the routes specific to a topic.
+    TopicRoutesConfiguration topic_routes{};
 
-    /**
-     * @brief Whether entities should be removed when they have no writers connected to them.
-     *
-     * @note False by default.
-     */
+    //! Whether entities should be removed when they have no writers connected to them.
     bool remove_unused_entities = false;
 };
 

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -71,7 +71,7 @@ struct DdsPipeConfiguration : public IConfiguration
      */
     DDSPIPE_CORE_DllAPI
     RoutesConfiguration get_routes_config(
-            const utils::Heritable<types::DistributedTopic> &topic) const noexcept;
+            const utils::Heritable<types::DistributedTopic>& topic) const noexcept;
 
     /////////////////////////
     // VARIABLES

--- a/ddspipe_core/include/ddspipe_core/configuration/RoutesConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/RoutesConfiguration.hpp
@@ -51,7 +51,7 @@ struct RoutesConfiguration : public IConfiguration
 
     DDSPIPE_CORE_DllAPI bool is_valid(
             utils::Formatter& error_msg,
-            std::map<types::ParticipantId, bool> participant_ids) const noexcept;
+            const std::map<types::ParticipantId, bool>& participants) const noexcept;
 
     /////////////////////////
     // OPERATORS

--- a/ddspipe_core/include/ddspipe_core/configuration/TopicRoutesConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/TopicRoutesConfiguration.hpp
@@ -52,7 +52,7 @@ struct TopicRoutesConfiguration : public IConfiguration
 
     DDSPIPE_CORE_DllAPI bool is_valid(
             utils::Formatter& error_msg,
-            std::map<types::ParticipantId, bool> participant_ids) const noexcept;
+            const std::map<types::ParticipantId, bool>& participant_ids) const noexcept;
 
     /////////////////////////
     // OPERATORS

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -136,13 +136,21 @@ protected:
     /////////////////////////
 
     /**
-     * @brief Method called every time a new endpoint has been discovered/updated
+     * @brief Method called every time a new endpoint has been discovered
      *
      * This method calls \c discovered_topic_ with the topic of \c endpoint as parameter.
      *
      * @param [in] endpoint : endpoint discovered
      */
     void discovered_endpoint_(
+            const types::Endpoint& endpoint) noexcept;
+
+    /**
+     * @brief Method called every time a new endpoint has been updated
+     *
+     * @param [in] endpoint : endpoint updated
+     */
+    void updated_endpoint_(
             const types::Endpoint& endpoint) noexcept;
 
     /**
@@ -176,10 +184,25 @@ protected:
      * @note This is the only method that adds topics to \c current_topics_
      *
      * @param [in] topic : topic discovered
+     * @param [in] subscriber_id : id of the subscriber who discovered the topic
      */
     void discovered_topic_nts_(
             const utils::Heritable<types::DistributedTopic>& topic,
             const types::ParticipantId& subscriber_id) noexcept;
+
+    /**
+     * @brief Method called every time a new endpoint has been discovered/updated
+     *
+     * This method is called with the topic of a new/updated \c Endpoint discovered.
+     * If the DdsPipe is enabled, the new Bridge is created and enabled.
+     *
+     * @note This is the only method that adds topics to \c current_topics_
+     *
+     * @param [in] topic : topic discovered
+     */
+    void removed_topic_nts_(
+        const utils::Heritable<types::DistributedTopic>& topic,
+        const types::ParticipantId& subscriber_id) noexcept;
 
     /**
      * @brief Method called every time a new endpoint (corresponding to a server) has been discovered/updated

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -362,12 +362,9 @@ protected:
      */
     std::map<types::RpcTopic, bool> current_services_;
 
-    /////
+    /////////////////////
     // AUXILIAR VARIABLES
-    /////////////////////////
-
-    //! Whether readers that aren't connected to any writers should be deleted
-    bool dynamic_tracks_;
+    /////////////////////
 
     //! Whether the DdsPipe is currently communicating data or not
     bool enabled_;
@@ -377,15 +374,22 @@ protected:
      */
     mutable std::mutex mutex_;
 
-    /////////////////////////
+    //////////////////////////
     // CONFIGURATION VARIABLES
-    /////////////////////////
+    //////////////////////////
 
     //! Custom forwarding routes
     RoutesConfiguration routes_config_;
 
     //! Custom forwarding routes per topic
     TopicRoutesConfiguration topic_routes_config_;
+
+    /////////////////
+    // DYNAMIC TRACKS
+    /////////////////
+
+    //! Whether readers that aren't connected to any writers should be deleted
+    bool dynamic_tracks_;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -191,20 +191,6 @@ protected:
             const types::ParticipantId& subscriber_id) noexcept;
 
     /**
-     * @brief Method called every time a new endpoint has been discovered/updated
-     *
-     * This method is called with the topic of a new/updated \c Endpoint discovered.
-     * If the DdsPipe is enabled, the new Bridge is created and enabled.
-     *
-     * @note This is the only method that adds topics to \c current_topics_
-     *
-     * @param [in] topic : topic discovered
-     */
-    void removed_topic_nts_(
-        const utils::Heritable<types::DistributedTopic>& topic,
-        const types::ParticipantId& subscriber_id) noexcept;
-
-    /**
      * @brief Method called every time a new endpoint (corresponding to a server) has been discovered/updated
      *
      * This method is called with the topic of a new/updated \c Endpoint discovered.

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -178,7 +178,8 @@ protected:
      * @param [in] topic : topic discovered
      */
     void discovered_topic_nts_(
-            const utils::Heritable<types::DistributedTopic>& topic) noexcept;
+            const utils::Heritable<types::DistributedTopic>& topic,
+            const types::ParticipantId& discoverer_participant_id) noexcept;
 
     /**
      * @brief Method called every time a new endpoint (corresponding to a server) has been discovered/updated
@@ -312,6 +313,7 @@ protected:
      * If the value is true, it means this topic is currently activated.
      */
     std::map<utils::Heritable<types::DistributedTopic>, bool> current_topics_;
+    std::map<utils::Heritable<types::DistributedTopic>, types::ParticipantId> current_topics_discoverers_;
 
     /**
      * @brief List of RPC topics discovered

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -67,6 +67,7 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<ParticipantsDatabase>& participants_database,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
+            const bool delete_unused_entities,
             const std::set<utils::Heritable<types::DistributedTopic>>& builtin_topics = {},
             bool start_enable = false,
             const RoutesConfiguration& routes_config = {},
@@ -361,9 +362,12 @@ protected:
      */
     std::map<types::RpcTopic, bool> current_services_;
 
-    /////////////////////////
+    /////
     // AUXILIAR VARIABLES
     /////////////////////////
+
+    //! Whether readers that aren't connected to any writers should be deleted
+    bool delete_unused_entities_;
 
     //! Whether the DdsPipe is currently communicating data or not
     bool enabled_;

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -71,7 +71,7 @@ public:
             bool start_enable = false,
             const RoutesConfiguration& routes_config = {},
             const TopicRoutesConfiguration& topic_routes_config = {},
-            const bool dynamic_tracks = false);
+            const bool remove_unused_entities = false);
 
     /**
      * @brief Destroy the DdsPipe object
@@ -384,12 +384,12 @@ protected:
     //! Custom forwarding routes per topic
     TopicRoutesConfiguration topic_routes_config_;
 
-    /////////////////
-    // DYNAMIC TRACKS
-    /////////////////
+    /////////////////////////
+    // REMOVE UNUSED ENTITIES
+    /////////////////////////
 
     //! Whether readers that aren't connected to any writers should be deleted
-    bool dynamic_tracks_;
+    bool remove_unused_entities_;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -67,11 +67,11 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<ParticipantsDatabase>& participants_database,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
-            const bool delete_unused_entities,
             const std::set<utils::Heritable<types::DistributedTopic>>& builtin_topics = {},
             bool start_enable = false,
             const RoutesConfiguration& routes_config = {},
-            const TopicRoutesConfiguration& topic_routes_config = {});
+            const TopicRoutesConfiguration& topic_routes_config = {},
+            const bool delete_unused_entities = false);
 
     /**
      * @brief Destroy the DdsPipe object

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -179,7 +179,7 @@ protected:
      */
     void discovered_topic_nts_(
             const utils::Heritable<types::DistributedTopic>& topic,
-            const types::ParticipantId& discoverer_participant_id) noexcept;
+            const types::ParticipantId& subscriber_id) noexcept;
 
     /**
      * @brief Method called every time a new endpoint (corresponding to a server) has been discovered/updated

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -204,13 +204,14 @@ protected:
      * If the DdsPipe is enabled, the new Bridge is created and enabled.
      *
      * @note This is the only method that adds topics to \c current_topics_
+     * @note This is the only method that adds topics to \c current_topics_discoverers_
      *
      * @param [in] topic : topic discovered
-     * @param [in] subscriber_id : id of the subscriber who discovered the topic
+     * @param [in] discoverer_participant_id : id of the subscriber who discovered the topic
      */
     void discovered_topic_nts_(
             const utils::Heritable<types::DistributedTopic>& topic,
-            const types::ParticipantId& subscriber_id) noexcept;
+            const types::ParticipantId& discoverer_participant_id) noexcept;
 
     /**
      * @brief Method called every time a new endpoint (corresponding to a server) has been discovered/updated
@@ -344,6 +345,12 @@ protected:
      * If the value is true, it means this topic is currently activated.
      */
     std::map<utils::Heritable<types::DistributedTopic>, bool> current_topics_;
+
+    /**
+     * @brief List of the ids of the participants who discovered each topic.
+     *
+     * Every topic discovered is added to the map.
+     */
     std::map<utils::Heritable<types::DistributedTopic>, types::ParticipantId> current_topics_discoverers_;
 
     /**

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -220,10 +220,8 @@ protected:
      * If the DdsPipe is enabled, the new Bridge is created and enabled.
      *
      * @note This is the only method that adds topics to \c current_topics_
-     * @note This is the only method that adds topics to \c current_topics_discoverers_
      *
      * @param [in] topic : topic discovered
-     * @param [in] discoverer_participant_id : id of the participant who discovered the topic
      */
     void discovered_topic_nts_(
             const utils::Heritable<types::DistributedTopic>& topic) noexcept;

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -68,7 +68,7 @@ public:
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const std::set<utils::Heritable<types::DistributedTopic>>& builtin_topics = {},
             bool start_enable = false,
-            const DdsPipeConfiguration& ddspipe_config = {});
+            const DdsPipeConfiguration& configuration = {});
 
     /**
      * @brief Destroy the DdsPipe object
@@ -384,7 +384,7 @@ protected:
     //////////////////////////
 
     //! Configuration of the DDS Pipe
-    DdsPipeConfiguration ddspipe_config_;
+    DdsPipeConfiguration configuration_;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -383,7 +383,7 @@ protected:
     // CONFIGURATION VARIABLES
     //////////////////////////
 
-    //! Custom forwarding routes
+    //! Configuration of the DDS Pipe
     DdsPipeConfiguration ddspipe_config_;
 };
 

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -71,7 +71,7 @@ public:
             bool start_enable = false,
             const RoutesConfiguration& routes_config = {},
             const TopicRoutesConfiguration& topic_routes_config = {},
-            const bool delete_unused_entities = false);
+            const bool dynamic_tracks = false);
 
     /**
      * @brief Destroy the DdsPipe object
@@ -367,7 +367,7 @@ protected:
     /////////////////////////
 
     //! Whether readers that aren't connected to any writers should be deleted
-    bool delete_unused_entities_;
+    bool dynamic_tracks_;
 
     //! Whether the DdsPipe is currently communicating data or not
     bool enabled_;

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -138,7 +138,7 @@ protected:
     /**
      * @brief Method called every time a new endpoint has been discovered
      *
-     * This method calls \c discovered_topic_ with the topic of \c endpoint as parameter.
+     * This method calls \c discovered_endpoint_nts_ with a lock on the mutex to make it thread safe.
      *
      * @param [in] endpoint : endpoint discovered
      */
@@ -148,6 +148,8 @@ protected:
     /**
      * @brief Method called every time a new endpoint has been updated
      *
+     * This method calls \c discovered_endpoint_nts_ or \c removed_endpoint_nts_ with a lock on the mutex to make it thread safe.
+     *
      * @param [in] endpoint : endpoint updated
      */
     void updated_endpoint_(
@@ -156,9 +158,29 @@ protected:
     /**
      * @brief Method called every time an endpoint has been removed/dropped
      *
+     * This method calls \c removed_endpoint_nts_ with a lock on the mutex to make it thread safe.
+     *
      * @param [in] endpoint : endpoint removed/dropped
      */
     void removed_endpoint_(
+            const types::Endpoint& endpoint) noexcept;
+
+    /**
+     * @brief Method called every time a new endpoint has been discovered
+     *
+     * This method calls \c discovered_topic_ with the topic of \c endpoint as parameter.
+     *
+     * @param [in] endpoint : endpoint discovered
+     */
+    void discovered_endpoint_nts_(
+            const types::Endpoint& endpoint) noexcept;
+
+    /**
+     * @brief Method called every time an endpoint has been removed/dropped
+     *
+     * @param [in] endpoint : endpoint removed/dropped
+     */
+    void removed_endpoint_nts_(
             const types::Endpoint& endpoint) noexcept;
 
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -196,7 +196,7 @@ protected:
      *
      * @param [in] endpoint : endpoint discovered, removed, or updated.
      */
-    bool is_endpoint_relevant_nts_(
+    bool is_endpoint_relevant_(
             const types::Endpoint& endpoint) noexcept;
 
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
+++ b/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
@@ -150,6 +150,13 @@ public:
             const types::Guid& endpoint_guid) const;
 
     /**
+     * @brief Get the map of endpoints
+     *
+     * @return Map of endpoints
+     */
+    std::map<types::Guid, types::Endpoint> get_endpoints() const noexcept;
+
+    /**
      * @brief Add callback to be called when discovering an Endpoint
      *
      * @param [in] endpoint_discovered_callback: callback to add

--- a/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
+++ b/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
@@ -154,6 +154,7 @@ public:
      *
      * @return Map of endpoints
      */
+    DDSPIPE_CORE_DllAPI
     std::map<types::Guid, types::Endpoint> get_endpoints() const noexcept;
 
     /**

--- a/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
+++ b/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
@@ -150,7 +150,7 @@ public:
             const types::Guid& endpoint_guid) const;
 
     /**
-     * @brief Apply a filter to the endpoints
+     * @brief Get the endpoints that pass the given filter
      *
      * @return A map with the endpoints that pass the filter
      */

--- a/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
+++ b/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
@@ -155,7 +155,8 @@ public:
      * @return Map of endpoints
      */
     DDSPIPE_CORE_DllAPI
-    std::map<types::Guid, types::Endpoint> get_endpoints() const noexcept;
+    std::map<types::Guid, types::Endpoint> get_endpoints(
+            std::function<bool(const types::Endpoint&)> is_valid_endpoint) const noexcept;
 
     /**
      * @brief Add callback to be called when discovering an Endpoint

--- a/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
+++ b/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
@@ -150,9 +150,9 @@ public:
             const types::Guid& endpoint_guid) const;
 
     /**
-     * @brief Get the map of endpoints
+     * @brief Apply a filter to the endpoints
      *
-     * @return Map of endpoints
+     * @return A map with the endpoints that pass the filter
      */
     DDSPIPE_CORE_DllAPI
     std::map<types::Guid, types::Endpoint> get_endpoints(

--- a/ddspipe_core/include/ddspipe_core/dynamic/ParticipantsDatabase.hpp
+++ b/ddspipe_core/include/ddspipe_core/dynamic/ParticipantsDatabase.hpp
@@ -79,6 +79,14 @@ public:
     DDSPIPE_CORE_DllAPI
     const std::map<types::ParticipantId, std::shared_ptr<IParticipant>>& get_participants_map() const noexcept;
 
+    /**
+     * @brief Get whether each participant is a repeater
+     *
+     * @return map of is_repeater tags indexed by ids
+     */
+    DDSPIPE_CORE_DllAPI
+    std::map<types::ParticipantId, bool> get_participants_repeater_map() const noexcept;
+
     //! Whether the database is empty
     DDSPIPE_CORE_DllAPI
     bool empty() const noexcept;

--- a/ddspipe_core/include/ddspipe_core/interface/ITopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/ITopic.hpp
@@ -21,6 +21,7 @@
 
 #include <ddspipe_core/library/library_dll.h>
 #include <ddspipe_core/types/topic/TopicInternalTypeDiscriminator.hpp>
+#include <ddspipe_core/types/participant/ParticipantId.hpp>
 
 namespace eprosima {
 namespace ddspipe {
@@ -65,6 +66,10 @@ public:
      */
     DDSPIPE_CORE_DllAPI
     virtual types::TopicInternalTypeDiscriminator internal_type_discriminator() const noexcept = 0;
+
+    //! ITopic discoverer participant id
+    DDSPIPE_CORE_DllAPI
+    virtual types::ParticipantId topic_discoverer() const noexcept = 0;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
@@ -91,7 +91,7 @@ struct Endpoint
     bool active {true};
 
     //! Id of participant who discovered this endpoint
-    ParticipantId discoverer_participant_id {};
+    ParticipantId discoverer_participant_id {DEFAULT_PARTICIPANT_ID};
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -146,8 +146,6 @@ TopicQoS
      */
     HistoryDepthType history_depth = HISTORY_DEPTH_DEFAULT;
 
-    static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
-
     //! Whether the topic has key or not
     bool keyed = false;
 
@@ -156,6 +154,8 @@ TopicQoS
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
     float max_reception_rate = 0;
+
+    static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -146,6 +146,8 @@ TopicQoS
      */
     HistoryDepthType history_depth = HISTORY_DEPTH_DEFAULT;
 
+    static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
+
     //! Whether the topic has key or not
     bool keyed = false;
 
@@ -154,8 +156,6 @@ TopicQoS
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
     float max_reception_rate = 0;
-
-    static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/participant/ParticipantId.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/participant/ParticipantId.hpp
@@ -30,6 +30,9 @@ namespace types {
  */
 using ParticipantId = std::string;
 
+//! Default Participant Id
+constexpr const char* DEFAULT_PARTICIPANT_ID("Undefined");
+
 } /* namespace types */
 } /* namespace core */
 } /* namespace ddspipe */

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -22,6 +22,7 @@
 #include <ddspipe_core/library/library_dll.h>
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/types/topic/TopicInternalTypeDiscriminator.hpp>
+#include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/interface/ITopic.hpp>
 
 namespace eprosima {
@@ -71,6 +72,10 @@ struct Topic : public ITopic, public IConfiguration
     DDSPIPE_CORE_DllAPI
     virtual TopicInternalTypeDiscriminator internal_type_discriminator() const noexcept override;
 
+    //! Id of the participant who discovered the ITopic
+    DDSPIPE_CORE_DllAPI
+    virtual ParticipantId topic_discoverer() const noexcept override;
+
     DDSPIPE_CORE_DllAPI
     virtual bool is_valid(
             utils::Formatter& error_msg) const noexcept override;
@@ -105,6 +110,11 @@ struct Topic : public ITopic, public IConfiguration
      * @note it is called with m_ because the name \c topic_name was already in used by parent.
      */
     TopicInternalTypeDiscriminator m_internal_type_discriminator{INTERNAL_TOPIC_TYPE_NONE};
+
+    /**
+     * @brief The id of the participant who discovered the topic.
+     */
+    ParticipantId m_topic_discoverer{};
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -114,7 +114,7 @@ struct Topic : public ITopic, public IConfiguration
     /**
      * @brief The id of the participant who discovered the topic.
      */
-    ParticipantId m_topic_discoverer{};
+    ParticipantId m_topic_discoverer {DEFAULT_PARTICIPANT_ID};
 };
 
 /**

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -39,9 +39,6 @@ DdsBridge::DdsBridge(
 
     if (remove_unused_entities)
     {
-        assert(topic->topic_discoverer() != "");
-        assert(topic->topic_discoverer() != "builtin-participant");
-
         // The builtin participants and some tests use an empty topic discoverer participant id
         create_writer(topic->topic_discoverer());
     }
@@ -151,6 +148,8 @@ void DdsBridge::create_all_tracks_()
 void DdsBridge::create_writer(
         const ParticipantId& participant_id)
 {
+    assert(participant_id != DEFAULT_PARTICIPANT_ID);
+
     std::lock_guard<std::mutex> lock(mutex_);
 
     // Create the writer.
@@ -164,6 +163,8 @@ void DdsBridge::create_writer(
 void DdsBridge::remove_writer(
         const ParticipantId& participant_id) noexcept
 {
+    assert(participant_id != DEFAULT_PARTICIPANT_ID);
+
     std::lock_guard<std::mutex> lock(mutex_);
 
     for (auto it = tracks_.cbegin(), next_it = it; it != tracks_.cend(); it = next_it)

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -212,12 +212,7 @@ void DdsBridge::add_writers_to_tracks_nts_(
 
             for (const auto& writer_id : writers_in_route)
             {
-                if (writers.count(writer_id) == 0)
-                {
-                    logInfo(DDSPIPE_DDSBRIDGE,
-                        "There's a writer in the route of participant " << id << " that has not been created yet.");
-                }
-                else
+                if (writers.count(writer_id) >= 1)
                 {
                     writers_of_track[writer_id] = writers[writer_id];
                 }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -207,7 +207,7 @@ void DdsBridge::add_writers_to_tracks_(
 
             for (const auto& writer_id : writers_in_route_of_reader)
             {
-                //writers_of_reader[writer_id] = writers[writer_id];
+                writers_of_reader[writer_id] = writers[writer_id];
             }
         }
         else

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -148,18 +148,6 @@ void DdsBridge::create_all_tracks_()
 void DdsBridge::create_writer(
         const ParticipantId& participant_id)
 {
-    // // A new subscriber has been discovered.
-    // // Check if the writer for this participant already exists.
-    // for (const auto& tracks_it : tracks_)
-    // {
-    //     const auto& track = tracks_it.second;
-
-    //     if (track->has_writer(discoverer_participant_id))
-    //     {
-    //         // The writer already exists. There is nothing to do. Exit.
-    //         return;
-    //     }
-    // }
     std::lock_guard<std::mutex> lock(mutex_);
 
     // Create the writer.

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -105,7 +105,6 @@ void DdsBridge::add_to_tracks(
     // Check if the writer for this participant already exists.
     for (const auto& id_to_track : tracks_)
     {
-        const auto& id = id_to_track.first;
         const auto& track = id_to_track.second;
 
         if (track->has_writer(discoverer_participant_id))
@@ -140,11 +139,13 @@ void DdsBridge::add_to_tracks(
         }
 
         // Create a copy of the writer
-        std::map<ParticipantId, std::shared_ptr<IWriter>> id_to_dst_writer;
-        id_to_dst_writer[discoverer_participant_id] = id_to_writer[discoverer_participant_id];
+        std::map<ParticipantId, std::shared_ptr<IWriter>> id_to_dst_writer(id_to_writer);
 
         if (tracks_.count(id))
         {
+            // Enable the writer before adding it to the track.
+            id_to_dst_writer[discoverer_participant_id]->enable();
+
             // The track already exists. Add the writer to it.
             tracks_[id]->add_writer(discoverer_participant_id, id_to_dst_writer[discoverer_participant_id]);
         }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -29,7 +29,7 @@ DdsBridge::DdsBridge(
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
         const RoutesConfiguration& routes_config,
-        const types::ParticipantId& subscriber_id)
+        const ParticipantId& subscriber_id)
     : Bridge(participants_database, payload_pool, thread_pool)
     , topic_(topic)
 {
@@ -88,9 +88,9 @@ void DdsBridge::disable() noexcept
     }
 }
 
-utils::ReturnCode DdsBridge::add_endpoint(const types::ParticipantId& subscriber_id) noexcept
+utils::ReturnCode DdsBridge::add_endpoint(const ParticipantId& subscriber_id) noexcept
 {
-    std::map<types::ParticipantId, std::shared_ptr<IWriter>> id_to_writer;
+    std::map<ParticipantId, std::shared_ptr<IWriter>> id_to_writer;
 
     for (const ParticipantId& id : participants_->get_participants_ids())
     {
@@ -117,7 +117,7 @@ utils::ReturnCode DdsBridge::add_endpoint(const types::ParticipantId& subscriber
         }
 
         // Create a copy of the writer
-        std::map<types::ParticipantId, std::shared_ptr<IWriter>> id_to_dst_writer;
+        std::map<ParticipantId, std::shared_ptr<IWriter>> id_to_dst_writer;
         id_to_dst_writer[subscriber_id] = id_to_writer[subscriber_id];
 
         if (tracks_.count(id))
@@ -146,7 +146,7 @@ utils::ReturnCode DdsBridge::add_endpoint(const types::ParticipantId& subscriber
     return utils::ReturnCode::RETCODE_OK;
 }
 
-utils::ReturnCode DdsBridge::remove_endpoint(const types::ParticipantId& subscriber_id) noexcept
+utils::ReturnCode DdsBridge::remove_endpoint(const ParticipantId& subscriber_id) noexcept
 {
     for (const auto& id_to_track : tracks_)
     {
@@ -155,10 +155,12 @@ utils::ReturnCode DdsBridge::remove_endpoint(const types::ParticipantId& subscri
 
         if (track->has_writer(subscriber_id))
         {
+            // Remove the writer from the track.
             track->remove_writer(subscriber_id);
 
             if (track->count_writers() <= 0)
             {
+                // The track doesn't have any writers. Remove it.
                 tracks_.erase(id);
             }
         }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -140,6 +140,24 @@ utils::ReturnCode DdsBridge::add_endpoint(const types::ParticipantId& subscriber
     return utils::ReturnCode::RETCODE_OK;
 }
 
+utils::ReturnCode DdsBridge::remove_endpoint(const types::ParticipantId& subscriber_id) noexcept
+{
+
+    for (const auto& id_to_track : tracks_)
+    {
+        const auto& id = id_to_track.first;
+        const auto& track = id_to_track.second;
+
+        if (track->has_writer(subscriber_id))
+        {
+            track->remove_writer(subscriber_id);
+        }
+    }
+
+    return utils::ReturnCode::RETCODE_OK;
+}
+
+
 std::ostream& operator <<(
         std::ostream& os,
         const DdsBridge& bridge)

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -29,7 +29,7 @@ DdsBridge::DdsBridge(
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
         const RoutesConfiguration& routes_config,
-        const bool dynamic_tracks,
+        const bool remove_unused_entities,
         const ParticipantId& discoverer_participant_id /* = "" */)
     : Bridge(participants_database, payload_pool, thread_pool)
     , topic_(topic)
@@ -38,7 +38,7 @@ DdsBridge::DdsBridge(
 
     routes_ = routes_config();
 
-    if (dynamic_tracks && discoverer_participant_id != "")
+    if (remove_unused_entities && discoverer_participant_id != "")
     {
         // The builtin participants and some tests use an empty discoverer participant id
         add_to_tracks(discoverer_participant_id);

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -37,8 +37,11 @@ DdsBridge::DdsBridge(
 
     routes_ = routes_config();
 
-    if (remove_unused_entities && topic->topic_discoverer() != "")
+    if (remove_unused_entities)
     {
+        assert(topic->topic_discoverer() != "");
+        assert(topic->topic_discoverer() != "builtin-participant");
+
         // The builtin participants and some tests use an empty topic discoverer participant id
         create_writer(topic->topic_discoverer());
     }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -88,7 +88,8 @@ void DdsBridge::disable() noexcept
     }
 }
 
-utils::ReturnCode DdsBridge::add_endpoint(const ParticipantId& subscriber_id) noexcept
+utils::ReturnCode DdsBridge::add_endpoint(
+        const ParticipantId& subscriber_id) noexcept
 {
     std::map<ParticipantId, std::shared_ptr<IWriter>> id_to_writer;
 
@@ -146,7 +147,8 @@ utils::ReturnCode DdsBridge::add_endpoint(const ParticipantId& subscriber_id) no
     return utils::ReturnCode::RETCODE_OK;
 }
 
-utils::ReturnCode DdsBridge::remove_endpoint(const ParticipantId& subscriber_id) noexcept
+utils::ReturnCode DdsBridge::remove_endpoint(
+        const ParticipantId& subscriber_id) noexcept
 {
     for (const auto& id_to_track : tracks_)
     {
@@ -168,7 +170,6 @@ utils::ReturnCode DdsBridge::remove_endpoint(const ParticipantId& subscriber_id)
 
     return utils::ReturnCode::RETCODE_OK;
 }
-
 
 std::ostream& operator <<(
         std::ostream& os,

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -259,6 +259,11 @@ void DdsBridge::add_writers_to_tracks_(
                 std::move(writers_of_reader),
                 payload_pool_,
                 thread_pool_);
+
+            if (enabled_)
+            {
+                tracks_[id]->enable();
+            }
         }
     }
 }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -207,7 +207,7 @@ void DdsBridge::add_writers_to_tracks_(
 
             for (const auto& writer_id : writers_in_route_of_reader)
             {
-                writers_of_reader[id] = writers[writer_id];
+                //writers_of_reader[writer_id] = writers[writer_id];
             }
         }
         else

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -171,10 +171,11 @@ void DdsBridge::add_to_tracks(
 void DdsBridge::remove_from_tracks(
         const ParticipantId& discoverer_participant_id) noexcept
 {
-    for (const auto& id_to_track : tracks_)
+    for (auto it = tracks_.cbegin(), next_it = it; it != tracks_.cend(); it = next_it)
     {
-        const auto& id = id_to_track.first;
-        const auto& track = id_to_track.second;
+        ++next_it;
+
+        const auto& track = it->second;
 
         // If the writer is in the track, remove it.
         track->remove_writer(discoverer_participant_id);
@@ -182,7 +183,7 @@ void DdsBridge::remove_from_tracks(
         if (track->count_writers() <= 0)
         {
             // The track doesn't have any writers. Remove it.
-            tracks_.erase(id);
+            tracks_.erase(it);
         }
     }
 }

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -145,6 +145,23 @@ void Track::add_writer(const types::ParticipantId& id, const std::shared_ptr<IWr
     enable();
 }
 
+void Track::remove_writer(const types::ParticipantId& id) noexcept
+{
+    disable();
+    writers_.erase(id);
+    enable();
+}
+
+bool Track::has_writer(const types::ParticipantId& id) noexcept
+{
+    return writers_.count(id) != 0;
+}
+
+int Track::count_writers() noexcept
+{
+    return writers_.size();
+}
+
 bool Track::should_transmit_() noexcept
 {
     return !exit_ && enabled_;

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -156,11 +156,13 @@ void Track::remove_writer(
 bool Track::has_writer(
         const ParticipantId& id) noexcept
 {
+    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     return writers_.count(id) != 0;
 }
 
 int Track::count_writers() noexcept
 {
+    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     return writers_.size();
 }
 

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -142,28 +142,36 @@ void Track::add_writer(
         const ParticipantId& id,
         const std::shared_ptr<IWriter>& writer) noexcept
 {
-    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
+    std::lock_guard<std::mutex> transmission_lock(on_transmission_mutex_);
+    std::lock_guard<std::mutex> track_lock(track_mutex_);
+
+    if (enabled_)
+    {
+        writer->enable();
+    }
+
     writers_[id] = writer;
 }
 
 void Track::remove_writer(
         const ParticipantId& id) noexcept
 {
-    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
+    std::lock_guard<std::mutex> transmission_lock(on_transmission_mutex_);
+    std::lock_guard<std::mutex> track_lock(track_mutex_);
     writers_.erase(id);
 }
 
 bool Track::has_writer(
         const ParticipantId& id) noexcept
 {
-    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
+    std::lock_guard<std::mutex> lock(track_mutex_);
     return writers_.count(id) != 0;
 }
 
-int Track::count_writers() noexcept
+bool Track::has_writers() noexcept
 {
-    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
-    return writers_.size();
+    std::lock_guard<std::mutex> lock(track_mutex_);
+    return writers_.size() > 0;
 }
 
 bool Track::should_transmit_() noexcept

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -33,10 +33,10 @@ using namespace eprosima::ddspipe::core::types;
 const unsigned int Track::MAX_MESSAGES_TRANSMIT_LOOP_ = 100;
 
 Track::Track(
-        const utils::Heritable<types::DistributedTopic>& topic,
-        const types::ParticipantId& reader_participant_id,
+        const utils::Heritable<DistributedTopic>& topic,
+        const ParticipantId& reader_participant_id,
         const std::shared_ptr<IReader>& reader,
-        std::map<types::ParticipantId, std::shared_ptr<IWriter>>&& writers,
+        std::map<ParticipantId, std::shared_ptr<IWriter>>&& writers,
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<utils::SlotThreadPool>& thread_pool) noexcept
     : topic_(topic)
@@ -138,19 +138,19 @@ void Track::disable() noexcept
     }
 }
 
-void Track::add_writer(const types::ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept
+void Track::add_writer(const ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept
 {
     std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     writers_[id] = writer;
 }
 
-void Track::remove_writer(const types::ParticipantId& id) noexcept
+void Track::remove_writer(const ParticipantId& id) noexcept
 {
     std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     writers_.erase(id);
 }
 
-bool Track::has_writer(const types::ParticipantId& id) noexcept
+bool Track::has_writer(const ParticipantId& id) noexcept
 {
     return writers_.count(id) != 0;
 }

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -140,7 +140,9 @@ void Track::disable() noexcept
 
 void Track::add_writer(const types::ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept
 {
+    disable();
     writers_[id] = writer;
+    enable();
 }
 
 bool Track::should_transmit_() noexcept

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -140,16 +140,14 @@ void Track::disable() noexcept
 
 void Track::add_writer(const types::ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept
 {
-    disable();
+    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     writers_[id] = writer;
-    enable();
 }
 
 void Track::remove_writer(const types::ParticipantId& id) noexcept
 {
-    disable();
+    std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     writers_.erase(id);
-    enable();
 }
 
 bool Track::has_writer(const types::ParticipantId& id) noexcept

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -142,8 +142,8 @@ void Track::add_writer(
         const ParticipantId& id,
         const std::shared_ptr<IWriter>& writer) noexcept
 {
-    std::lock_guard<std::mutex> transmission_lock(on_transmission_mutex_);
     std::lock_guard<std::mutex> track_lock(track_mutex_);
+    std::lock_guard<std::mutex> transmission_lock(on_transmission_mutex_);
 
     if (enabled_)
     {
@@ -156,8 +156,8 @@ void Track::add_writer(
 void Track::remove_writer(
         const ParticipantId& id) noexcept
 {
-    std::lock_guard<std::mutex> transmission_lock(on_transmission_mutex_);
     std::lock_guard<std::mutex> track_lock(track_mutex_);
+    std::lock_guard<std::mutex> transmission_lock(on_transmission_mutex_);
     writers_.erase(id);
 }
 

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -138,6 +138,11 @@ void Track::disable() noexcept
     }
 }
 
+void Track::add_writer(const types::ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept
+{
+    writers_[id] = writer;
+}
+
 bool Track::should_transmit_() noexcept
 {
     return !exit_ && enabled_;

--- a/ddspipe_core/src/cpp/communication/dds/Track.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/Track.cpp
@@ -138,19 +138,23 @@ void Track::disable() noexcept
     }
 }
 
-void Track::add_writer(const ParticipantId& id, const std::shared_ptr<IWriter>& writer) noexcept
+void Track::add_writer(
+        const ParticipantId& id,
+        const std::shared_ptr<IWriter>& writer) noexcept
 {
     std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     writers_[id] = writer;
 }
 
-void Track::remove_writer(const ParticipantId& id) noexcept
+void Track::remove_writer(
+        const ParticipantId& id) noexcept
 {
     std::lock_guard<std::mutex> lock(on_transmission_mutex_);
     writers_.erase(id);
 }
 
-bool Track::has_writer(const ParticipantId& id) noexcept
+bool Track::has_writer(
+        const ParticipantId& id) noexcept
 {
     return writers_.count(id) != 0;
 }

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -46,14 +46,15 @@ bool DdsPipeConfiguration::is_valid(
 }
 
 RoutesConfiguration DdsPipeConfiguration::get_routes_config(
-        const utils::Heritable<types::DistributedTopic> &topic) const noexcept
+        const utils::Heritable<types::DistributedTopic>& topic) const noexcept
 {
     if (topic_routes().count(topic) != 0)
     {
         // There is a topic route configuration. Use it, and ignore the generic one.
         return topic_routes()[topic];
     }
-    else{
+    else
+    {
         // There isn't a topic route configuration. Use the generic one.
         return routes;
     }

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -29,7 +29,7 @@ namespace core {
 bool DdsPipeConfiguration::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
-    return routes_config.is_valid(error_msg) && topic_routes_config.is_valid(error_msg);
+    return routes.is_valid(error_msg) && topic_routes.is_valid(error_msg);
 }
 
 bool DdsPipeConfiguration::is_valid(
@@ -41,21 +41,21 @@ bool DdsPipeConfiguration::is_valid(
         return false;
     }
 
-    return routes_config.is_valid(error_msg, participant_ids) && \
-           topic_routes_config.is_valid(error_msg, participant_ids);
+    return routes.is_valid(error_msg, participant_ids) &&
+           topic_routes.is_valid(error_msg, participant_ids);
 }
 
 RoutesConfiguration DdsPipeConfiguration::get_routes_config(
         const utils::Heritable<types::DistributedTopic> &topic) const noexcept
 {
-    if (topic_routes_config().count(topic) != 0)
+    if (topic_routes().count(topic) != 0)
     {
         // There is a topic route configuration. Use it, and ignore the generic one.
-        return topic_routes_config()[topic];
+        return topic_routes()[topic];
     }
     else{
         // There isn't a topic route configuration. Use the generic one.
-        return routes_config;
+        return routes;
     }
 }
 

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -34,15 +34,15 @@ bool DdsPipeConfiguration::is_valid(
 
 bool DdsPipeConfiguration::is_valid(
         utils::Formatter& error_msg,
-        std::map<ddspipe::core::types::ParticipantId, bool> participant_ids) const noexcept
+        const std::map<types::ParticipantId, bool>& participant_ids) const noexcept
 {
     if (!is_valid(error_msg))
     {
         return false;
     }
 
-    return routes.is_valid(error_msg, participant_ids) &&
-           topic_routes.is_valid(error_msg, participant_ids);
+    return routes.is_valid(error_msg, participants) &&
+           topic_routes.is_valid(error_msg, participants);
 }
 
 RoutesConfiguration DdsPipeConfiguration::get_routes_config(

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -1,0 +1,64 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file DdsPipeConfiguration.cpp
+ *
+ */
+
+#include <cpp_utils/Formatter.hpp>
+#include <cpp_utils/Log.hpp>
+
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace core {
+
+bool DdsPipeConfiguration::is_valid(
+        utils::Formatter& error_msg) const noexcept
+{
+    return routes_config.is_valid(error_msg) && topic_routes_config.is_valid(error_msg);
+}
+
+bool DdsPipeConfiguration::is_valid(
+        utils::Formatter& error_msg,
+        std::map<ddspipe::core::types::ParticipantId, bool> participant_ids) const noexcept
+{
+    if (!is_valid(error_msg))
+    {
+        return false;
+    }
+
+    return routes_config.is_valid(error_msg, participant_ids) && \
+           topic_routes_config.is_valid(error_msg, participant_ids);
+}
+
+RoutesConfiguration DdsPipeConfiguration::get_routes_config(
+        const utils::Heritable<types::DistributedTopic> &topic) const noexcept
+{
+    if (topic_routes_config().count(topic) != 0)
+    {
+        // There is a topic route configuration. Use it, and ignore the generic one.
+        return topic_routes_config()[topic];
+    }
+    else{
+        // There isn't a topic route configuration. Use the generic one.
+        return routes_config;
+    }
+}
+
+} /* namespace core */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -41,8 +41,8 @@ bool DdsPipeConfiguration::is_valid(
         return false;
     }
 
-    return routes.is_valid(error_msg, participants) &&
-           topic_routes.is_valid(error_msg, participants);
+    return routes.is_valid(error_msg, participant_ids) &&
+           topic_routes.is_valid(error_msg, participant_ids);
 }
 
 RoutesConfiguration DdsPipeConfiguration::get_routes_config(

--- a/ddspipe_core/src/cpp/configuration/RoutesConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/RoutesConfiguration.cpp
@@ -40,7 +40,7 @@ bool RoutesConfiguration::is_valid(
 
 bool RoutesConfiguration::is_valid(
         utils::Formatter& error_msg,
-        std::map<ddspipe::core::types::ParticipantId, bool> participant_ids) const noexcept
+        const std::map<ddspipe::core::types::ParticipantId, bool>& participant_ids) const noexcept
 {
     if (!is_valid(error_msg))
     {
@@ -61,7 +61,8 @@ bool RoutesConfiguration::is_valid(
         }
 
         bool src_in_dst = false;
-        bool is_repeater = participant_ids[src_id];
+        bool is_repeater = participant_ids.at(src_id);
+
         for (const auto& dst_id : dst_ids)
         {
             // Check participant with this id exists

--- a/ddspipe_core/src/cpp/configuration/TopicRoutesConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/TopicRoutesConfiguration.cpp
@@ -44,7 +44,7 @@ bool TopicRoutesConfiguration::is_valid(
 
 bool TopicRoutesConfiguration::is_valid(
         utils::Formatter& error_msg,
-        std::map<ddspipe::core::types::ParticipantId, bool> participant_ids) const noexcept
+        const std::map<types::ParticipantId, bool>& participant_ids) const noexcept
 {
     if (!is_valid(error_msg))
     {

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -34,20 +34,20 @@ DdsPipe::DdsPipe(
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<ParticipantsDatabase>& participants_database,
         const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
-        const bool delete_unused_entities,
         const std::set<utils::Heritable<DistributedTopic>>& builtin_topics, /* = {} */
         bool start_enable, /* = false */
         const RoutesConfiguration& routes_config, /* = {} */
-        const TopicRoutesConfiguration& topic_routes_config /* = {} */)
+        const TopicRoutesConfiguration& topic_routes_config, /* = {} */
+        const bool delete_unused_entities /* = false */)
     : allowed_topics_(allowed_topics)
     , discovery_database_(discovery_database)
     , payload_pool_(payload_pool)
     , participants_database_(participants_database)
     , thread_pool_(thread_pool)
-    , delete_unused_entities_(delete_unused_entities)
     , enabled_(false)
     , routes_config_(routes_config)
     , topic_routes_config_(topic_routes_config)
+    , delete_unused_entities_(delete_unused_entities)
 {
     logDebug(DDSPIPE, "Creating DDS Pipe.");
 

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -251,7 +251,7 @@ void DdsPipe::discovered_endpoint_nts_(
         {
             // Service server discovered
             discovered_service_nts_(RpcTopic(
-                endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
+                        endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
         }
     }
     else if (is_endpoint_relevant_(endpoint))
@@ -272,7 +272,8 @@ void DdsPipe::removed_endpoint_nts_(
         if (endpoint.is_server_endpoint())
         {
             // Service server removed/dropped
-            removed_service_nts_(RpcTopic(endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
+            removed_service_nts_(RpcTopic(endpoint.topic), endpoint.discoverer_participant_id,
+                    endpoint.guid.guid_prefix());
         }
 
     }
@@ -323,12 +324,12 @@ bool DdsPipe::is_endpoint_relevant_(
     }
 
     auto is_endpoint_relevant = [endpoint](const Endpoint& entity)
-    {
-        return entity.active &&
-                entity.is_reader() &&
-                entity.topic == endpoint.topic &&
-                entity.discoverer_participant_id == endpoint.discoverer_participant_id;
-    };
+            {
+                return entity.active &&
+                       entity.is_reader() &&
+                       entity.topic == endpoint.topic &&
+                       entity.discoverer_participant_id == endpoint.discoverer_participant_id;
+            };
 
     const auto& relevant_endpoints = discovery_database_->get_endpoints(is_endpoint_relevant);
 

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -321,10 +321,8 @@ void DdsPipe::removed_endpoint_nts_(
 
         if (it_bridge == bridges_.end())
         {
-            // The bridge does not exist. Error.
-            logError(DDSPIPE,
-                    "Error finding Bridge for topic " << topic <<
-                    ". The Bridge does not exist.");
+            // The bridge does not exist. We cannot remove the writer. Exit.
+            return;
         }
         else if (dynamic_tracks_)
         {

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -245,11 +245,14 @@ void DdsPipe::discovered_endpoint_nts_(
 {
     logDebug(DDSPIPE, "Endpoint discovered in DDS Pipe core: " << endpoint << ".");
 
-    if (RpcTopic::is_service_topic(endpoint.topic) && endpoint.is_reader() && endpoint.is_server_endpoint())
+    if (RpcTopic::is_service_topic(endpoint.topic))
     {
-        // Service server discovered
-        discovered_service_nts_(RpcTopic(
+        if (endpoint.is_reader() && endpoint.is_server_endpoint())
+        {
+            // Service server discovered
+            discovered_service_nts_(RpcTopic(
                 endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
+        }
     }
     else if (is_endpoint_relevant_nts_(endpoint))
     {
@@ -264,10 +267,14 @@ void DdsPipe::removed_endpoint_nts_(
 
     const auto& topic = utils::Heritable<DdsTopic>::make_heritable(endpoint.topic);
 
-    if (RpcTopic::is_service_topic(endpoint.topic) && endpoint.is_server_endpoint())
+    if (RpcTopic::is_service_topic(endpoint.topic))
     {
-        // Service server removed/dropped
-        removed_service_nts_(RpcTopic(endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
+        if (endpoint.is_server_endpoint())
+        {
+            // Service server removed/dropped
+            removed_service_nts_(RpcTopic(endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
+        }
+
     }
     else if (ddspipe_config_.remove_unused_entities && is_endpoint_relevant_nts_(endpoint))
     {

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -234,7 +234,8 @@ void DdsPipe::discovered_endpoint_(
     {
         if (!RpcTopic::is_service_topic(endpoint.topic))
         {
-            discovered_topic_nts_(utils::Heritable<DdsTopic>::make_heritable(endpoint.topic), endpoint.discoverer_participant_id);
+            discovered_topic_nts_(utils::Heritable<DdsTopic>::make_heritable(
+                        endpoint.topic), endpoint.discoverer_participant_id);
         }
         else if (endpoint.is_server_endpoint())
         {
@@ -280,7 +281,8 @@ void DdsPipe::removed_endpoint_(
 
     if (!RpcTopic::is_service_topic(endpoint.topic))
     {
-        if (endpoint.is_writer()) {
+        if (endpoint.is_writer())
+        {
             // An external writer has been removed.
             // The bridge and the tracks remain intact.
             return;
@@ -324,7 +326,8 @@ void DdsPipe::discovered_topic_nts_(
     // Check if the bridge (and the topic) already exist.
     auto it_bridge = bridges_.find(topic);
 
-    if (it_bridge != bridges_.end()) {
+    if (it_bridge != bridges_.end())
+    {
         // The bridge already exists. Add the discoverer_id.
         it_bridge->second->add_endpoint(discoverer_id);
         return;
@@ -397,10 +400,9 @@ void DdsPipe::create_new_bridge_nts_(
 
     try
     {
-        // Use topic specific forwarding routes if available
-        RoutesConfiguration routes_config = topic_routes_config_().count(topic) !=
+        auto routes_config__ = topic_routes_config_().count(topic) !=
                 0 ? topic_routes_config_()[topic] : routes_config_;
-
+                
         auto discoverer_id = current_topics_discoverers_[topic];
 
         // Create bridge instance

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -245,10 +245,10 @@ void DdsPipe::updated_endpoint_(
             const auto& entity = guid_to_entity.second;
 
             if (guid != endpoint.guid &&
-                entity.active &&
-                entity.is_reader() &&
-                entity.topic == endpoint.topic &&
-                entity.discoverer_participant_id == endpoint.discoverer_participant_id)
+                    entity.active &&
+                    entity.is_reader() &&
+                    entity.topic == endpoint.topic &&
+                    entity.discoverer_participant_id == endpoint.discoverer_participant_id)
             {
                 // There is an active reader other than us.
                 // If we have been reactivated, there is nothing to do.
@@ -321,8 +321,8 @@ void DdsPipe::removed_endpoint_nts_(
         {
             // The bridge does not exist. Error.
             logError(DDSPIPE,
-                "Error finding Bridge for topic " << topic <<
-                ". The Bridge does not exist.");
+                    "Error finding Bridge for topic " << topic <<
+                    ". The Bridge does not exist.");
         }
         else
         {

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -34,6 +34,7 @@ DdsPipe::DdsPipe(
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<ParticipantsDatabase>& participants_database,
         const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
+        const bool delete_unused_entities,
         const std::set<utils::Heritable<DistributedTopic>>& builtin_topics, /* = {} */
         bool start_enable, /* = false */
         const RoutesConfiguration& routes_config, /* = {} */
@@ -43,6 +44,7 @@ DdsPipe::DdsPipe(
     , payload_pool_(payload_pool)
     , participants_database_(participants_database)
     , thread_pool_(thread_pool)
+    , delete_unused_entities_(delete_unused_entities)
     , enabled_(false)
     , routes_config_(routes_config)
     , topic_routes_config_(topic_routes_config)
@@ -324,7 +326,7 @@ void DdsPipe::removed_endpoint_nts_(
                     "Error finding Bridge for topic " << topic <<
                     ". The Bridge does not exist.");
         }
-        else
+        else if (delete_unused_entities_)
         {
             it_bridge->second->remove_from_tracks(endpoint.discoverer_participant_id);
         }

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -38,7 +38,7 @@ DdsPipe::DdsPipe(
         bool start_enable, /* = false */
         const RoutesConfiguration& routes_config, /* = {} */
         const TopicRoutesConfiguration& topic_routes_config, /* = {} */
-        const bool delete_unused_entities /* = false */)
+        const bool dynamic_tracks /* = false */)
     : allowed_topics_(allowed_topics)
     , discovery_database_(discovery_database)
     , payload_pool_(payload_pool)
@@ -47,7 +47,7 @@ DdsPipe::DdsPipe(
     , enabled_(false)
     , routes_config_(routes_config)
     , topic_routes_config_(topic_routes_config)
-    , delete_unused_entities_(delete_unused_entities)
+    , dynamic_tracks_(dynamic_tracks)
 {
     logDebug(DDSPIPE, "Creating DDS Pipe.");
 
@@ -326,7 +326,7 @@ void DdsPipe::removed_endpoint_nts_(
                     "Error finding Bridge for topic " << topic <<
                     ". The Bridge does not exist.");
         }
-        else if (delete_unused_entities_)
+        else if (dynamic_tracks_)
         {
             it_bridge->second->remove_from_tracks(endpoint.discoverer_participant_id);
         }
@@ -343,7 +343,7 @@ void DdsPipe::init_bridges_nts_(
 {
     for (const auto& topic : builtin_topics)
     {
-        discovered_topic_nts_(topic, "builtin-participant");
+        discovered_topic_nts_(topic, "");
         create_new_bridge_nts_(topic, false);
     }
 }
@@ -433,7 +433,7 @@ void DdsPipe::create_new_bridge_nts_(
     {
         auto routes_config__ = topic_routes_config_().count(topic) !=
                 0 ? topic_routes_config_()[topic] : routes_config_;
-                
+
         auto discoverer_participant_id = current_topics_discoverers_[topic];
 
         // Create bridge instance
@@ -442,6 +442,7 @@ void DdsPipe::create_new_bridge_nts_(
                         payload_pool_,
                         thread_pool_,
                         routes_config,
+                        dynamic_tracks_,
                         discoverer_participant_id);
 
         if (enabled)

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -38,7 +38,7 @@ DdsPipe::DdsPipe(
         bool start_enable, /* = false */
         const RoutesConfiguration& routes_config, /* = {} */
         const TopicRoutesConfiguration& topic_routes_config, /* = {} */
-        const bool dynamic_tracks /* = false */)
+        const bool remove_unused_entities /* = false */)
     : allowed_topics_(allowed_topics)
     , discovery_database_(discovery_database)
     , payload_pool_(payload_pool)
@@ -47,7 +47,7 @@ DdsPipe::DdsPipe(
     , enabled_(false)
     , routes_config_(routes_config)
     , topic_routes_config_(topic_routes_config)
-    , dynamic_tracks_(dynamic_tracks)
+    , remove_unused_entities_(remove_unused_entities)
 {
     logDebug(DDSPIPE, "Creating DDS Pipe.");
 
@@ -324,7 +324,7 @@ void DdsPipe::removed_endpoint_nts_(
             // The bridge does not exist. We cannot remove the writer. Exit.
             return;
         }
-        else if (dynamic_tracks_)
+        else if (remove_unused_entities_)
         {
             it_bridge->second->remove_from_tracks(endpoint.discoverer_participant_id);
         }
@@ -440,7 +440,7 @@ void DdsPipe::create_new_bridge_nts_(
                         payload_pool_,
                         thread_pool_,
                         routes_config,
-                        dynamic_tracks_,
+                        remove_unused_entities_,
                         discoverer_participant_id);
 
         if (enabled)

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -34,7 +34,7 @@ DdsPipe::DdsPipe(
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<ParticipantsDatabase>& participants_database,
         const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
-        const std::set<utils::Heritable<types::DistributedTopic>>& builtin_topics, /* = {} */
+        const std::set<utils::Heritable<DistributedTopic>>& builtin_topics, /* = {} */
         bool start_enable, /* = false */
         const RoutesConfiguration& routes_config, /* = {} */
         const TopicRoutesConfiguration& topic_routes_config /* = {} */)
@@ -239,7 +239,7 @@ void DdsPipe::discovered_endpoint_(
         else if (endpoint.is_server_endpoint())
         {
             // Service server discovered
-            discovered_service_nts_(types::RpcTopic(
+            discovered_service_nts_(RpcTopic(
                         endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
         }
     }
@@ -301,12 +301,12 @@ void DdsPipe::removed_endpoint_(
     else if (endpoint.is_server_endpoint())
     {
         // Service server removed/dropped
-        removed_service_nts_(types::RpcTopic(endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
+        removed_service_nts_(RpcTopic(endpoint.topic), endpoint.discoverer_participant_id, endpoint.guid.guid_prefix());
     }
 }
 
 void DdsPipe::init_bridges_nts_(
-        const std::set<utils::Heritable<types::DistributedTopic>>& builtin_topics)
+        const std::set<utils::Heritable<DistributedTopic>>& builtin_topics)
 {
     for (const auto& topic : builtin_topics)
     {
@@ -316,8 +316,8 @@ void DdsPipe::init_bridges_nts_(
 }
 
 void DdsPipe::discovered_topic_nts_(
-        const utils::Heritable<types::DistributedTopic>& topic,
-        const types::ParticipantId& discoverer_id) noexcept
+        const utils::Heritable<DistributedTopic>& topic,
+        const ParticipantId& discoverer_id) noexcept
 {
     logInfo(DDSPIPE, "Discovered topic: " << topic << ", by: " << discoverer_id << ".");
 
@@ -344,7 +344,7 @@ void DdsPipe::discovered_topic_nts_(
 }
 
 void DdsPipe::discovered_service_nts_(
-        const types::RpcTopic& topic,
+        const RpcTopic& topic,
         const ParticipantId& server_participant_id,
         const GuidPrefix& server_guid_prefix) noexcept
 {
@@ -375,7 +375,7 @@ void DdsPipe::discovered_service_nts_(
 }
 
 void DdsPipe::removed_service_nts_(
-        const types::RpcTopic& topic,
+        const RpcTopic& topic,
         const ParticipantId& server_participant_id,
         const GuidPrefix& server_guid_prefix) noexcept
 {
@@ -390,7 +390,7 @@ void DdsPipe::removed_service_nts_(
 }
 
 void DdsPipe::create_new_bridge_nts_(
-        const utils::Heritable<types::DistributedTopic>& topic,
+        const utils::Heritable<DistributedTopic>& topic,
         bool enabled /*= false*/) noexcept
 {
     logInfo(DDSPIPE, "Creating Bridge for topic: " << topic << ".");
@@ -427,7 +427,7 @@ void DdsPipe::create_new_bridge_nts_(
 }
 
 void DdsPipe::create_new_service_nts_(
-        const types::RpcTopic& topic) noexcept
+        const RpcTopic& topic) noexcept
 {
     logInfo(DDSPIPE, "Creating Service: " << topic << ".");
 
@@ -436,7 +436,7 @@ void DdsPipe::create_new_service_nts_(
 }
 
 void DdsPipe::activate_topic_nts_(
-        const utils::Heritable<types::DistributedTopic>& topic) noexcept
+        const utils::Heritable<DistributedTopic>& topic) noexcept
 {
     logInfo(DDSPIPE, "Activating topic: " << topic << ".");
 
@@ -459,7 +459,7 @@ void DdsPipe::activate_topic_nts_(
 }
 
 void DdsPipe::deactivate_topic_nts_(
-        const utils::Heritable<types::DistributedTopic>& topic) noexcept
+        const utils::Heritable<DistributedTopic>& topic) noexcept
 {
     logInfo(DDSPIPE, "Deactivating topic: " << topic << ".");
 

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -343,34 +343,6 @@ void DdsPipe::discovered_topic_nts_(
     }
 }
 
-void DdsPipe::removed_topic_nts_(
-        const utils::Heritable<types::DistributedTopic>& topic,
-        const types::ParticipantId& discoverer_id) noexcept
-{
-    logInfo(DDSPIPE, "Removed topic: " << topic << ", by: " << discoverer_id << ".");
-
-    // Check if the bridge (and the topic) already exist.
-    auto it_bridge = bridges_.find(topic);
-
-    if (it_bridge != bridges_.end()) {
-        // The bridge already exists. Add the discoverer_id.
-        it_bridge->second->add_endpoint(discoverer_id);
-        return;
-    }
-
-    // Add topic to current_topics as non activated
-    current_topics_.emplace(topic, false);
-
-    // Save the id of the participant who discovered the topic
-    current_topics_discoverers_.emplace(topic, discoverer_id);
-
-    // If Pipe is enabled and topic allowed, activate it
-    if (enabled_ && allowed_topics_->is_topic_allowed(*topic))
-    {
-        activate_topic_nts_(topic);
-    }
-}
-
 void DdsPipe::discovered_service_nts_(
         const types::RpcTopic& topic,
         const ParticipantId& server_participant_id,

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -429,7 +429,7 @@ void DdsPipe::create_new_bridge_nts_(
 
     try
     {
-        auto routes_config__ = topic_routes_config_().count(topic) !=
+        auto routes_config = topic_routes_config_().count(topic) !=
                 0 ? topic_routes_config_()[topic] : routes_config_;
 
         auto discoverer_participant_id = current_topics_discoverers_[topic];

--- a/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
@@ -244,10 +244,25 @@ Endpoint DiscoveryDatabase::get_endpoint(
     return it->second;
 }
 
-std::map<Guid, Endpoint> DiscoveryDatabase::get_endpoints() const noexcept
+std::map<Guid, Endpoint> DiscoveryDatabase::get_endpoints(
+    std::function<bool(const Endpoint&)> is_valid_endpoint) const noexcept
 {
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
-    return entities_;
+
+    std::map<Guid, Endpoint> endpoints;
+
+    for (const auto& guid_to_entity : entities_)
+    {
+        const auto& guid = guid_to_entity.first;
+        const auto& entity = guid_to_entity.second;
+
+        if (is_valid_endpoint(entity))
+        {
+            endpoints[guid] = entity;
+        }
+    }
+
+    return endpoints;
 }
 
 void DiscoveryDatabase::add_endpoint_discovered_callback(

--- a/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
@@ -245,7 +245,7 @@ Endpoint DiscoveryDatabase::get_endpoint(
 }
 
 std::map<Guid, Endpoint> DiscoveryDatabase::get_endpoints(
-    std::function<bool(const Endpoint&)> is_valid_endpoint) const noexcept
+        std::function<bool(const Endpoint&)> is_valid_endpoint) const noexcept
 {
     std::shared_lock<std::shared_timed_mutex> lock(mutex_);
 

--- a/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
@@ -244,6 +244,11 @@ Endpoint DiscoveryDatabase::get_endpoint(
     return it->second;
 }
 
+std::map<Guid, Endpoint> DiscoveryDatabase::get_endpoints() const noexcept
+{
+    return entities_;
+}
+
 void DiscoveryDatabase::add_endpoint_discovered_callback(
         std::function<void(Endpoint)> endpoint_discovered_callback) noexcept
 {

--- a/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
@@ -246,6 +246,7 @@ Endpoint DiscoveryDatabase::get_endpoint(
 
 std::map<Guid, Endpoint> DiscoveryDatabase::get_endpoints() const noexcept
 {
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
     return entities_;
 }
 

--- a/ddspipe_core/src/cpp/dynamic/ParticipantsDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/ParticipantsDatabase.cpp
@@ -77,6 +77,22 @@ const std::map<types::ParticipantId,
     return participants_;
 }
 
+std::map<types::ParticipantId, bool> ParticipantsDatabase::get_participants_repeater_map() const noexcept
+{
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
+
+    std::map<types::ParticipantId, bool> participants_repeater_map;
+
+    for (auto it : participants_)
+    {
+        const auto& id = it.first;
+        const auto& participant = it.second;
+        participants_repeater_map[id] = participant->is_repeater();
+    }
+
+    return participants_repeater_map;
+}
+
 bool ParticipantsDatabase::empty() const noexcept
 {
     return participants_.empty();

--- a/ddspipe_core/src/cpp/testing/random_values.cpp
+++ b/ddspipe_core/src/cpp/testing/random_values.cpp
@@ -96,10 +96,7 @@ Endpoint random_endpoint(
     endpoint.guid = random_guid(seed);
     endpoint.kind = random_endpoint_kind(seed);
     endpoint.topic = random_dds_topic(seed);
-
-    // The discoverer participant id cannot be random.
-    // It must belong to an actual participant or be an empty string.
-    endpoint.discoverer_participant_id = "";
+    endpoint.discoverer_participant_id = random_participant_id(seed);
 
     return endpoint;
 }

--- a/ddspipe_core/src/cpp/testing/random_values.cpp
+++ b/ddspipe_core/src/cpp/testing/random_values.cpp
@@ -91,11 +91,16 @@ Endpoint random_endpoint(
         unsigned int seed /* = 0 */)
 {
     Endpoint endpoint;
+
     endpoint.active = (seed % 2);
     endpoint.guid = random_guid(seed);
-    endpoint.discoverer_participant_id = random_participant_id(seed);
     endpoint.kind = random_endpoint_kind(seed);
     endpoint.topic = random_dds_topic(seed);
+
+    // The discoverer participant id cannot be random.
+    // It must belong to an actual participant or be an empty string.
+    endpoint.discoverer_participant_id = "";
+
     return endpoint;
 }
 

--- a/ddspipe_core/src/cpp/types/topic/Topic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/Topic.cpp
@@ -62,6 +62,11 @@ TopicInternalTypeDiscriminator Topic::internal_type_discriminator() const noexce
     return m_internal_type_discriminator;
 }
 
+ParticipantId Topic::topic_discoverer() const noexcept
+{
+    return m_topic_discoverer;
+}
+
 bool Topic::is_valid(
         utils::Formatter& error_msg) const noexcept
 {

--- a/ddspipe_participants/src/cpp/utils/utils.cpp
+++ b/ddspipe_participants/src/cpp/utils/utils.cpp
@@ -66,6 +66,7 @@ core::types::Endpoint create_common_endpoint_from_info_(
     endpoint.topic.m_topic_name = std::string(info.info.topicName());
     endpoint.topic.type_name = std::string(info.info.typeName());
     endpoint.topic.m_internal_type_discriminator = core::types::INTERNAL_TOPIC_TYPE_RTPS;
+    endpoint.topic.m_topic_discoverer = participant_discoverer_id;
 
     // Parse specific QoS of the entity
     if (endpoint.topic.topic_qos.has_partitions())

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -135,7 +135,7 @@ constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (numb
 constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
 constexpr const char* MAX_RECEPTION_RATE_TAG("max-reception-rate"); //! Process up to *max_reception_rate* samples in a 1 second bin
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
-constexpr const char* DELETE_UNUSED_ENTITIES_TAG("delete-unused-entities"); //! Delete the unused entities and tracks.
+constexpr const char* DYNAMIC_TRACKS_TAG("dynamic-tracks"); //! Dynamically create and delete tracks.
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -135,7 +135,7 @@ constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (numb
 constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
 constexpr const char* MAX_RECEPTION_RATE_TAG("max-reception-rate"); //! Process up to *max_reception_rate* samples in a 1 second bin
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
-constexpr const char* DYNAMIC_TRACKS_TAG("dynamic-tracks"); //! Dynamically create and delete tracks.
+constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -135,6 +135,7 @@ constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (numb
 constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
 constexpr const char* MAX_RECEPTION_RATE_TAG("max-reception-rate"); //! Process up to *max_reception_rate* samples in a 1 second bin
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
+constexpr const char* DELETE_UNUSED_ENTITIES_TAG("delete-unused-entities"); //! Delete the unused entities and tracks.
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -436,6 +436,9 @@ void YamlReader::fill(
     // Data Type required
     object.type_name = get<std::string>(yml, TOPIC_TYPE_NAME_TAG, version);
 
+    // Discoverer Participant Id
+    object.m_topic_discoverer = "builtin-participant";
+
     // Optional QoS
     if (is_tag_present(yml, TOPIC_QOS_TAG))
     {

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -436,9 +436,6 @@ void YamlReader::fill(
     // Data Type required
     object.type_name = get<std::string>(yml, TOPIC_TYPE_NAME_TAG, version);
 
-    // Discoverer Participant Id
-    object.m_topic_discoverer = "builtin-participant";
-
     // Optional QoS
     if (is_tag_present(yml, TOPIC_QOS_TAG))
     {


### PR DESCRIPTION
In the previous version, the DdsBridge created a reader and a writer for every participant. Then, for each reader, the DdsBridge created a track towards every writer (except the participant's writer unless the participant was configured as a repeater).

In this version, the DdsBridge creates the readers and the writers dynamically. 

- Whenever a participant discovers an external subscriber, the DdsBridge:
    1. Creates a writer in the participant who discovered the subscriber.
    2. Creates readers in the participants who have a route towards the participant who discovered the subscriber.

- Whenever an external subscriber drops or disconnects, the DdsBridge:
    1. Removes its associated writer from every track it was on.
    2. Removes the tracks that don't have any writers in them.


**Merge after** 
- https://github.com/eProsima/DDS-Pipe/pull/56