### PR TITLE
Save instanceHandle data for keyed topics [19601]

### DIFF
--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -332,7 +332,7 @@ fastrtps::rtps::ReaderAttributes CommonReader::reckon_reader_attributes_(
     {
         att.endpoint.topicKind = eprosima::fastrtps::rtps::WITH_KEY;
 
-        // If the topic has a key, accept inline qos
+        // If the topic has a key, request inline qos (containing the instance handle)
         att.expectsInlineQos = true;
     }
     else

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -331,6 +331,9 @@ fastrtps::rtps::ReaderAttributes CommonReader::reckon_reader_attributes_(
     if (topic.topic_qos.keyed)
     {
         att.endpoint.topicKind = eprosima::fastrtps::rtps::WITH_KEY;
+
+        // If the topic has a key, accept inline qos
+        att.expectsInlineQos = true;
     }
     else
     {

--- a/ddspipe_participants/src/cpp/types/dds/TopicDataType.cpp
+++ b/ddspipe_participants/src/cpp/types/dds/TopicDataType.cpp
@@ -91,19 +91,18 @@ std::function<uint32_t()> TopicDataType::getSerializedSizeProvider(
 }
 
 bool TopicDataType::getKey(
-        void*,
-        eprosima::fastrtps::rtps::InstanceHandle_t*,
+        void* data,
+        eprosima::fastrtps::rtps::InstanceHandle_t* handle,
         bool /* = false */)
 {
     if (m_isGetKeyDefined)
     {
-        // NOTE: this should not happen, if Fast asks for a key we are not able to give it
-        // This should not happen as using reader qos expects_inline_qos the instance handle should arrive in
-        // inline_qos and this function should not be called
-        // PD for reviewer: You shall remember this line, as it will bring hell on hearth in a possible future.
-        logDevError(DDSPIPE_PARTICIPANTS_TYPESUPPORT,
-                "Generic TypeSupport does not know how to retrieve the key, this should not happen.");
+        // Save the data's instanceHandle
+        auto p = static_cast<DataType*>(data);
+        *handle = p->instanceHandle;
+        return true;
     }
+
     return false;
 }
 

--- a/ddspipe_participants/src/cpp/types/dds/TopicDataType.cpp
+++ b/ddspipe_participants/src/cpp/types/dds/TopicDataType.cpp
@@ -97,7 +97,7 @@ bool TopicDataType::getKey(
 {
     if (m_isGetKeyDefined)
     {
-        // Save the data's instanceHandle
+        // Load the instanceHandle from data into handle
         auto p = static_cast<DataType*>(data);
         *handle = p->instanceHandle;
         return true;


### PR DESCRIPTION
Communication between DDS Participants (i.e. participants configured through XML) on keyed topics was faulty because the instanceHandle data was not being saved correctly.

Additionally, instanceHandle propagation from a RTPS participant to a DDS one was not being done, as the RTPS reader was not requesting it to remote writers in the first place.