### PR TITLE
Fix 0 history depth in XML Participants

### DIFF
--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -213,7 +213,15 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
             ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
             : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
 
-    qos.history().depth = topic_.topic_qos.history_depth;
+    if (topic_.topic_qos.history_depth == 0)
+    {
+        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
+    }
+    else
+    {
+        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
+        qos.history().depth = topic_.topic_qos.history_depth;
+    }
 
     return qos;
 }

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -160,7 +160,15 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
             ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
             : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
 
-    qos.history().depth = topic_.topic_qos.history_depth;
+    if (topic_.topic_qos.history_depth == 0)
+    {
+        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
+    }
+    else
+    {
+        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
+        qos.history().depth = topic_.topic_qos.history_depth;
+    }
 
     // Set minimum deadline so it matches with everything
     qos.deadline().period = eprosima::fastrtps::Duration_t(0);


### PR DESCRIPTION
An assert was going off when the max-depth was set to 0 and both participants used XML.