### PR TITLE
Max-reception-rate and down-sampling tags for DDS participants

### DIFF
--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cpp_utils/types/Fuzzy.hpp>
+
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/common/Types.h>
 
@@ -150,10 +152,10 @@ TopicQoS
     bool keyed = false;
 
     //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
-    unsigned int downsampling = 1;
+    utils::Fuzzy<unsigned int> downsampling;
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
-    float max_reception_rate = 0;
+    utils::Fuzzy<float> max_reception_rate;
 
     static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
 };

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -33,10 +33,12 @@ TopicQoS::TopicQoS()
 {
     // Set history by default
     history_depth = default_history_depth;
+
     // Set downsampling by default
-    downsampling = default_downsampling;
+    downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
+
     // Set max reception rate by default
-    max_reception_rate = default_max_reception_rate;
+    max_reception_rate.set_value(default_max_reception_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool TopicQoS::operator ==(

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cpp_utils/types/Fuzzy.hpp>
+
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 
 #include <ddspipe_core/configuration/IConfiguration.hpp>
@@ -47,6 +49,12 @@ struct ParticipantConfiguration : public core::IConfiguration
 
     //! Whether this Participant should connect its readers with its writers.
     bool is_repeater {false};
+
+    //! Participant downsampling rate associated with this configuration.
+    utils::Fuzzy<unsigned int> downsampling{};
+
+    //! Participant max reception rate associated with this configuration.
+    utils::Fuzzy<float> max_reception_rate{};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <mutex>
 
+#include <cpp_utils/time/time_utils.hpp>
+
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/interface/IReader.hpp>
 #include <ddspipe_core/interface/ITopic.hpp>
@@ -123,6 +125,10 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::ParticipantId participant_id() const noexcept override;
 
+    //! Whether a sample received should be processed
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual bool can_accept_sample_() noexcept;
+
     /////////////////////////
     // RPC REQUIRED METHODS
     /////////////////////////
@@ -156,7 +162,9 @@ protected:
      * @param participant_id parent participant id
      */
     BaseReader(
-            const core::types::ParticipantId& participant_id);
+            const core::types::ParticipantId& participant_id,
+            const float max_reception_rate = 0,
+            const unsigned int downsampling = 1);
 
     /////////////////////////
     // PROTECTED METHODS
@@ -215,6 +223,21 @@ protected:
 
     //! Mutex that guards every access to the Reader
     mutable std::recursive_mutex mutex_;
+
+    // Max reception rate
+    float max_reception_rate_;
+
+    //! Downsampling value
+    unsigned int downsampling_;
+
+    //! Counter used to keep only 1 sample of every N received, with N being the topic's downsampling factor.
+    unsigned int downsampling_idx_ = 0;
+
+    //! Reception timestamp of the last received (and processed) message, upon which max reception rate can be applied.
+    utils::Timestamp last_received_ts_ = utils::the_beginning_of_time();
+
+    //! Minimum time [ns] between received samples required to be processed (0 <=> no restriction).
+    std::chrono::nanoseconds min_intersample_period_ = std::chrono::nanoseconds(0);
 
     //! Default callback. It shows a warning that callback is not set
     static const std::function<void()> DEFAULT_ON_DATA_AVAILABLE_CALLBACK;

--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -272,7 +272,7 @@ protected:
 
     //! Whether a change received should be processed
     DDSPIPE_PARTICIPANTS_DllAPI
-    virtual bool accept_change_(
+    virtual bool can_accept_change_(
             const fastrtps::rtps::CacheChange_t* change) noexcept;
 
     //! Whether a change received is from this Participant (to avoid auto-feedback)
@@ -317,15 +317,6 @@ protected:
 
     //! Reader QoS to create the internal RTPS Reader.
     fastrtps::ReaderQos reader_qos_;
-
-    //! Counter used to keep only 1 sample of every N received, with N being the topic's downsampling factor.
-    unsigned int downsampling_idx_ = 0;
-
-    // ! Reception timestamp of the last received (and processed) message, upon which max reception rate can be applied.
-    utils::Timestamp last_received_ts_ = utils::the_beginning_of_time();
-
-    //! Minimum time [ns] between received samples required to be processed (0 <=> no restriction).
-    std::chrono::nanoseconds min_intersample_period_ = std::chrono::nanoseconds(0);
 };
 
 } /* namespace rtps */

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -162,11 +162,13 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
 {
     // Can only create DDS Topics
     const core::types::DdsTopic* topic_ptr = dynamic_cast<const core::types::DdsTopic*>(&topic);
+
     if (!topic_ptr)
     {
         logDebug(DDSPIPE_DDS_PARTICIPANT, "Not creating Reader for topic " << topic.topic_name());
         return std::make_shared<BlankReader>();
     }
+
     const core::types::DdsTopic& dds_topic = *topic_ptr;
 
     // Check that it is RTPS topic

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -91,7 +91,11 @@ void CommonReader::on_data_available(
         fastdds::dds::DataReader* /* reader */)
 {
     logInfo(DDSPIPE_DDS_READER, "On data available in reader in " << participant_id_ << " for topic " << topic_ << ".");
-    on_data_available_();
+
+    if (can_accept_sample_())
+    {
+        on_data_available_();
+    }
 }
 
 CommonReader::CommonReader(
@@ -100,7 +104,7 @@ CommonReader::CommonReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity)
-    : BaseReader(participant_id)
+    : BaseReader(participant_id, topic.topic_qos.max_reception_rate, topic.topic_qos.downsampling)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(payload_pool)
@@ -167,7 +171,7 @@ void CommonReader::enable_nts_() noexcept
 {
     // If the topic is reliable, the reader will keep the samples received when it was disabled.
     // However, if the topic is best_effort, the reader will discard the samples received when it was disabled.
-    if (topic_.topic_qos.is_reliable())
+    if (topic_.topic_qos.is_reliable() && can_accept_sample_())
     {
         on_data_available_();
     }

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -51,6 +51,8 @@ constexpr const char* PARTICIPANT_KIND_TAG("kind");   //! Participant Kind
 constexpr const char* PARTICIPANT_NAME_TAG("name");   //! Participant Name
 constexpr const char* COLLECTION_PARTICIPANTS_TAG("participants"); //! TODO: add comment
 constexpr const char* IS_REPEATER_TAG("repeater");   //! Is participant a repeater
+constexpr const char* PARTICIPANT_DOWNSAMPLING_TAG("downsampling");   //! Participant specific downsampling factor
+constexpr const char* PARTICIPANT_MAX_RECEPTION_RATE_TAG("max-reception-rate");   //! Participant specific max reception rate
 
 // Echo related tags
 constexpr const char* ECHO_DATA_TAG("data");            //! Echo Data received

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -160,6 +160,18 @@ void YamlReader::fill(
     {
         object.ignore_participant_flags = core::types::IgnoreParticipantFlags::no_filter;
     }
+
+    // Optional downsampling
+    if (YamlReader::is_tag_present(yml, PARTICIPANT_DOWNSAMPLING_TAG))
+    {
+        object.downsampling.set_value(YamlReader::get<unsigned int>(yml, PARTICIPANT_DOWNSAMPLING_TAG, version));
+    }
+
+    // Optional max reception rate
+    if (YamlReader::is_tag_present(yml, PARTICIPANT_MAX_RECEPTION_RATE_TAG))
+    {
+        object.max_reception_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_RECEPTION_RATE_TAG, version));
+    }
 }
 
 template <>


### PR DESCRIPTION
- Implement the max-reception-rate and down-sampling tags at the participant level. These tags can now be present at three different levels of configuration; in order of precedence: topic, participant, and specs.
- Implement the max-reception-rate and down-sampling tags for DDS participants.