### PR TITLE
Manually fix a set of Topic QoS, and implement the max-tx-rate, max-rx-rate, and downsampling

### DIFF
--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -154,8 +154,7 @@ protected:
      * First, it imposes the Topic QoSs configured at \c manual_topics and then the ones configured at \c participants.
      */
     DDSPIPE_CORE_DllAPI
-    void customize_topic_for_participant_nts_(
-            types::DdsTopic& topic,
+    utils::Heritable<types::Topic> create_topic_for_participant_nts_(
             const std::shared_ptr<IParticipant>& participant) noexcept;
 
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -20,8 +20,8 @@
 #include <ddspipe_core/communication/dds/Track.hpp>
 #include <ddspipe_core/configuration/RoutesConfiguration.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
-#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 #include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 namespace eprosima {
 namespace ddspipe {

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -20,6 +20,7 @@
 #include <ddspipe_core/communication/dds/Track.hpp>
 #include <ddspipe_core/configuration/RoutesConfiguration.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 namespace eprosima {
 namespace ddspipe {
@@ -162,14 +163,14 @@ protected:
     // VARIABLES
     /////////////////////////
 
-    //! TODO
+    //! Topic associated to the DdsBridge.
     utils::Heritable<types::DistributedTopic> topic_;
+
+    //! Routes associted to the Topic.
+    RoutesConfiguration::RoutesMap routes_;
 
     //! Topics that explicitally set a QoS attribute for this participant.
     std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics_;
-
-    //! TODO
-    RoutesConfiguration::RoutesMap routes_;
 
     /**
      * Inside \c Tracks

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -21,6 +21,7 @@
 #include <ddspipe_core/configuration/RoutesConfiguration.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
+#include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 
 namespace eprosima {
 namespace ddspipe {
@@ -60,7 +61,7 @@ public:
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const RoutesConfiguration& routes_config,
             const bool remove_unused_entities,
-            const std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>>& manual_topics);
+            const std::vector<core::types::ManualTopic>& manual_topics);
 
     DDSPIPE_CORE_DllAPI
     ~DdsBridge();
@@ -149,9 +150,9 @@ protected:
             std::map<types::ParticipantId, std::shared_ptr<IWriter>>& writers);
 
     /**
-     * @brief Impose the Topic QoSs that have been pre-configured for a participant.
+     * @brief Impose the Topic QoS that have been pre-configured for a participant.
      *
-     * First, it imposes the Topic QoSs configured at \c manual_topics and then the ones configured at \c participants.
+     * First, it imposes the Topic QoS configured at \c manual_topics and then the ones configured at \c participants.
      */
     DDSPIPE_CORE_DllAPI
     utils::Heritable<types::DistributedTopic> create_topic_for_participant_nts_(
@@ -164,11 +165,11 @@ protected:
     //! Topic associated to the DdsBridge.
     utils::Heritable<types::DistributedTopic> topic_;
 
-    //! Routes associted to the Topic.
+    //! Routes associated to the Topic.
     RoutesConfiguration::RoutesMap routes_;
 
     //! Topics that explicitally set a QoS attribute for this participant.
-    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics_;
+    std::vector<types::ManualTopic> manual_topics_;
 
     /**
      * Inside \c Tracks

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -126,8 +126,6 @@ protected:
      * If the Participant's IReader doesn't exist, create it.
      * If the Participant's Track doesn't exist, create it.
      *
-     * Thread safe
-     *
      * @param writers: The map of ids to writers that are required for the tracks.
      *
      * @throw InitializationException in case \c IReaders creation fails.
@@ -141,8 +139,6 @@ protected:
      * Add each Participant's IWriters to its Track.
      * If the Participant's IReader doesn't exist, create it.
      * If the Participant's Track doesn't exist, create it.
-     *
-     * Thread safe
      *
      * @param writers: The map of ids to writers that are required for the tracks.
      *

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -155,7 +155,8 @@ protected:
      * TODO
      */
     DDSPIPE_CORE_DllAPI
-    types::DistributedTopic create_topic_for_participant_(const std::shared_ptr<IParticipant>& participant);
+    types::DistributedTopic create_topic_for_participant_(
+            const std::shared_ptr<IParticipant>& participant);
 
     /////////////////////////
     // VARIABLES

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -152,12 +152,15 @@ protected:
     void add_writers_to_tracks_nts_(
             std::map<types::ParticipantId, std::shared_ptr<IWriter>>& writers);
 
-    /*
-     * TODO
+    /**
+     * @brief Impose the Topic QoSs that have been pre-configured for a participant.
+     *
+     * First, it imposes the Topic QoSs configured at \c manual_topics and then the ones configured at \c participants.
      */
     DDSPIPE_CORE_DllAPI
-    types::DistributedTopic create_topic_for_participant_(
-            const std::shared_ptr<IParticipant>& participant);
+    void customize_topic_for_participant_nts_(
+            types::DdsTopic& topic,
+            const std::shared_ptr<IParticipant>& participant) noexcept;
 
     /////////////////////////
     // VARIABLES

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -58,7 +58,8 @@ public:
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const RoutesConfiguration& routes_config,
-            const bool remove_unused_entities);
+            const bool remove_unused_entities,
+            const std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>>& manual_topics);
 
     DDSPIPE_CORE_DllAPI
     ~DdsBridge();
@@ -150,8 +151,23 @@ protected:
     void add_writers_to_tracks_nts_(
             std::map<types::ParticipantId, std::shared_ptr<IWriter>>& writers);
 
+    /*
+     * TODO
+     */
+    DDSPIPE_CORE_DllAPI
+    types::DistributedTopic create_topic_for_participant_(const std::shared_ptr<IParticipant>& participant);
+
+    /////////////////////////
+    // VARIABLES
+    /////////////////////////
+
+    //! TODO
     utils::Heritable<types::DistributedTopic> topic_;
 
+    //! Topics that explicitally set a QoS attribute for this participant.
+    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics_;
+
+    //! TODO
     RoutesConfiguration::RoutesMap routes_;
 
     /**

--- a/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
+++ b/ddspipe_core/include/ddspipe_core/communication/dds/DdsBridge.hpp
@@ -154,7 +154,7 @@ protected:
      * First, it imposes the Topic QoSs configured at \c manual_topics and then the ones configured at \c participants.
      */
     DDSPIPE_CORE_DllAPI
-    utils::Heritable<types::Topic> create_topic_for_participant_nts_(
+    utils::Heritable<types::DistributedTopic> create_topic_for_participant_nts_(
             const std::shared_ptr<IParticipant>& participant) noexcept;
 
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -66,13 +66,6 @@ struct DdsPipeConfiguration : public IConfiguration
             const std::map<types::ParticipantId, bool>& participants) const noexcept;
 
     /**
-     * @brief Set internal values with the values reloaded.
-     */
-    DDSPIPE_CORE_DllAPI
-    void reload(
-            const DdsPipeConfiguration& new_configuration);
-
-    /**
      * @brief Select the \c RoutesConfiguration for a topic.
      *
      * @return The route configuration for a specific topic.

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -81,6 +81,14 @@ struct DdsPipeConfiguration : public IConfiguration
     RoutesConfiguration get_routes_config(
             const utils::Heritable<types::DistributedTopic>& topic) const noexcept;
 
+    /**
+     * @brief Select the \c manual_topics for a topic.
+     *
+     * @return The manual topics for a specific topic.
+     */
+    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> get_manual_topics(
+            const core::ITopic& topic) const noexcept;
+
     /////////////////////////
     // VARIABLES
     /////////////////////////
@@ -93,7 +101,7 @@ struct DdsPipeConfiguration : public IConfiguration
     std::set<utils::Heritable<ddspipe::core::types::DistributedTopic>> builtin_topics{};
 
     //! Set of fixed topics' QoS
-    std::vector<utils::Heritable<ddspipe::core::types::WildcardDdsFilterTopic>> manual_topics {};
+    std::vector<utils::Heritable<ddspipe::core::types::WildcardDdsFilterTopic>> manual_topics{};
 
     //! Configuration of the generic routes.
     RoutesConfiguration routes{};

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -24,6 +24,7 @@
 #include <ddspipe_core/configuration/TopicRoutesConfiguration.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <ddspipe_core/library/library_dll.h>
 
@@ -76,6 +77,9 @@ struct DdsPipeConfiguration : public IConfiguration
     /////////////////////////
     // VARIABLES
     /////////////////////////
+
+    //! Set of fixed topics' QoS
+    std::vector<utils::Heritable<ddspipe::core::types::WildcardDdsFilterTopic>> manual_topics {};
 
     //! Configuration of the generic routes.
     RoutesConfiguration routes{};

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -79,6 +79,7 @@ struct DdsPipeConfiguration : public IConfiguration
      *
      * @return The manual topics for a specific topic.
      */
+    DDSPIPE_CORE_DllAPI
     std::vector<core::types::ManualTopic> get_manual_topics(
             const core::ITopic& topic) const noexcept;
 

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -66,6 +66,13 @@ struct DdsPipeConfiguration : public IConfiguration
             const std::map<types::ParticipantId, bool>& participants) const noexcept;
 
     /**
+     * @brief Set internal values with the values reloaded.
+     */
+    DDSPIPE_CORE_DllAPI
+    void reload(
+            const DdsPipeConfiguration& new_configuration);
+
+    /**
      * @brief Select the \c RoutesConfiguration for a topic.
      *
      * @return The route configuration for a specific topic.
@@ -78,6 +85,13 @@ struct DdsPipeConfiguration : public IConfiguration
     // VARIABLES
     /////////////////////////
 
+    //! Topic lists to build the AllowedTopics
+    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> allowlist{};
+    std::set<utils::Heritable<ddspipe::core::types::IFilterTopic>> blocklist{};
+
+    //! Builtin topics to create at the beggining of the execution
+    std::set<utils::Heritable<ddspipe::core::types::DistributedTopic>> builtin_topics{};
+
     //! Set of fixed topics' QoS
     std::vector<utils::Heritable<ddspipe::core::types::WildcardDdsFilterTopic>> manual_topics {};
 
@@ -89,6 +103,9 @@ struct DdsPipeConfiguration : public IConfiguration
 
     //! Whether entities should be removed when they have no writers connected to them.
     bool remove_unused_entities = false;
+
+    //! Whether the DDS Pipe should be initialized enabled.
+    bool init_enabled = false;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -24,7 +24,7 @@
 #include <ddspipe_core/configuration/TopicRoutesConfiguration.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
-#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
+#include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 
 #include <ddspipe_core/library/library_dll.h>
 
@@ -79,7 +79,7 @@ struct DdsPipeConfiguration : public IConfiguration
      *
      * @return The manual topics for a specific topic.
      */
-    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> get_manual_topics(
+    std::vector<core::types::ManualTopic> get_manual_topics(
             const core::ITopic& topic) const noexcept;
 
     /////////////////////////
@@ -93,8 +93,8 @@ struct DdsPipeConfiguration : public IConfiguration
     //! Builtin topics to create at the beggining of the execution
     std::set<utils::Heritable<ddspipe::core::types::DistributedTopic>> builtin_topics{};
 
-    //! Set of fixed topics' QoS
-    std::vector<utils::Heritable<ddspipe::core::types::WildcardDdsFilterTopic>> manual_topics{};
+    //! Set of manually configured Topic QoS
+    std::vector<ddspipe::core::types::ManualTopic> manual_topics{};
 
     //! Configuration of the generic routes.
     RoutesConfiguration routes{};

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -155,11 +155,6 @@ protected:
     /////////////////////////
 
     /**
-     * @brief In each participant, reference each manual-topic the participant is listed in.
-     */
-    void load_manual_topics_into_participants_() noexcept;
-
-    /**
      * @brief Method called every time a new endpoint has been discovered
      *
      * This method calls \c discovered_endpoint_nts_ with a lock on the mutex to make it thread safe.

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -134,6 +134,11 @@ protected:
     /////////////////////////
 
     /**
+     * @brief In each participant, reference each manual-topic the participant is listed in.
+     */
+    void load_manual_topics_into_participants_() noexcept;
+
+    /**
      * @brief Method called every time a new endpoint has been discovered
      *
      * This method calls \c discovered_endpoint_nts_ with a lock on the mutex to make it thread safe.

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -333,6 +333,13 @@ protected:
      */
     void deactivate_all_topics_nts_() noexcept;
 
+    //////////////////////////
+    // CONFIGURATION VARIABLES
+    //////////////////////////
+
+    //! Configuration of the DDS Pipe
+    DdsPipeConfiguration configuration_;
+
     /////////////////////////
     // SHARED DATA STORAGE
     /////////////////////////
@@ -403,13 +410,6 @@ protected:
      * @brief Internal mutex for concurrent calls
      */
     mutable std::mutex mutex_;
-
-    //////////////////////////
-    // CONFIGURATION VARIABLES
-    //////////////////////////
-
-    //! Configuration of the DDS Pipe
-    DdsPipeConfiguration configuration_;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -61,14 +61,14 @@ public:
      */
     DDSPIPE_CORE_DllAPI
     DdsPipe(
+            const DdsPipeConfiguration& configuration,
             const std::shared_ptr<AllowedTopicList>& allowed_topics,
             const std::shared_ptr<DiscoveryDatabase>& discovery_database,
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<ParticipantsDatabase>& participants_database,
             const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
             const std::set<utils::Heritable<types::DistributedTopic>>& builtin_topics = {},
-            bool start_enable = false,
-            const DdsPipeConfiguration& configuration = {});
+            bool start_enable = false);
 
     /**
      * @brief Destroy the DdsPipe object

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -82,15 +82,17 @@ public:
     /////////////////////////
 
     /**
-     * @brief Reload the allowed topic configuration
+     * @brief Reload the DdsPipe configuration.
      *
-     * @param [in] configuration : new configuration
+     * @param [in] configuration : new configuration.
      *
-     * @return \c RETCODE_OK if configuration has been updated correctly
-     * @return \c RETCODE_NO_DATA if new configuration has not changed
-     * @return \c RETCODE_ERROR if any other error has occurred
+     * @return \c RETCODE_OK if the configuration has been updated correctly.
+     * @return \c RETCODE_NO_DATA if the new configuration has not changed.
+     * @return \c RETCODE_ERROR if any other error has occurred.
      *
-     * @throw \c ConfigurationException in case the new yaml is not well-formed
+     * @note This method checks that the new configuration file is valid and calls \c reload_allowed_topics_
+     *
+     * @throw \c ConfigurationException in case the new yaml is not well-formed.
      */
     DDSPIPE_CORE_DllAPI
     utils::ReturnCode reload_configuration(
@@ -137,15 +139,13 @@ protected:
     void init_allowed_topics_();
 
     /**
-     * @brief Reload the allowed topic configuration
+     * @brief Reload the allowed topics configuration.
      *
-     * @param [in] configuration : new configuration
+     * @param [in] allowed_topics : new allowed topics.
      *
-     * @return \c RETCODE_OK if configuration has been updated correctly
-     * @return \c RETCODE_NO_DATA if new configuration has not changed
-     * @return \c RETCODE_ERROR if any other error has occurred
-     *
-     * @throw \c ConfigurationException in case the new yaml is not well-formed
+     * @return \c RETCODE_OK if the allowed topics have been updated correctly.
+     * @return \c RETCODE_NO_DATA if the new allowed topics have not changed.
+     * @return \c RETCODE_ERROR if any other error has occurred.
      */
     utils::ReturnCode reload_allowed_topics_(
             const std::shared_ptr<AllowedTopicList>& allowed_topics);

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -62,13 +62,10 @@ public:
     DDSPIPE_CORE_DllAPI
     DdsPipe(
             const DdsPipeConfiguration& configuration,
-            const std::shared_ptr<AllowedTopicList>& allowed_topics,
             const std::shared_ptr<DiscoveryDatabase>& discovery_database,
             const std::shared_ptr<PayloadPool>& payload_pool,
             const std::shared_ptr<ParticipantsDatabase>& participants_database,
-            const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
-            const std::set<utils::Heritable<types::DistributedTopic>>& builtin_topics = {},
-            bool start_enable = false);
+            const std::shared_ptr<utils::SlotThreadPool>& thread_pool);
 
     /**
      * @brief Destroy the DdsPipe object
@@ -96,8 +93,8 @@ public:
      * @throw \c ConfigurationException in case the new yaml is not well-formed
      */
     DDSPIPE_CORE_DllAPI
-    utils::ReturnCode reload_allowed_topics(
-            const std::shared_ptr<AllowedTopicList>& allowed_topics);
+    utils::ReturnCode reload_configuration(
+            const DdsPipeConfiguration& new_configuration);
 
     /////////////////////////
     // ENABLING METHODS
@@ -128,6 +125,29 @@ public:
     utils::ReturnCode disable() noexcept;
 
 protected:
+
+    /////////////////////////
+    // INTERACTION METHODS
+    /////////////////////////
+    /**
+     * @brief Load allowed topics from configuration
+     *
+     * @throw \c ConfigurationException in case the yaml inside allowlist is not well-formed
+     */
+    void init_allowed_topics_();
+
+    /**
+     * @brief Reload the allowed topic configuration
+     *
+     * @param [in] configuration : new configuration
+     *
+     * @return \c RETCODE_OK if configuration has been updated correctly
+     * @return \c RETCODE_NO_DATA if new configuration has not changed
+     * @return \c RETCODE_ERROR if any other error has occurred
+     *
+     * @throw \c ConfigurationException in case the new yaml is not well-formed
+     */
+    utils::ReturnCode reload_allowed_topics_(const std::shared_ptr<AllowedTopicList>& allowed_topics);
 
     /////////////////////////
     // CALLBACK METHODS

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -147,7 +147,8 @@ protected:
      *
      * @throw \c ConfigurationException in case the new yaml is not well-formed
      */
-    utils::ReturnCode reload_allowed_topics_(const std::shared_ptr<AllowedTopicList>& allowed_topics);
+    utils::ReturnCode reload_allowed_topics_(
+            const std::shared_ptr<AllowedTopicList>& allowed_topics);
 
     /////////////////////////
     // CALLBACK METHODS

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -84,7 +84,7 @@ public:
     /**
      * @brief Reload the DdsPipe configuration.
      *
-     * @param [in] configuration : new configuration.
+     * @param [in] new_configuration : new configuration.
      *
      * @return \c RETCODE_OK if the configuration has been updated correctly.
      * @return \c RETCODE_NO_DATA if the new configuration has not changed.

--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -102,9 +102,7 @@ public:
     // VARIABLES
     /////////////////////////
 
-    /**
-     * @brief TODO
-     */
+    //! Topics that explicitally set a QoS attribute for this participant.
     std::set<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics;
 };
 

--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -14,9 +14,14 @@
 
 #pragma once
 
+#include <memory>
+
+#include <cpp_utils/memory/Heritable.hpp>
+
 #include <ddspipe_core/interface/IReader.hpp>
 #include <ddspipe_core/interface/IWriter.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 #include <ddspipe_core/types/topic/Topic.hpp>
 
 namespace eprosima {
@@ -56,7 +61,7 @@ public:
     virtual bool is_rtps_kind() const noexcept = 0;
 
     /**
-     * @brief Whether this Participant requires to connect ist own readers with its own writers.
+     * @brief Whether this Participant requires to connect its own readers with its own writers.
      */
     DDSPIPE_CORE_DllAPI
     virtual bool is_repeater() const noexcept = 0;
@@ -92,6 +97,15 @@ public:
     DDSPIPE_CORE_DllAPI
     virtual std::shared_ptr<IReader> create_reader(
             const ITopic& topic) = 0;
+
+    /////////////////////////
+    // VARIABLES
+    /////////////////////////
+
+    /**
+     * @brief TODO
+     */
+    std::set<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -103,7 +103,7 @@ public:
     /////////////////////////
 
     //! Topics that explicitally set a QoS attribute for this participant.
-    std::set<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics;
+    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -14,15 +14,10 @@
 
 #pragma once
 
-#include <memory>
-
-#include <cpp_utils/memory/Heritable.hpp>
-
 #include <ddspipe_core/interface/IReader.hpp>
 #include <ddspipe_core/interface/IWriter.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
-#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 #include <ddspipe_core/types/topic/Topic.hpp>
 
 namespace eprosima {
@@ -49,27 +44,19 @@ public:
     DDSPIPE_CORE_DllAPI
     virtual ~IParticipant() = default;
 
-    /**
-     * @brief Return the unique identifier of this Participant.
-     *
-     * @return This Participant id
-     */
+    //! The Participant's unique identifier.
     DDSPIPE_CORE_DllAPI
     virtual types::ParticipantId id() const noexcept = 0;
 
-    //! Whether this participant is RTPS
+    //! Whether the Participant is RTPS.
     DDSPIPE_CORE_DllAPI
     virtual bool is_rtps_kind() const noexcept = 0;
 
-    /**
-     * @brief Whether this Participant requires to connect its own readers with its own writers.
-     */
+    //! Whether the Participant requires to connect its own readers with its own writers.
     DDSPIPE_CORE_DllAPI
     virtual bool is_repeater() const noexcept = 0;
 
-    /**
-     * @brief TODO
-     */
+    //! The Participant's Topic QoS.
     DDSPIPE_CORE_DllAPI
     virtual types::TopicQoS topic_qos() const noexcept = 0;
 

--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -20,6 +20,7 @@
 
 #include <ddspipe_core/interface/IReader.hpp>
 #include <ddspipe_core/interface/IWriter.hpp>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 #include <ddspipe_core/types/topic/Topic.hpp>
@@ -67,6 +68,12 @@ public:
     virtual bool is_repeater() const noexcept = 0;
 
     /**
+     * @brief TODO
+     */
+    DDSPIPE_CORE_DllAPI
+    virtual types::TopicQoS topic_qos() const noexcept = 0;
+
+    /**
      * @brief Return a new Writer
      *
      * Each writer is associated with a \c Bridge with the topic \c topic .
@@ -97,13 +104,6 @@ public:
     DDSPIPE_CORE_DllAPI
     virtual std::shared_ptr<IReader> create_reader(
             const ITopic& topic) = 0;
-
-    /////////////////////////
-    // VARIABLES
-    /////////////////////////
-
-    //! Topics that explicitally set a QoS attribute for this participant.
-    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/interface/ITopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/ITopic.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <cpp_utils/Formatter.hpp>
+#include <cpp_utils/memory/Heritable.hpp>
 
 #include <ddspipe_core/library/library_dll.h>
 #include <ddspipe_core/types/topic/TopicInternalTypeDiscriminator.hpp>
@@ -59,6 +60,10 @@ public:
     //! ITopic serialization to string
     DDSPIPE_CORE_DllAPI
     virtual std::string serialize() const noexcept = 0;
+
+    //! Make a copy of the ITopic
+    DDSPIPE_CORE_DllAPI
+    virtual utils::Heritable<ITopic> copy() const noexcept = 0;
 
     /**
      * This refers to an internal used identifier that declares which kind of data type is going to be

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -118,7 +118,7 @@ TopicQoS
     utils::Fuzzy<bool> keyed{DEFAULT_KEYED, utils::FuzzyLevelValues::fuzzy_level_default};
 
     //! Depth of the history
-    utils::Fuzzy<HistoryDepthType> history_depth{DEFAULT_KEYED, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<HistoryDepthType> history_depth{DEFAULT_HISTORY_DEPTH, utils::FuzzyLevelValues::fuzzy_level_default};
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
     utils::Fuzzy<float> max_tx_rate{DEFAULT_MAX_TX_RATE, utils::FuzzyLevelValues::fuzzy_level_default};

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -87,7 +87,7 @@ TopicQoS
     bool has_partitions() const noexcept;
 
     /**
-     * @brief Set the Topic QoSs that have not been set and are set in \c qos .
+     * @brief Set the Topic QoS that have not been set and are set in \c qos .
      *
      * @note A Topic QoS is considered as set when it has a FuzzyLevel higher than DEFAULT.
      */
@@ -97,7 +97,7 @@ TopicQoS
             const utils::FuzzyLevelValues& fuzzy_level = utils::FuzzyLevelValues::fuzzy_level_fuzzy) noexcept;
 
     /**
-     * @brief Set the default Topic QoSs.
+     * @brief Set the default Topic QoS.
      */
     DDSPIPE_CORE_DllAPI
     void set_default_qos(

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -55,16 +55,7 @@ TopicQoS
 
     //! Default TopicQoS with reader less restrictive parameters
     DDSPIPE_CORE_DllAPI
-    TopicQoS(
-            DurabilityKind durability_qos = DEFAULT_DURABILITY_QOS,
-            ReliabilityKind reliability_qos = DEFAULT_RELIABILITY_QOS,
-            OwnershipQosPolicyKind ownership_qos = DEFAULT_OWNERSHIP_QOS,
-            bool use_partitions = DEFAULT_USE_PARTITIONS,
-            bool keyed = DEFAULT_KEYED,
-            HistoryDepthType history_depth = DEFAULT_HISTORY_DEPTH,
-            float max_tx_rate = DEFAULT_MAX_TX_RATE,
-            float max_rx_rate = DEFAULT_MAX_RX_RATE,
-            unsigned int downsampling = DEFAULT_DOWNSAMPLING);
+    TopicQoS();
 
     /////////////////////////
     // OPERATORS
@@ -104,6 +95,21 @@ TopicQoS
     void set_qos(
             const TopicQoS& qos,
             const utils::FuzzyLevelValues& fuzzy_level = utils::FuzzyLevelValues::fuzzy_level_fuzzy) noexcept;
+
+    /**
+     * @brief Set the default Topic QoSs.
+     */
+    DDSPIPE_CORE_DllAPI
+    void set_default_qos(
+            DurabilityKind durability_qos = DEFAULT_DURABILITY_QOS,
+            ReliabilityKind reliability_qos = DEFAULT_RELIABILITY_QOS,
+            OwnershipQosPolicyKind ownership_qos = DEFAULT_OWNERSHIP_QOS,
+            bool use_partitions = DEFAULT_USE_PARTITIONS,
+            bool keyed = DEFAULT_KEYED,
+            HistoryDepthType history_depth = DEFAULT_HISTORY_DEPTH,
+            float max_tx_rate = DEFAULT_MAX_TX_RATE,
+            float max_rx_rate = DEFAULT_MAX_RX_RATE,
+            unsigned int downsampling = DEFAULT_DOWNSAMPLING) noexcept;
 
     /////////////////////////
     // VARIABLES

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -41,15 +41,8 @@ using OwnershipQosPolicyKind = eprosima::fastdds::dds::OwnershipQosPolicyKind;
 /**
  * Collection of QoS related with a Topic.
  *
- * The QoS associated with Topic are:
- * - Reliability
- * - Durability
- * - Ownership
- * - Partitions
- * - History Depth (history kind is always KEEP_LAST)
- *
- * @warning partitions are considered as a QoS, thus a Topic can only have partitions, or not have any, but cannot
- * support empty partition and partitions.
+ * @warning partitions are considered a Topic QoS. A Topic can then only either have partitions or not have them, but it
+ * cannot support empty partitions.
  *
  * @todo add keys to Topic QoS
  */
@@ -93,7 +86,11 @@ TopicQoS
     DDSPIPE_CORE_DllAPI
     bool has_partitions() const noexcept;
 
-    //! Whether the Topic has partitions, not empty partition
+    /**
+     * @brief Set the Topic QoSs that have not been set and are set in \c qos .
+     *
+     * @note A Topic QoS is considered as set when it has a FuzzyLevel higher than DEFAULT.
+     */
     DDSPIPE_CORE_DllAPI
     void set_qos(
             const TopicQoS& qos) noexcept;

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -97,47 +97,49 @@ TopicQoS
             const utils::FuzzyLevelValues& fuzzy_level = utils::FuzzyLevelValues::fuzzy_level_fuzzy) noexcept;
 
     /////////////////////////
+    // VARIABLES
+    /////////////////////////
+
+    //! Durability kind
+    utils::Fuzzy<DurabilityKind> durability_qos{DEFAULT_DURABILITY_QOS, utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Reliability kind
+    utils::Fuzzy<ReliabilityKind> reliability_qos{DEFAULT_RELIABILITY_QOS,
+                                                  utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Ownership kind of the topic
+    utils::Fuzzy<OwnershipQosPolicyKind> ownership_qos{DEFAULT_OWNERSHIP_QOS,
+                                                       utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Whether the topics uses partitions
+    utils::Fuzzy<bool> use_partitions{DEFAULT_USE_PARTITIONS, utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Whether the topic has key or not
+    utils::Fuzzy<bool> keyed{DEFAULT_KEYED, utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Depth of the history
+    utils::Fuzzy<HistoryDepthType> history_depth{DEFAULT_KEYED, utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
+    utils::Fuzzy<float> max_tx_rate{DEFAULT_MAX_TX_RATE, utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
+    utils::Fuzzy<float> max_rx_rate{DEFAULT_MAX_RX_RATE, utils::FuzzyLevelValues::fuzzy_level_default};
+
+    //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
+    utils::Fuzzy<unsigned int> downsampling{DEFAULT_DOWNSAMPLING, utils::FuzzyLevelValues::fuzzy_level_default};
+
+    /////////////////////////
     // GLOBAL VARIABLES
     /////////////////////////
 
     //! Global value to store the default Topic QoS in this execution.
     DDSPIPE_CORE_DllAPI
-    static std::atomic<TopicQoS> default_topic_qos;
+    static utils::Fuzzy<TopicQoS> default_topic_qos;
 
     /////////////////////////
-    // VARIABLES
+    // DEFAULT VALUES
     /////////////////////////
-
-    //! Durability kind
-    utils::Fuzzy<DurabilityKind> durability_qos;
-
-    //! Reliability kind
-    utils::Fuzzy<ReliabilityKind> reliability_qos;
-
-    //! Ownership kind of the topic
-    utils::Fuzzy<OwnershipQosPolicyKind> ownership_qos;
-
-    //! Whether the topics uses partitions
-    utils::Fuzzy<bool> use_partitions;
-
-    //! Whether the topic has key or not
-    utils::Fuzzy<bool> keyed;
-
-    //! Depth of the history
-    utils::Fuzzy<HistoryDepthType> history_depth;
-
-    //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
-    utils::Fuzzy<float> max_tx_rate;
-
-    //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
-    utils::Fuzzy<float> max_rx_rate;
-
-    //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
-    utils::Fuzzy<unsigned int> downsampling;
-
-    //////////////////////////////////////////
-    // GLOBAL VARIABLES' DEFAULT VALUES
-    //////////////////////////////////////////
 
     //! Durability kind (Default = VOLATILE)
     DDSPIPE_CORE_DllAPI

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -93,92 +93,16 @@ TopicQoS
      */
     DDSPIPE_CORE_DllAPI
     void set_qos(
-            const TopicQoS& qos) noexcept;
+            const TopicQoS& qos,
+            const utils::FuzzyLevelValues& fuzzy_level = utils::FuzzyLevelValues::fuzzy_level_fuzzy) noexcept;
 
     /////////////////////////
     // GLOBAL VARIABLES
     /////////////////////////
 
-    /**
-     * @brief Global value to store the default durability qos in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c durability_qos default.
-     */
+    //! Global value to store the default Topic QoS in this execution.
     DDSPIPE_CORE_DllAPI
-    static std::atomic<DurabilityKind> default_durability_qos;
-
-    /**
-     * @brief Global value to store the default reliability qos in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c reliability_qos default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<ReliabilityKind> default_reliability_qos;
-
-    /**
-     * @brief Global value to store the default ownership qos in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c ownership_qos default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<OwnershipQosPolicyKind> default_ownership_qos;
-
-    /**
-     * @brief Global value to store the default use_partitions in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c use_partitions default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<bool> default_use_partitions;
-
-    /**
-     * @brief Global value to store the default keyed in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c keyed default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<bool> default_keyed;
-
-    /**
-     * @brief Global value to store the default  in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c history_depth default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<HistoryDepthType> default_history_depth;
-
-    /**
-     * @brief Global value to store the default max transmission rate in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c max_tx_rate default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<float> default_max_tx_rate;
-
-    /**
-     * @brief Global value to store the default max reception rate in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c max_rx_rate default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<float> default_max_rx_rate;
-
-    /**
-     * @brief Global value to store the default downsampling factor in this execution.
-     *
-     * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c downsampling default.
-     */
-    DDSPIPE_CORE_DllAPI
-    static std::atomic<unsigned int> default_downsampling;
+    static std::atomic<TopicQoS> default_topic_qos;
 
     /////////////////////////
     // VARIABLES

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -133,16 +133,16 @@ TopicQoS
     /////////////////////////
 
     //! Durability kind (Default = VOLATILE)
-    DurabilityKind durability_qos = DurabilityKind::VOLATILE;
+    utils::Fuzzy<DurabilityKind> durability_qos;
 
     //! Reliability kind (Default = BEST_EFFORT)
-    ReliabilityKind reliability_qos = ReliabilityKind::BEST_EFFORT;
+    utils::Fuzzy<ReliabilityKind> reliability_qos;
 
     //! Ownership kind of the topic
-    OwnershipQosPolicyKind ownership_qos = OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+    utils::Fuzzy<OwnershipQosPolicyKind> ownership_qos;
 
     //! Whether the topics uses partitions
-    bool use_partitions = false;
+    utils::Fuzzy<bool> use_partitions;
 
     /**
      * @brief History Qos
@@ -150,10 +150,10 @@ TopicQoS
      * @note Default value would be taken from \c default_history_depth in object creation.
      * @note It only stores the depth because in pipe it will always be keep last, as RTPS has not resource limits.
      */
-    HistoryDepthType history_depth = HISTORY_DEPTH_DEFAULT;
+    utils::Fuzzy<HistoryDepthType> history_depth;
 
     //! Whether the topic has key or not
-    bool keyed = false;
+    utils::Fuzzy<bool> keyed;
 
     //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
     utils::Fuzzy<unsigned int> downsampling;
@@ -161,7 +161,30 @@ TopicQoS
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
     utils::Fuzzy<float> max_rx_rate;
 
+
+    //! Durability kind (Default = VOLATILE)
+    static constexpr DurabilityKind DURABILITY_QOS_DEFAULT = DurabilityKind::VOLATILE;
+
+    //! Reliability kind (Default = BEST_EFFORT)
+    static constexpr ReliabilityKind RELIABILITY_QOS_DEFAULT = ReliabilityKind::BEST_EFFORT;
+
+    //! Ownership kind of the topic
+    static constexpr OwnershipQosPolicyKind OWNERSHIP_QOS_DEFAULT = OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+
+    //! Whether the topics uses partitions
+    static constexpr bool USE_PARTITIONS_DEFAULT = false;
+
+    //! TODO
     static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
+
+    //! TODO
+    static constexpr bool KEYED_DEFAULT = false;
+
+    //! TODO
+    static constexpr unsigned int DOWNSAMPLING_DEFAULT = 1;
+
+    //! TODO
+    static constexpr float MAX_RX_RATE_DEFAULT = 0;
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -39,12 +39,23 @@ using HistoryDepthType = unsigned int;
 using OwnershipQosPolicyKind = eprosima::fastdds::dds::OwnershipQosPolicyKind;
 
 /**
- * Collection of QoS related with a Topic.
+ * The collection of QoS related to a Topic.
+ *
+ * The Topic QoS are:
+ *  - Durability
+ *  - Reliability
+ *  - Ownership
+ *  - Partitions
+ *  - Keyed
+ *  - History Depth
+ *  - Max Transmission Rate
+ *  - Max Reception Rate
+ *  - Downsampling
  *
  * @warning partitions are considered a Topic QoS. A Topic can then only either have partitions or not have them, but it
  * cannot support empty partitions.
  *
- * @todo add keys to Topic QoS
+ * @todo create a child of TopicQoS called DdsTopicQoS that contains the QoS specific to DDS.
  */
 struct
 TopicQoS

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -93,6 +93,10 @@ TopicQoS
     DDSPIPE_CORE_DllAPI
     bool has_partitions() const noexcept;
 
+    //! Whether the Topic has partitions, not empty partition
+    DDSPIPE_CORE_DllAPI
+    void set_qos(const TopicQoS& qos) noexcept;
+
     /////////////////////////
     // GLOBAL VARIABLES
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cpp_utils/types/Fuzzy.hpp>
+
 #include <fastdds/dds/core/policy/QosPolicies.hpp>
 #include <fastdds/rtps/common/Types.h>
 
@@ -150,10 +152,10 @@ TopicQoS
     bool keyed = false;
 
     //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
-    unsigned int downsampling = 1;
+    utils::Fuzzy<unsigned int> downsampling;
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
-    float max_reception_rate = 0;
+    utils::Fuzzy<float> max_reception_rate;
 
     static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
 };

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -95,7 +95,8 @@ TopicQoS
 
     //! Whether the Topic has partitions, not empty partition
     DDSPIPE_CORE_DllAPI
-    void set_qos(const TopicQoS& qos) noexcept;
+    void set_qos(
+            const TopicQoS& qos) noexcept;
 
     /////////////////////////
     // GLOBAL VARIABLES

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -128,6 +128,15 @@ TopicQoS
     DDSPIPE_CORE_DllAPI
     static std::atomic<float> default_max_rx_rate;
 
+    /**
+     * @brief Global value to store the default max transmission rate in this execution.
+     *
+     * This value can change along the execution.
+     * Every new TopicQoS object will use this value as \c max_tx_rate default.
+     */
+    DDSPIPE_CORE_DllAPI
+    static std::atomic<float> default_max_tx_rate;
+
     /////////////////////////
     // VARIABLES
     /////////////////////////
@@ -161,6 +170,9 @@ TopicQoS
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
     utils::Fuzzy<float> max_rx_rate;
 
+    //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
+    utils::Fuzzy<float> max_tx_rate;
+
 
     //! Durability kind (Default = VOLATILE)
     static constexpr DurabilityKind DURABILITY_QOS_DEFAULT = DurabilityKind::VOLATILE;
@@ -185,6 +197,9 @@ TopicQoS
 
     //! TODO
     static constexpr float MAX_RX_RATE_DEFAULT = 0;
+
+    //! TODO
+    static constexpr float MAX_TX_RATE_DEFAULT = 0;
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -103,7 +103,52 @@ TopicQoS
     /////////////////////////
 
     /**
-     * @brief Global value to store the default history depth in this execution.
+     * @brief Global value to store the default durability qos in this execution.
+     *
+     * This value can change along the execution.
+     * Every new TopicQoS object will use this value as \c durability_qos default.
+     */
+    DDSPIPE_CORE_DllAPI
+    static std::atomic<DurabilityKind> default_durability_qos;
+
+    /**
+     * @brief Global value to store the default reliability qos in this execution.
+     *
+     * This value can change along the execution.
+     * Every new TopicQoS object will use this value as \c reliability_qos default.
+     */
+    DDSPIPE_CORE_DllAPI
+    static std::atomic<ReliabilityKind> default_reliability_qos;
+
+    /**
+     * @brief Global value to store the default ownership qos in this execution.
+     *
+     * This value can change along the execution.
+     * Every new TopicQoS object will use this value as \c ownership_qos default.
+     */
+    DDSPIPE_CORE_DllAPI
+    static std::atomic<OwnershipQosPolicyKind> default_ownership_qos;
+
+    /**
+     * @brief Global value to store the default use_partitions in this execution.
+     *
+     * This value can change along the execution.
+     * Every new TopicQoS object will use this value as \c use_partitions default.
+     */
+    DDSPIPE_CORE_DllAPI
+    static std::atomic<bool> default_use_partitions;
+
+    /**
+     * @brief Global value to store the default keyed in this execution.
+     *
+     * This value can change along the execution.
+     * Every new TopicQoS object will use this value as \c keyed default.
+     */
+    DDSPIPE_CORE_DllAPI
+    static std::atomic<bool> default_keyed;
+
+    /**
+     * @brief Global value to store the default  in this execution.
      *
      * This value can change along the execution.
      * Every new TopicQoS object will use this value as \c history_depth default.
@@ -142,10 +187,10 @@ TopicQoS
     // VARIABLES
     /////////////////////////
 
-    //! Durability kind (Default = VOLATILE)
+    //! Durability kind
     utils::Fuzzy<DurabilityKind> durability_qos;
 
-    //! Reliability kind (Default = BEST_EFFORT)
+    //! Reliability kind
     utils::Fuzzy<ReliabilityKind> reliability_qos;
 
     //! Ownership kind of the topic
@@ -154,16 +199,11 @@ TopicQoS
     //! Whether the topics uses partitions
     utils::Fuzzy<bool> use_partitions;
 
-    /**
-     * @brief History Qos
-     *
-     * @note Default value would be taken from \c default_history_depth in object creation.
-     * @note It only stores the depth because in pipe it will always be keep last, as RTPS has not resource limits.
-     */
-    utils::Fuzzy<HistoryDepthType> history_depth;
-
     //! Whether the topic has key or not
     utils::Fuzzy<bool> keyed;
+
+    //! Depth of the history
+    utils::Fuzzy<HistoryDepthType> history_depth;
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
     utils::Fuzzy<float> max_tx_rate;
@@ -174,33 +214,45 @@ TopicQoS
     //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
     utils::Fuzzy<unsigned int> downsampling;
 
+    //////////////////////////////////////////
+    // GLOBAL VARIABLES' DEFAULT VALUES
+    //////////////////////////////////////////
 
     //! Durability kind (Default = VOLATILE)
-    static constexpr DurabilityKind DURABILITY_QOS_DEFAULT = DurabilityKind::VOLATILE;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const DurabilityKind DEFAULT_DURABILITY_QOS = DurabilityKind::VOLATILE;
 
     //! Reliability kind (Default = BEST_EFFORT)
-    static constexpr ReliabilityKind RELIABILITY_QOS_DEFAULT = ReliabilityKind::BEST_EFFORT;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const ReliabilityKind DEFAULT_RELIABILITY_QOS = ReliabilityKind::BEST_EFFORT;
 
     //! Ownership kind (Default = SHARED_OWNERSHIP)
-    static constexpr OwnershipQosPolicyKind OWNERSHIP_QOS_DEFAULT = OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const OwnershipQosPolicyKind DEFAULT_OWNERSHIP_QOS = OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
 
     //! Whether the topic uses partitions (Default = False)
-    static constexpr bool USE_PARTITIONS_DEFAULT = false;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const bool DEFAULT_USE_PARTITIONS = false;
 
     //! History depth (Default = 5000)
-    static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const HistoryDepthType DEFAULT_HISTORY_DEPTH = 5000;
 
     //! Whether the topic has a key (Default = False)
-    static constexpr bool KEYED_DEFAULT = false;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const bool DEFAULT_KEYED = false;
 
     //! Max Tx Rate (Default = 0)
-    static constexpr float MAX_TX_RATE_DEFAULT = 0;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const float DEFAULT_MAX_TX_RATE = 0;
 
     //! Max Rx Rate (Default = 0)
-    static constexpr float MAX_RX_RATE_DEFAULT = 0;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const float DEFAULT_MAX_RX_RATE = 0;
 
     //! Downsampling (Default = 1)
-    static constexpr unsigned int DOWNSAMPLING_DEFAULT = 1;
+    DDSPIPE_CORE_DllAPI
+    static constexpr const unsigned int DEFAULT_DOWNSAMPLING = 1;
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -55,7 +55,16 @@ TopicQoS
 
     //! Default TopicQoS with reader less restrictive parameters
     DDSPIPE_CORE_DllAPI
-    TopicQoS();
+    TopicQoS(
+            DurabilityKind durability_qos = DEFAULT_DURABILITY_QOS,
+            ReliabilityKind reliability_qos = DEFAULT_RELIABILITY_QOS,
+            OwnershipQosPolicyKind ownership_qos = DEFAULT_OWNERSHIP_QOS,
+            bool use_partitions = DEFAULT_USE_PARTITIONS,
+            bool keyed = DEFAULT_KEYED,
+            HistoryDepthType history_depth = DEFAULT_HISTORY_DEPTH,
+            float max_tx_rate = DEFAULT_MAX_TX_RATE,
+            float max_rx_rate = DEFAULT_MAX_RX_RATE,
+            unsigned int downsampling = DEFAULT_DOWNSAMPLING);
 
     /////////////////////////
     // OPERATORS
@@ -101,33 +110,31 @@ TopicQoS
     /////////////////////////
 
     //! Durability kind
-    utils::Fuzzy<DurabilityKind> durability_qos{DEFAULT_DURABILITY_QOS, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<DurabilityKind> durability_qos;
 
     //! Reliability kind
-    utils::Fuzzy<ReliabilityKind> reliability_qos{DEFAULT_RELIABILITY_QOS,
-                                                  utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<ReliabilityKind> reliability_qos;
 
     //! Ownership kind of the topic
-    utils::Fuzzy<OwnershipQosPolicyKind> ownership_qos{DEFAULT_OWNERSHIP_QOS,
-                                                       utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<OwnershipQosPolicyKind> ownership_qos;
 
     //! Whether the topics uses partitions
-    utils::Fuzzy<bool> use_partitions{DEFAULT_USE_PARTITIONS, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<bool> use_partitions;
 
     //! Whether the topic has key or not
-    utils::Fuzzy<bool> keyed{DEFAULT_KEYED, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<bool> keyed;
 
     //! Depth of the history
-    utils::Fuzzy<HistoryDepthType> history_depth{DEFAULT_HISTORY_DEPTH, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<HistoryDepthType> history_depth;
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
-    utils::Fuzzy<float> max_tx_rate{DEFAULT_MAX_TX_RATE, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<float> max_tx_rate;
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
-    utils::Fuzzy<float> max_rx_rate{DEFAULT_MAX_RX_RATE, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<float> max_rx_rate;
 
     //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
-    utils::Fuzzy<unsigned int> downsampling{DEFAULT_DOWNSAMPLING, utils::FuzzyLevelValues::fuzzy_level_default};
+    utils::Fuzzy<unsigned int> downsampling;
 
     /////////////////////////
     // GLOBAL VARIABLES

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -119,10 +119,10 @@ TopicQoS
      * @brief Global value to store the default max reception rate in this execution.
      *
      * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c max_reception_rate default.
+     * Every new TopicQoS object will use this value as \c max_rx_rate default.
      */
     DDSPIPE_CORE_DllAPI
-    static std::atomic<float> default_max_reception_rate;
+    static std::atomic<float> default_max_rx_rate;
 
     /////////////////////////
     // VARIABLES
@@ -155,7 +155,7 @@ TopicQoS
     utils::Fuzzy<unsigned int> downsampling;
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
-    utils::Fuzzy<float> max_reception_rate;
+    utils::Fuzzy<float> max_rx_rate;
 
     static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
 };

--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -111,13 +111,13 @@ TopicQoS
     static std::atomic<HistoryDepthType> default_history_depth;
 
     /**
-     * @brief Global value to store the default downsampling factor in this execution.
+     * @brief Global value to store the default max transmission rate in this execution.
      *
      * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c downsampling default.
+     * Every new TopicQoS object will use this value as \c max_tx_rate default.
      */
     DDSPIPE_CORE_DllAPI
-    static std::atomic<unsigned int> default_downsampling;
+    static std::atomic<float> default_max_tx_rate;
 
     /**
      * @brief Global value to store the default max reception rate in this execution.
@@ -129,13 +129,13 @@ TopicQoS
     static std::atomic<float> default_max_rx_rate;
 
     /**
-     * @brief Global value to store the default max transmission rate in this execution.
+     * @brief Global value to store the default downsampling factor in this execution.
      *
      * This value can change along the execution.
-     * Every new TopicQoS object will use this value as \c max_tx_rate default.
+     * Every new TopicQoS object will use this value as \c downsampling default.
      */
     DDSPIPE_CORE_DllAPI
-    static std::atomic<float> default_max_tx_rate;
+    static std::atomic<unsigned int> default_downsampling;
 
     /////////////////////////
     // VARIABLES
@@ -164,14 +164,14 @@ TopicQoS
     //! Whether the topic has key or not
     utils::Fuzzy<bool> keyed;
 
-    //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
-    utils::Fuzzy<unsigned int> downsampling;
+    //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
+    utils::Fuzzy<float> max_tx_rate;
 
     //! Discard msgs if less than 1/rate seconds elapsed since the last sample was processed [Hz]. Default: 0 (no limit)
     utils::Fuzzy<float> max_rx_rate;
 
-    //! Discard msgs if less than 1/rate seconds elapsed since the last sample was transmitted [Hz]. Default: 0 (no limit)
-    utils::Fuzzy<float> max_tx_rate;
+    //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
+    utils::Fuzzy<unsigned int> downsampling;
 
 
     //! Durability kind (Default = VOLATILE)
@@ -180,26 +180,26 @@ TopicQoS
     //! Reliability kind (Default = BEST_EFFORT)
     static constexpr ReliabilityKind RELIABILITY_QOS_DEFAULT = ReliabilityKind::BEST_EFFORT;
 
-    //! Ownership kind of the topic
+    //! Ownership kind (Default = SHARED_OWNERSHIP)
     static constexpr OwnershipQosPolicyKind OWNERSHIP_QOS_DEFAULT = OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
 
-    //! Whether the topics uses partitions
+    //! Whether the topic uses partitions (Default = False)
     static constexpr bool USE_PARTITIONS_DEFAULT = false;
 
-    //! TODO
+    //! History depth (Default = 5000)
     static constexpr HistoryDepthType HISTORY_DEPTH_DEFAULT = 5000;
 
-    //! TODO
+    //! Whether the topic has a key (Default = False)
     static constexpr bool KEYED_DEFAULT = false;
 
-    //! TODO
-    static constexpr unsigned int DOWNSAMPLING_DEFAULT = 1;
+    //! Max Tx Rate (Default = 0)
+    static constexpr float MAX_TX_RATE_DEFAULT = 0;
 
-    //! TODO
+    //! Max Rx Rate (Default = 0)
     static constexpr float MAX_RX_RATE_DEFAULT = 0;
 
-    //! TODO
-    static constexpr float MAX_TX_RATE_DEFAULT = 0;
+    //! Downsampling (Default = 1)
+    static constexpr unsigned int DOWNSAMPLING_DEFAULT = 1;
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -118,12 +118,11 @@ struct Topic : public ITopic, public IConfiguration
     ParticipantId m_topic_discoverer {DEFAULT_PARTICIPANT_ID};
 
     /**
-     * @brief Topic QoS
+     * @brief The Topic QoS for the Topic.
      *
-     * DOES THIS MAKE SENSE?
-     *
-     * @todo this makes few sense here as the qos does not depend on the QoS itself but in the discovery of it.
-     * This Topic class is a proxy, not an actual Topic Entity of DDS, so it should not have QoS.
+     * If the Topic is built-in, they take their default value.
+     * If the Topic isn't built-in, they take their value by discovery.
+     * If the Topic has manually configured Topic QoSs, the Topic QoSs that are manually configured get overriden.
      */
     types::TopicQoS topic_qos{};
 };

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -131,7 +131,7 @@ struct Topic : public ITopic, public IConfiguration
      *
      * If the Topic is built-in, they take their default value.
      * If the Topic isn't built-in, they take their value by discovery.
-     * If the Topic has manually configured Topic QoSs, the Topic QoSs that are manually configured get overriden.
+     * If the Topic has manually configured Topic QoS, the Topic QoS that are manually configured get overriden.
      */
     types::TopicQoS topic_qos{};
 };

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <cpp_utils/Formatter.hpp>
+#include <cpp_utils/memory/Heritable.hpp>
 
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/interface/ITopic.hpp>
@@ -62,6 +63,10 @@ struct Topic : public ITopic, public IConfiguration
     virtual bool operator <(
             const ITopic& other) const noexcept override;
 
+    DDSPIPE_CORE_DllAPI
+    virtual Topic& operator = (
+            const Topic& other) noexcept;
+
     /////////////////////////
     // METHODS
     /////////////////////////
@@ -80,6 +85,10 @@ struct Topic : public ITopic, public IConfiguration
     DDSPIPE_CORE_DllAPI
     virtual bool is_valid(
             utils::Formatter& error_msg) const noexcept override;
+
+    //! Make a copy of the Topic
+    DDSPIPE_CORE_DllAPI
+    virtual utils::Heritable<ITopic> copy() const noexcept override;
 
     /////////////////////////
     // METHODS TO OVERRIDE

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -19,11 +19,12 @@
 
 #include <cpp_utils/Formatter.hpp>
 
-#include <ddspipe_core/library/library_dll.h>
 #include <ddspipe_core/configuration/IConfiguration.hpp>
+#include <ddspipe_core/interface/ITopic.hpp>
+#include <ddspipe_core/library/library_dll.h>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/TopicInternalTypeDiscriminator.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
-#include <ddspipe_core/interface/ITopic.hpp>
 
 namespace eprosima {
 namespace ddspipe {
@@ -115,6 +116,16 @@ struct Topic : public ITopic, public IConfiguration
      * @brief The id of the participant who discovered the topic.
      */
     ParticipantId m_topic_discoverer {DEFAULT_PARTICIPANT_ID};
+
+    /**
+     * @brief Topic QoS
+     *
+     * DOES THIS MAKE SENSE?
+     *
+     * @todo this makes few sense here as the qos does not depend on the QoS itself but in the discovery of it.
+     * This Topic class is a proxy, not an actual Topic Entity of DDS, so it should not have QoS.
+     */
+    types::TopicQoS topic_qos{};
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -64,7 +64,7 @@ struct Topic : public ITopic, public IConfiguration
             const ITopic& other) const noexcept override;
 
     DDSPIPE_CORE_DllAPI
-    virtual Topic& operator = (
+    virtual Topic& operator =(
             const Topic& other) noexcept;
 
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
@@ -46,8 +46,9 @@ struct DdsTopic : public DistributedTopic
     // OPERATORS
     /////////////////////////
 
-    virtual DdsTopic& operator = (
-        const DdsTopic& other) noexcept;
+    DDSPIPE_CORE_DllAPI
+    virtual DdsTopic& operator =(
+            const DdsTopic& other) noexcept;
 
     /////////////////////////
     // METHODS

--- a/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <string>
 
+#include <cpp_utils/memory/Heritable.hpp>
 #include <cpp_utils/types/Fuzzy.hpp>
 
 #include <ddspipe_core/library/library_dll.h>
@@ -42,6 +43,13 @@ struct DdsTopic : public DistributedTopic
     DdsTopic();
 
     /////////////////////////
+    // OPERATORS
+    /////////////////////////
+
+    virtual DdsTopic& operator = (
+        const DdsTopic& other) noexcept;
+
+    /////////////////////////
     // METHODS
     /////////////////////////
 
@@ -54,6 +62,10 @@ struct DdsTopic : public DistributedTopic
 
     DDSPIPE_CORE_DllAPI
     virtual std::string serialize() const noexcept override;
+
+    //! Make a copy of the Topic
+    DDSPIPE_CORE_DllAPI
+    virtual utils::Heritable<ITopic> copy() const noexcept override;
 
     /////////////////////////
     // STATIC METHODS

--- a/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
@@ -20,7 +20,6 @@
 #include <cpp_utils/types/Fuzzy.hpp>
 
 #include <ddspipe_core/library/library_dll.h>
-#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/dds/DistributedTopic.hpp>
 
 namespace eprosima {
@@ -73,14 +72,6 @@ struct DdsTopic : public DistributedTopic
 
     //! Topic Type name
     std::string type_name{};
-
-    /**
-     * @brief Topic QoS
-     *
-     * @todo this makes few sense here as the qos does not depend on the QoS itself but in the discovery of it.
-     * This Topic class is a proxy, not an actual Topic Entity of DDS, so it should not have QoS.
-     */
-    types::TopicQoS topic_qos{};
 };
 
 } /* namespace types */

--- a/ddspipe_core/include/ddspipe_core/types/topic/filter/ManualTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/filter/ManualTopic.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License\.
+
+#pragma once
+
+#include <ddspipe_core/library/library_dll.h>
+#include <ddspipe_core/types/participant/ParticipantId.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace core {
+namespace types {
+
+using ManualTopic = std::pair<utils::Heritable<WildcardDdsFilterTopic>, std::set<ParticipantId>>;
+
+} /* namespace types */
+} /* namespace core */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
@@ -20,6 +20,8 @@
 #include <cpp_utils/types/Fuzzy.hpp>
 
 #include <ddspipe_core/library/library_dll.h>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
+#include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/types/topic/filter/IFilterTopic.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 
@@ -74,6 +76,10 @@ struct WildcardDdsFilterTopic : public IFilterTopic
 
     //! Type name filter. If not set matches with all.
     utils::Fuzzy<std::string> type_name;
+
+    utils::Fuzzy<types::TopicQoS> topic_qos;
+
+    utils::Fuzzy<std::set<types::ParticipantId>> participants;
 
 protected:
 

--- a/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
@@ -80,9 +80,6 @@ struct WildcardDdsFilterTopic : public IFilterTopic
     //! The subset of manually configured Topic QoS.
     utils::Fuzzy<types::TopicQoS> topic_qos;
 
-    //! The participants to which the manually configured Topic QoS apply.
-    utils::Fuzzy<std::set<types::ParticipantId>> participants;
-
 protected:
 
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
@@ -77,10 +77,10 @@ struct WildcardDdsFilterTopic : public IFilterTopic
     //! Type name filter. If not set matches with all.
     utils::Fuzzy<std::string> type_name;
 
-    //! The subset of fixed Topic QoS.
+    //! The subset of manually configured Topic QoS.
     utils::Fuzzy<types::TopicQoS> topic_qos;
 
-    //! The participants to which the fixed Topic QoS apply.
+    //! The participants to which the manually configured Topic QoS apply.
     utils::Fuzzy<std::set<types::ParticipantId>> participants;
 
 protected:

--- a/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp
@@ -71,14 +71,16 @@ struct WildcardDdsFilterTopic : public IFilterTopic
     // VARIABLES
     /////////////////////////
 
-    //! Topic name filter
+    //! Topic name filter.
     utils::Fuzzy<std::string> topic_name;
 
     //! Type name filter. If not set matches with all.
     utils::Fuzzy<std::string> type_name;
 
+    //! The subset of fixed Topic QoS.
     utils::Fuzzy<types::TopicQoS> topic_qos;
 
+    //! The participants to which the fixed Topic QoS apply.
     utils::Fuzzy<std::set<types::ParticipantId>> participants;
 
 protected:

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -140,7 +140,7 @@ void DdsBridge::create_all_tracks_()
     for (const auto& id : writers_to_create)
     {
         std::shared_ptr<IParticipant> participant = participants_->get_participant(id);
-        const auto& topic = create_topic_for_participant_nts_(participant);
+        const auto topic = create_topic_for_participant_nts_(participant);
         writers[id] = participant->create_writer(*topic);
     }
 
@@ -157,7 +157,7 @@ void DdsBridge::create_writer(
 
     // Create the writer.
     std::shared_ptr<IParticipant> participant = participants_->get_participant(participant_id);
-    const auto& topic = create_topic_for_participant_nts_(participant);
+    const auto topic = create_topic_for_participant_nts_(participant);
     auto writer = participant->create_writer(*topic);
 
     // Add the writer to the tracks it has routes for.
@@ -263,7 +263,7 @@ void DdsBridge::add_writers_to_tracks_nts_(
         {
             // The track doesn't exist. Create it.
             std::shared_ptr<IParticipant> participant = participants_->get_participant(id);
-            const auto& topic = create_topic_for_participant_nts_(participant);
+            const auto topic = create_topic_for_participant_nts_(participant);
             auto reader = participant->create_reader(*topic);
 
             tracks_[id] = std::make_unique<Track>(

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -297,12 +297,12 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
 
         if (participant_ids.empty() || participant_ids.count(participant->id()))
         {
-            topic->topic_qos.set_qos(manual_topic->topic_qos);
+            topic->topic_qos.set_qos(manual_topic->topic_qos, utils::FuzzyLevelValues::fuzzy_level_hard);
         }
     }
 
     // 2. Participant Topic QoSs.
-    topic->topic_qos.set_qos(participant->topic_qos());
+    topic->topic_qos.set_qos(participant->topic_qos(), utils::FuzzyLevelValues::fuzzy_level_hard);
 
     return topic;
 }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -281,7 +281,8 @@ void DdsBridge::add_writers_to_tracks_nts_(
     }
 }
 
-DistributedTopic DdsBridge::create_topic_for_participant_(const std::shared_ptr<IParticipant>& participant)
+DistributedTopic DdsBridge::create_topic_for_participant_(
+        const std::shared_ptr<IParticipant>& participant)
 {
     DistributedTopic topic = *topic_;
 

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -284,8 +284,12 @@ void DdsBridge::add_writers_to_tracks_nts_(
 DistributedTopic DdsBridge::create_topic_for_participant_(
         const std::shared_ptr<IParticipant>& participant)
 {
+    // Make a copy of the original topic to be able to modify the Topic QoS for each participant.
     DistributedTopic topic = *topic_;
 
+    // Impose the Topic QoSs that have been pre-configured on the topic.
+
+    // 1. Manually Configured Topic QoSs.
     for (const auto& manual_topic : manual_topics_)
     {
         const auto& participant_ids = manual_topic->participants.get_value();
@@ -296,6 +300,7 @@ DistributedTopic DdsBridge::create_topic_for_participant_(
         }
     }
 
+    // 2. Participant Topic QoSs.
     topic.topic_qos.set_qos(participant->topic_qos());
 
     return topic;

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -282,12 +282,11 @@ void DdsBridge::add_writers_to_tracks_nts_(
     }
 }
 
-utils::Heritable<Topic> DdsBridge::create_topic_for_participant_nts_(
+utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
         const std::shared_ptr<IParticipant>& participant) noexcept
 {
     // Make a copy of the Topic to customize it according to the Participant's configured QoS.
-    // The Topic must be casted to a DdsTopic so the type_name tag doesn't get lost.
-    utils::Heritable<Topic> topic = topic_->copy();
+    utils::Heritable<DistributedTopic> topic = topic_->copy();
 
     // Impose the Topic QoSs that have been pre-configured on the topic.
 

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -45,6 +45,13 @@ bool DdsPipeConfiguration::is_valid(
            topic_routes.is_valid(error_msg, participant_ids);
 }
 
+void DdsPipeConfiguration::reload(
+        const DdsPipeConfiguration& new_configuration)
+{
+    this->allowlist = new_configuration.allowlist;
+    this->blocklist = new_configuration.blocklist;
+}
+
 RoutesConfiguration DdsPipeConfiguration::get_routes_config(
         const utils::Heritable<types::DistributedTopic>& topic) const noexcept
 {

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -60,15 +60,15 @@ RoutesConfiguration DdsPipeConfiguration::get_routes_config(
     }
 }
 
-std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> DdsPipeConfiguration::get_manual_topics(
+std::vector<core::types::ManualTopic> DdsPipeConfiguration::get_manual_topics(
         const core::ITopic& topic) const noexcept
 {
     // Filter the manual topics to only return the ones that match with the given topic.
-    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> matching_manual_topics{};
+    std::vector<core::types::ManualTopic> matching_manual_topics{};
 
     for (const auto& manual_topic : manual_topics)
     {
-        if (manual_topic->matches(topic))
+        if (manual_topic.first->matches(topic))
         {
             matching_manual_topics.push_back(manual_topic);
         }

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -67,6 +67,22 @@ RoutesConfiguration DdsPipeConfiguration::get_routes_config(
     }
 }
 
+std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> DdsPipeConfiguration::get_manual_topics(
+        const core::ITopic& topic) const noexcept
+{
+    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics{};
+
+    for (const auto& manual_topic : manual_topics)
+    {
+        if (manual_topic->matches(topic))
+        {
+            manual_topics.push_back(manual_topic);
+        }
+    }
+
+    return manual_topics;
+}
+
 } /* namespace core */
 } /* namespace ddspipe */
 } /* namespace eprosima */

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -45,13 +45,6 @@ bool DdsPipeConfiguration::is_valid(
            topic_routes.is_valid(error_msg, participant_ids);
 }
 
-void DdsPipeConfiguration::reload(
-        const DdsPipeConfiguration& new_configuration)
-{
-    this->allowlist = new_configuration.allowlist;
-    this->blocklist = new_configuration.blocklist;
-}
-
 RoutesConfiguration DdsPipeConfiguration::get_routes_config(
         const utils::Heritable<types::DistributedTopic>& topic) const noexcept
 {
@@ -70,17 +63,18 @@ RoutesConfiguration DdsPipeConfiguration::get_routes_config(
 std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> DdsPipeConfiguration::get_manual_topics(
         const core::ITopic& topic) const noexcept
 {
-    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> manual_topics{};
+    // Filter the manual topics to only return the ones that match with the given topic.
+    std::vector<utils::Heritable<core::types::WildcardDdsFilterTopic>> matching_manual_topics{};
 
     for (const auto& manual_topic : manual_topics)
     {
         if (manual_topic->matches(topic))
         {
-            manual_topics.push_back(manual_topic);
+            matching_manual_topics.push_back(manual_topic);
         }
     }
 
-    return manual_topics;
+    return matching_manual_topics;
 }
 
 } /* namespace core */

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -52,7 +52,7 @@ DdsPipe::DdsPipe(
                       "Configuration for DDS Pipe is invalid: " << error_msg);
     }
 
-    // Init topic allowed
+    // Initialize the allowed topics
     init_allowed_topics_();
 
     // Add callback to be called by the discovery database when an Endpoint is discovered

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -118,7 +118,7 @@ utils::ReturnCode DdsPipe::reload_configuration(
 {
     // Check that the configuration is correct
     utils::Formatter error_msg;
-    if (!new_configuration.is_valid(error_msg))
+    if (!new_configuration.is_valid(error_msg, participants_database_->get_participants_repeater_map()))
     {
         throw utils::ConfigurationException(
                   utils::Formatter() <<

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -122,7 +122,7 @@ utils::ReturnCode DdsPipe::reload_configuration(
     {
         throw utils::ConfigurationException(
                   utils::Formatter() <<
-                      "Configuration for Reload DDS Router is invalid: " << error_msg);
+                      "Configuration for Reload DDS Pipe is invalid: " << error_msg);
     }
 
     auto allowed_topics = std::make_shared<ddspipe::core::AllowedTopicList>(

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -196,7 +196,8 @@ void DdsPipe::init_allowed_topics_()
     logInfo(DDSROUTER, "DDS Router configured with allowed topics: " << *allowed_topics_);
 }
 
-utils::ReturnCode DdsPipe::reload_allowed_topics_(const std::shared_ptr<AllowedTopicList>& allowed_topics)
+utils::ReturnCode DdsPipe::reload_allowed_topics_(
+        const std::shared_ptr<AllowedTopicList>& allowed_topics)
 {
     std::lock_guard<std::mutex> lock(mutex_);
 

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -235,7 +235,14 @@ void DdsPipe::load_manual_topics_into_participants_() noexcept
 {
     for (const auto& manual_topic : configuration_.manual_topics)
     {
-        for (const auto& participant_id : manual_topic->participants.get_value())
+        std::set<types::ParticipantId> participants_ids = manual_topic->participants.get_value();
+
+        if (participants_ids.empty())
+        {
+            participants_ids = participants_database_->get_participants_ids();
+        }
+
+        for (const auto& participant_id : participants_ids)
         {
             // The participant exists since the configuration is valid.
             participants_database_->get_participant(participant_id)->manual_topics.push_back(manual_topic);

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -409,7 +409,7 @@ void DdsPipe::discovered_topic_nts_(
         return;
     }
 
-    // Add topic to current_topics as non activated
+    // Add topic to current_topics as not activated
     current_topics_.emplace(topic, false);
 
     // If Pipe is enabled and topic allowed, activate it

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -232,7 +232,7 @@ utils::ReturnCode DdsPipe::disable() noexcept
 
 void DdsPipe::load_manual_topics_into_participants_() noexcept
 {
-    for (const auto& manual_topic : ddspipe_config_.manual_topics)
+    for (const auto& manual_topic : configuration_.manual_topics)
     {
         for (const auto& participant_id : manual_topic->participants.get_value())
         {

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -29,21 +29,21 @@ namespace core {
 using namespace eprosima::ddspipe::core::types;
 
 DdsPipe::DdsPipe(
+        const DdsPipeConfiguration& configuration,
         const std::shared_ptr<AllowedTopicList>& allowed_topics,
         const std::shared_ptr<DiscoveryDatabase>& discovery_database,
         const std::shared_ptr<PayloadPool>& payload_pool,
         const std::shared_ptr<ParticipantsDatabase>& participants_database,
         const std::shared_ptr<utils::SlotThreadPool>& thread_pool,
         const std::set<utils::Heritable<DistributedTopic>>& builtin_topics, /* = {} */
-        bool start_enable, /* = false */
-        const DdsPipeConfiguration& configuration /* = {} */)
-    : allowed_topics_(allowed_topics)
+        bool start_enable /* = false */)
+    : configuration_(configuration)
+    , allowed_topics_(allowed_topics)
     , discovery_database_(discovery_database)
     , payload_pool_(payload_pool)
     , participants_database_(participants_database)
     , thread_pool_(thread_pool)
     , enabled_(false)
-    , configuration_(configuration)
 {
     logDebug(DDSPIPE, "Creating DDS Pipe.");
 
@@ -110,7 +110,8 @@ DdsPipe::~DdsPipe()
     // Destroy RpcBridges, so Writers and Readers are destroyed before the Databases
     rpc_bridges_.clear();
 
-    // There is no need to destroy shared ptrs as they will delete itslefs with 0 references
+    // There is no need to destroy shared pointers.
+    // They self-destruct when they have 0 references.
 
     logDebug(DDSPIPE, "DDS Pipe destroyed.");
 }

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -56,6 +56,8 @@ DdsPipe::DdsPipe(
                       "Configuration for DDS Pipe is invalid: " << error_msg);
     }
 
+    load_manual_topics_into_participants_();
+
     // Add callback to be called by the discovery database when an Endpoint is discovered
     discovery_database_->add_endpoint_discovered_callback(std::bind(&DdsPipe::discovered_endpoint_, this,
             std::placeholders::_1));
@@ -225,6 +227,18 @@ utils::ReturnCode DdsPipe::disable() noexcept
     {
         logInfo(DDSPIPE, "Trying to disable a disabled DDS Pipe.");
         return utils::ReturnCode::RETCODE_PRECONDITION_NOT_MET;
+    }
+}
+
+void DdsPipe::load_manual_topics_into_participants_() noexcept
+{
+    for (const auto& manual_topic : ddspipe_config_.manual_topics)
+    {
+        for (const auto& participant_id : manual_topic->participants.get_value())
+        {
+            // The participant exists since the configuration is valid.
+            participants_database_->get_participant(participant_id)->manual_topics.push_back(manual_topic);
+        }
     }
 }
 

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -32,31 +32,31 @@ std::atomic<float> TopicQoS::default_max_tx_rate{MAX_TX_RATE_DEFAULT};
 
 TopicQoS::TopicQoS()
 {
-    // TODO
+    // Set the default durability
     durability_qos.set_value(DURABILITY_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // TODO
+    // Set the default reliabitliy
     reliability_qos.set_value(RELIABILITY_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // TODO
+    // Set the default ownership
     ownership_qos.set_value(OWNERSHIP_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // TODO
+    // Set whether by default the Topic should use partitions
     use_partitions.set_value(USE_PARTITIONS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // TODO
+    // Set whether by default the Topic has a key
     keyed.set_value(KEYED_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // TODO
+    // Set the default history depth
     history_depth.set_value(default_history_depth, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // Set downsampling by default
+    // Set the default downsampling
     downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // Set max reception rate by default
+    // Set the default max reception rate
     max_rx_rate.set_value(default_max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // Set max reception rate by default
+    // Set the default max transmision rate
     max_tx_rate.set_value(default_max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -25,44 +25,12 @@ namespace ddspipe {
 namespace core {
 namespace types {
 
-std::atomic<DurabilityKind> TopicQoS::default_durability_qos{DEFAULT_DURABILITY_QOS};
-std::atomic<ReliabilityKind> TopicQoS::default_reliability_qos{DEFAULT_RELIABILITY_QOS};
-std::atomic<OwnershipQosPolicyKind> TopicQoS::default_ownership_qos{DEFAULT_OWNERSHIP_QOS};
-std::atomic<bool> TopicQoS::default_use_partitions{DEFAULT_USE_PARTITIONS};
-std::atomic<bool> TopicQoS::default_keyed{DEFAULT_KEYED};
-std::atomic<HistoryDepthType> TopicQoS::default_history_depth{DEFAULT_HISTORY_DEPTH};
-std::atomic<float> TopicQoS::default_max_tx_rate{DEFAULT_MAX_TX_RATE};
-std::atomic<float> TopicQoS::default_max_rx_rate{DEFAULT_MAX_RX_RATE};
-std::atomic<unsigned int> TopicQoS::default_downsampling{DEFAULT_DOWNSAMPLING};
+std::atomic<TopicQoS> default_topic_qos{};
 
 TopicQoS::TopicQoS()
 {
-    // Set the default durability
-    durability_qos.set_value(default_durability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set the default reliabitliy
-    reliability_qos.set_value(default_reliability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set the default ownership
-    ownership_qos.set_value(default_ownership_qos, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set whether by default the Topic should use partitions
-    use_partitions.set_value(default_use_partitions, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set whether by default the Topic has a key
-    keyed.set_value(default_keyed, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set the default history depth
-    history_depth.set_value(default_history_depth, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set the default max transmision rate
-    max_tx_rate.set_value(default_max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set the default max reception rate
-    max_rx_rate.set_value(default_max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
-
-    // Set the default downsampling
-    downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
+    // Set the default Topic QoS.
+    set_qos(default_topic_qos, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool TopicQoS::operator ==(
@@ -101,51 +69,52 @@ bool TopicQoS::has_partitions() const noexcept
 }
 
 void TopicQoS::set_qos(
-        const TopicQoS& qos) noexcept
+        const TopicQoS& qos,
+        const utils::FuzzyLevelValues& fuzzy_level /*= utils::FuzzyLevelValues::fuzzy_level_fuzzy*/) noexcept
 {
     if (!durability_qos.is_set() && qos.durability_qos.is_set())
     {
-        durability_qos.set_value(qos.durability_qos.get_value());
+        durability_qos.set_value(qos.durability_qos.get_value(), fuzzy_level);
     }
 
     if (!reliability_qos.is_set() && qos.reliability_qos.is_set())
     {
-        reliability_qos.set_value(qos.reliability_qos.get_value());
+        reliability_qos.set_value(qos.reliability_qos.get_value(), fuzzy_level);
     }
 
     if (!ownership_qos.is_set() && qos.ownership_qos.is_set())
     {
-        ownership_qos.set_value(qos.ownership_qos.get_value());
+        ownership_qos.set_value(qos.ownership_qos.get_value(), fuzzy_level);
     }
 
     if (!use_partitions.is_set() && qos.use_partitions.is_set())
     {
-        use_partitions.set_value(qos.use_partitions.get_value());
+        use_partitions.set_value(qos.use_partitions.get_value(), fuzzy_level);
     }
 
     if (!history_depth.is_set() && qos.history_depth.is_set())
     {
-        history_depth.set_value(qos.history_depth.get_value());
+        history_depth.set_value(qos.history_depth.get_value(), fuzzy_level);
     }
 
     if (!keyed.is_set() && qos.keyed.is_set())
     {
-        keyed.set_value(qos.keyed.get_value());
+        keyed.set_value(qos.keyed.get_value(), fuzzy_level);
     }
 
     if (!max_tx_rate.is_set() && qos.max_tx_rate.is_set())
     {
-        max_tx_rate.set_value(qos.max_tx_rate.get_value());
+        max_tx_rate.set_value(qos.max_tx_rate.get_value(), fuzzy_level);
     }
 
     if (!max_rx_rate.is_set() && qos.max_rx_rate.is_set())
     {
-        max_rx_rate.set_value(qos.max_rx_rate.get_value());
+        max_rx_rate.set_value(qos.max_rx_rate.get_value(), fuzzy_level);
     }
 
     if (!downsampling.is_set() && qos.downsampling.is_set())
     {
-        downsampling.set_value(qos.downsampling.get_value());
+        downsampling.set_value(qos.downsampling.get_value(), fuzzy_level);
     }
 }
 

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -25,27 +25,32 @@ namespace ddspipe {
 namespace core {
 namespace types {
 
-std::atomic<HistoryDepthType> TopicQoS::default_history_depth{HISTORY_DEPTH_DEFAULT};
-std::atomic<float> TopicQoS::default_max_tx_rate{MAX_TX_RATE_DEFAULT};
-std::atomic<float> TopicQoS::default_max_rx_rate{MAX_RX_RATE_DEFAULT};
-std::atomic<unsigned int> TopicQoS::default_downsampling{DOWNSAMPLING_DEFAULT};
+std::atomic<DurabilityKind> TopicQoS::default_durability_qos{DEFAULT_DURABILITY_QOS};
+std::atomic<ReliabilityKind> TopicQoS::default_reliability_qos{DEFAULT_RELIABILITY_QOS};
+std::atomic<OwnershipQosPolicyKind> TopicQoS::default_ownership_qos{DEFAULT_OWNERSHIP_QOS};
+std::atomic<bool> TopicQoS::default_use_partitions{DEFAULT_USE_PARTITIONS};
+std::atomic<bool> TopicQoS::default_keyed{DEFAULT_KEYED};
+std::atomic<HistoryDepthType> TopicQoS::default_history_depth{DEFAULT_HISTORY_DEPTH};
+std::atomic<float> TopicQoS::default_max_tx_rate{DEFAULT_MAX_TX_RATE};
+std::atomic<float> TopicQoS::default_max_rx_rate{DEFAULT_MAX_RX_RATE};
+std::atomic<unsigned int> TopicQoS::default_downsampling{DEFAULT_DOWNSAMPLING};
 
 TopicQoS::TopicQoS()
 {
     // Set the default durability
-    durability_qos.set_value(DURABILITY_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+    durability_qos.set_value(default_durability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set the default reliabitliy
-    reliability_qos.set_value(RELIABILITY_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+    reliability_qos.set_value(default_reliability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set the default ownership
-    ownership_qos.set_value(OWNERSHIP_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+    ownership_qos.set_value(default_ownership_qos, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set whether by default the Topic should use partitions
-    use_partitions.set_value(USE_PARTITIONS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+    use_partitions.set_value(default_use_partitions, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set whether by default the Topic has a key
-    keyed.set_value(KEYED_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+    keyed.set_value(default_keyed, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set the default history depth
     history_depth.set_value(default_history_depth, utils::FuzzyLevelValues::fuzzy_level_default);

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -27,7 +27,7 @@ namespace types {
 
 std::atomic<HistoryDepthType> TopicQoS::default_history_depth{HISTORY_DEPTH_DEFAULT};
 std::atomic<unsigned int> TopicQoS::default_downsampling{1};
-std::atomic<float> TopicQoS::default_max_reception_rate{0};
+std::atomic<float> TopicQoS::default_max_rx_rate{0};
 
 TopicQoS::TopicQoS()
 {
@@ -38,7 +38,7 @@ TopicQoS::TopicQoS()
     downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set max reception rate by default
-    max_reception_rate.set_value(default_max_reception_rate, utils::FuzzyLevelValues::fuzzy_level_default);
+    max_rx_rate.set_value(default_max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool TopicQoS::operator ==(
@@ -52,7 +52,7 @@ bool TopicQoS::operator ==(
         this->use_partitions == other.use_partitions &&
         this->keyed == other.keyed &&
         this->downsampling == other.downsampling &&
-        this->max_reception_rate == other.max_reception_rate;
+        this->max_rx_rate == other.max_rx_rate;
 }
 
 bool TopicQoS::is_reliable() const noexcept
@@ -161,7 +161,7 @@ std::ostream& operator <<(
         (qos.keyed ? ";keyed" : "") <<
         ";depth(" << qos.history_depth << ")" <<
         ";downsampling(" << qos.downsampling << ")" <<
-        ";max_reception_rate(" << qos.max_reception_rate << ")" <<
+        ";max_rx_rate(" << qos.max_rx_rate << ")" <<
         "}";
 
     return os;

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -95,41 +95,51 @@ bool TopicQoS::has_partitions() const noexcept
     return use_partitions;
 }
 
-void TopicQoS::set_qos(const TopicQoS& qos) noexcept
+void TopicQoS::set_qos(
+        const TopicQoS& qos) noexcept
 {
-    if (!durability_qos.is_set() && qos.durability_qos.is_set()) {
+    if (!durability_qos.is_set() && qos.durability_qos.is_set())
+    {
         durability_qos.set_value(qos.durability_qos.get_value());
     }
 
-    if (!reliability_qos.is_set() && qos.reliability_qos.is_set()) {
+    if (!reliability_qos.is_set() && qos.reliability_qos.is_set())
+    {
         reliability_qos.set_value(qos.reliability_qos.get_value());
     }
 
-    if (!ownership_qos.is_set() && qos.ownership_qos.is_set()) {
+    if (!ownership_qos.is_set() && qos.ownership_qos.is_set())
+    {
         ownership_qos.set_value(qos.ownership_qos.get_value());
     }
 
-    if (!use_partitions.is_set() && qos.use_partitions.is_set()) {
+    if (!use_partitions.is_set() && qos.use_partitions.is_set())
+    {
         use_partitions.set_value(qos.use_partitions.get_value());
     }
 
-    if (!history_depth.is_set() && qos.history_depth.is_set()) {
+    if (!history_depth.is_set() && qos.history_depth.is_set())
+    {
         history_depth.set_value(qos.history_depth.get_value());
     }
 
-    if (!keyed.is_set() && qos.keyed.is_set()) {
+    if (!keyed.is_set() && qos.keyed.is_set())
+    {
         keyed.set_value(qos.keyed.get_value());
     }
 
-    if (!max_tx_rate.is_set() && qos.max_tx_rate.is_set()) {
+    if (!max_tx_rate.is_set() && qos.max_tx_rate.is_set())
+    {
         max_tx_rate.set_value(qos.max_tx_rate.get_value());
     }
 
-    if (!max_rx_rate.is_set() && qos.max_rx_rate.is_set()) {
+    if (!max_rx_rate.is_set() && qos.max_rx_rate.is_set())
+    {
         max_rx_rate.set_value(qos.max_rx_rate.get_value());
     }
 
-    if (!downsampling.is_set() && qos.downsampling.is_set()) {
+    if (!downsampling.is_set() && qos.downsampling.is_set())
+    {
         downsampling.set_value(qos.downsampling.get_value());
     }
 }

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -26,13 +26,28 @@ namespace core {
 namespace types {
 
 std::atomic<HistoryDepthType> TopicQoS::default_history_depth{HISTORY_DEPTH_DEFAULT};
-std::atomic<unsigned int> TopicQoS::default_downsampling{1};
-std::atomic<float> TopicQoS::default_max_rx_rate{0};
+std::atomic<unsigned int> TopicQoS::default_downsampling{DOWNSAMPLING_DEFAULT};
+std::atomic<float> TopicQoS::default_max_rx_rate{MAX_RX_RATE_DEFAULT};
 
 TopicQoS::TopicQoS()
 {
-    // Set history by default
-    history_depth = default_history_depth;
+    // TODO
+    durability_qos.set_value(DURABILITY_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+
+    // TODO
+    reliability_qos.set_value(RELIABILITY_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+
+    // TODO
+    ownership_qos.set_value(OWNERSHIP_QOS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+
+    // TODO
+    use_partitions.set_value(USE_PARTITIONS_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+
+    // TODO
+    keyed.set_value(KEYED_DEFAULT, utils::FuzzyLevelValues::fuzzy_level_default);
+
+    // TODO
+    history_depth.set_value(default_history_depth, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set downsampling by default
     downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
@@ -45,11 +60,11 @@ bool TopicQoS::operator ==(
         const TopicQoS& other) const noexcept
 {
     return
-        this->reliability_qos == other.reliability_qos &&
         this->durability_qos == other.durability_qos &&
-        this->history_depth == other.history_depth &&
+        this->reliability_qos == other.reliability_qos &&
         this->ownership_qos == other.ownership_qos &&
         this->use_partitions == other.use_partitions &&
+        this->history_depth == other.history_depth &&
         this->keyed == other.keyed &&
         this->downsampling == other.downsampling &&
         this->max_rx_rate == other.max_rx_rate;
@@ -77,6 +92,30 @@ bool TopicQoS::has_partitions() const noexcept
 
 void TopicQoS::set_qos(const TopicQoS& qos) noexcept
 {
+    if (qos.durability_qos.is_set()) {
+        durability_qos.set_value(qos.durability_qos.get_value());
+    }
+
+    if (qos.reliability_qos.is_set()) {
+        reliability_qos.set_value(qos.reliability_qos.get_value());
+    }
+
+    if (qos.ownership_qos.is_set()) {
+        ownership_qos.set_value(qos.ownership_qos.get_value());
+    }
+
+    if (qos.use_partitions.is_set()) {
+        use_partitions.set_value(qos.use_partitions.get_value());
+    }
+
+    if (qos.history_depth.is_set()) {
+        history_depth.set_value(qos.history_depth.get_value());
+    }
+
+    if (qos.keyed.is_set()) {
+        keyed.set_value(qos.keyed.get_value());
+    }
+
     if (qos.downsampling.is_set()) {
         downsampling.set_value(qos.downsampling.get_value());
     }

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -75,6 +75,17 @@ bool TopicQoS::has_partitions() const noexcept
     return use_partitions;
 }
 
+void TopicQoS::set_qos(const TopicQoS& qos) noexcept
+{
+    if (qos.downsampling.is_set()) {
+        downsampling.set_value(qos.downsampling.get_value());
+    }
+
+    if (qos.max_rx_rate.is_set()) {
+        max_rx_rate.set_value(qos.max_rx_rate.get_value());
+    }
+}
+
 std::ostream& operator <<(
         std::ostream& os,
         const DurabilityKind& kind)

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -26,9 +26,9 @@ namespace core {
 namespace types {
 
 std::atomic<HistoryDepthType> TopicQoS::default_history_depth{HISTORY_DEPTH_DEFAULT};
-std::atomic<unsigned int> TopicQoS::default_downsampling{DOWNSAMPLING_DEFAULT};
-std::atomic<float> TopicQoS::default_max_rx_rate{MAX_RX_RATE_DEFAULT};
 std::atomic<float> TopicQoS::default_max_tx_rate{MAX_TX_RATE_DEFAULT};
+std::atomic<float> TopicQoS::default_max_rx_rate{MAX_RX_RATE_DEFAULT};
+std::atomic<unsigned int> TopicQoS::default_downsampling{DOWNSAMPLING_DEFAULT};
 
 TopicQoS::TopicQoS()
 {
@@ -50,14 +50,14 @@ TopicQoS::TopicQoS()
     // Set the default history depth
     history_depth.set_value(default_history_depth, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // Set the default downsampling
-    downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
+    // Set the default max transmision rate
+    max_tx_rate.set_value(default_max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 
     // Set the default max reception rate
     max_rx_rate.set_value(default_max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 
-    // Set the default max transmision rate
-    max_tx_rate.set_value(default_max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
+    // Set the default downsampling
+    downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool TopicQoS::operator ==(
@@ -70,9 +70,9 @@ bool TopicQoS::operator ==(
         this->use_partitions == other.use_partitions &&
         this->history_depth == other.history_depth &&
         this->keyed == other.keyed &&
-        this->downsampling == other.downsampling &&
+        this->max_tx_rate == other.max_tx_rate &&
         this->max_rx_rate == other.max_rx_rate &&
-        this->max_tx_rate == other.max_tx_rate;
+        this->downsampling == other.downsampling;
 }
 
 bool TopicQoS::is_reliable() const noexcept
@@ -97,40 +97,40 @@ bool TopicQoS::has_partitions() const noexcept
 
 void TopicQoS::set_qos(const TopicQoS& qos) noexcept
 {
-    if (qos.durability_qos.is_set()) {
+    if (!durability_qos.is_set() && qos.durability_qos.is_set()) {
         durability_qos.set_value(qos.durability_qos.get_value());
     }
 
-    if (qos.reliability_qos.is_set()) {
+    if (!reliability_qos.is_set() && qos.reliability_qos.is_set()) {
         reliability_qos.set_value(qos.reliability_qos.get_value());
     }
 
-    if (qos.ownership_qos.is_set()) {
+    if (!ownership_qos.is_set() && qos.ownership_qos.is_set()) {
         ownership_qos.set_value(qos.ownership_qos.get_value());
     }
 
-    if (qos.use_partitions.is_set()) {
+    if (!use_partitions.is_set() && qos.use_partitions.is_set()) {
         use_partitions.set_value(qos.use_partitions.get_value());
     }
 
-    if (qos.history_depth.is_set()) {
+    if (!history_depth.is_set() && qos.history_depth.is_set()) {
         history_depth.set_value(qos.history_depth.get_value());
     }
 
-    if (qos.keyed.is_set()) {
+    if (!keyed.is_set() && qos.keyed.is_set()) {
         keyed.set_value(qos.keyed.get_value());
     }
 
-    if (qos.downsampling.is_set()) {
-        downsampling.set_value(qos.downsampling.get_value());
+    if (!max_tx_rate.is_set() && qos.max_tx_rate.is_set()) {
+        max_tx_rate.set_value(qos.max_tx_rate.get_value());
     }
 
-    if (qos.max_rx_rate.is_set()) {
+    if (!max_rx_rate.is_set() && qos.max_rx_rate.is_set()) {
         max_rx_rate.set_value(qos.max_rx_rate.get_value());
     }
 
-    if (qos.max_tx_rate.is_set()) {
-        max_tx_rate.set_value(qos.max_tx_rate.get_value());
+    if (!downsampling.is_set() && qos.downsampling.is_set()) {
+        downsampling.set_value(qos.downsampling.get_value());
     }
 }
 
@@ -219,9 +219,9 @@ std::ostream& operator <<(
         (qos.has_partitions() ? ";partitions" : "") <<
         (qos.keyed ? ";keyed" : "") <<
         ";depth(" << qos.history_depth << ")" <<
-        ";downsampling(" << qos.downsampling << ")" <<
-        ";max_rx_rate(" << qos.max_rx_rate << ")" <<
         ";max_tx_rate(" << qos.max_tx_rate << ")" <<
+        ";max_rx_rate(" << qos.max_rx_rate << ")" <<
+        ";downsampling(" << qos.downsampling << ")" <<
         "}";
 
     return os;

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -25,12 +25,14 @@ namespace ddspipe {
 namespace core {
 namespace types {
 
-std::atomic<TopicQoS> default_topic_qos{};
+utils::Fuzzy<TopicQoS> TopicQoS::default_topic_qos{};
 
 TopicQoS::TopicQoS()
 {
-    // Set the default Topic QoS.
-    set_qos(default_topic_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    if (default_topic_qos.is_set())
+    {
+        set_qos(default_topic_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    }
 }
 
 bool TopicQoS::operator ==(

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -27,36 +27,15 @@ namespace types {
 
 utils::Fuzzy<TopicQoS> TopicQoS::default_topic_qos{};
 
-TopicQoS::TopicQoS(
-        DurabilityKind durability_qos /*= DEFAULT_DURABILITY_QOS */,
-        ReliabilityKind reliability_qos /*= DEFAULT_RELIABILITY_QOS */,
-        OwnershipQosPolicyKind ownership_qos /*= DEFAULT_OWNERSHIP_QOS */,
-        bool use_partitions /*= DEFAULT_USE_PARTITIONS */,
-        bool keyed /*= DEFAULT_KEYED */,
-        HistoryDepthType history_depth /*= DEFAULT_HISTORY_DEPTH */,
-        float max_tx_rate /*= DEFAULT_MAX_TX_RATE */,
-        float max_rx_rate /*= DEFAULT_MAX_RX_RATE */,
-        unsigned int downsampling /*= DEFAULT_DOWNSAMPLING */)
+TopicQoS::TopicQoS()
 {
-    /**
-     * @note The default values must be set here. Otherwise, Ubuntu 20.04 Debug does not compile.
-     */
-    this->durability_qos.set_value(durability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->reliability_qos.set_value(reliability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->ownership_qos.set_value(ownership_qos, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->use_partitions.set_value(use_partitions, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->history_depth.set_value(history_depth, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->keyed.set_value(keyed, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->max_tx_rate.set_value(max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->max_rx_rate.set_value(max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
-    this->downsampling.set_value(downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
+    set_default_qos();
 
-    /**
-     * @note This check must be done. If not, the constructor of the default Topic QoS would enter into a loop.
-     */
+    // This check must be done. If not, the constructor of the default Topic QoS would enter into a loop.
     if (default_topic_qos.is_set())
     {
-        set_qos(default_topic_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+        // The FuzzyLevel must be set so that specs overwrites the discovery values.
+        set_qos(default_topic_qos, utils::FuzzyLevelValues::fuzzy_level_set);
     }
 }
 
@@ -99,50 +78,73 @@ void TopicQoS::set_qos(
         const TopicQoS& qos,
         const utils::FuzzyLevelValues& fuzzy_level /*= utils::FuzzyLevelValues::fuzzy_level_fuzzy*/) noexcept
 {
-    if (!durability_qos.is_set() && qos.durability_qos.is_set())
+    if (durability_qos.get_level() < fuzzy_level && qos.durability_qos.is_set())
     {
         durability_qos.set_value(qos.durability_qos.get_value(), fuzzy_level);
     }
 
-    if (!reliability_qos.is_set() && qos.reliability_qos.is_set())
+    if (reliability_qos.get_level() < fuzzy_level && qos.reliability_qos.is_set())
     {
         reliability_qos.set_value(qos.reliability_qos.get_value(), fuzzy_level);
     }
 
-    if (!ownership_qos.is_set() && qos.ownership_qos.is_set())
+    if (ownership_qos.get_level() < fuzzy_level && qos.ownership_qos.is_set())
     {
         ownership_qos.set_value(qos.ownership_qos.get_value(), fuzzy_level);
     }
 
-    if (!use_partitions.is_set() && qos.use_partitions.is_set())
+    if (use_partitions.get_level() < fuzzy_level && qos.use_partitions.is_set())
     {
         use_partitions.set_value(qos.use_partitions.get_value(), fuzzy_level);
     }
 
-    if (!history_depth.is_set() && qos.history_depth.is_set())
+    if (history_depth.get_level() < fuzzy_level && qos.history_depth.is_set())
     {
         history_depth.set_value(qos.history_depth.get_value(), fuzzy_level);
     }
 
-    if (!keyed.is_set() && qos.keyed.is_set())
+    if (keyed.get_level() < fuzzy_level && qos.keyed.is_set())
     {
         keyed.set_value(qos.keyed.get_value(), fuzzy_level);
     }
 
-    if (!max_tx_rate.is_set() && qos.max_tx_rate.is_set())
+    if (max_tx_rate.get_level() < fuzzy_level && qos.max_tx_rate.is_set())
     {
         max_tx_rate.set_value(qos.max_tx_rate.get_value(), fuzzy_level);
     }
 
-    if (!max_rx_rate.is_set() && qos.max_rx_rate.is_set())
+    if (max_rx_rate.get_level() < fuzzy_level && qos.max_rx_rate.is_set())
     {
         max_rx_rate.set_value(qos.max_rx_rate.get_value(), fuzzy_level);
     }
 
-    if (!downsampling.is_set() && qos.downsampling.is_set())
+    if (downsampling.get_level() < fuzzy_level && qos.downsampling.is_set())
     {
         downsampling.set_value(qos.downsampling.get_value(), fuzzy_level);
     }
+}
+
+void TopicQoS::set_default_qos(
+        DurabilityKind durability_qos /*= DEFAULT_DURABILITY_QOS */,
+        ReliabilityKind reliability_qos /*= DEFAULT_RELIABILITY_QOS */,
+        OwnershipQosPolicyKind ownership_qos /*= DEFAULT_OWNERSHIP_QOS */,
+        bool use_partitions /*= DEFAULT_USE_PARTITIONS */,
+        bool keyed /*= DEFAULT_KEYED */,
+        HistoryDepthType history_depth /*= DEFAULT_HISTORY_DEPTH */,
+        float max_tx_rate /*= DEFAULT_MAX_TX_RATE */,
+        float max_rx_rate /*= DEFAULT_MAX_RX_RATE */,
+        unsigned int downsampling /*= DEFAULT_DOWNSAMPLING */) noexcept
+{
+    // The default values must be received as arguments. Otherwise, Ubuntu 20.04 Debug does not compile.
+    this->durability_qos.set_value(durability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->reliability_qos.set_value(reliability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->ownership_qos.set_value(ownership_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->use_partitions.set_value(use_partitions, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->history_depth.set_value(history_depth, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->keyed.set_value(keyed, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->max_tx_rate.set_value(max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->max_rx_rate.set_value(max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->downsampling.set_value(downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 std::ostream& operator <<(

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -28,6 +28,7 @@ namespace types {
 std::atomic<HistoryDepthType> TopicQoS::default_history_depth{HISTORY_DEPTH_DEFAULT};
 std::atomic<unsigned int> TopicQoS::default_downsampling{DOWNSAMPLING_DEFAULT};
 std::atomic<float> TopicQoS::default_max_rx_rate{MAX_RX_RATE_DEFAULT};
+std::atomic<float> TopicQoS::default_max_tx_rate{MAX_TX_RATE_DEFAULT};
 
 TopicQoS::TopicQoS()
 {
@@ -54,6 +55,9 @@ TopicQoS::TopicQoS()
 
     // Set max reception rate by default
     max_rx_rate.set_value(default_max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
+
+    // Set max reception rate by default
+    max_tx_rate.set_value(default_max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool TopicQoS::operator ==(
@@ -67,7 +71,8 @@ bool TopicQoS::operator ==(
         this->history_depth == other.history_depth &&
         this->keyed == other.keyed &&
         this->downsampling == other.downsampling &&
-        this->max_rx_rate == other.max_rx_rate;
+        this->max_rx_rate == other.max_rx_rate &&
+        this->max_tx_rate == other.max_tx_rate;
 }
 
 bool TopicQoS::is_reliable() const noexcept
@@ -122,6 +127,10 @@ void TopicQoS::set_qos(const TopicQoS& qos) noexcept
 
     if (qos.max_rx_rate.is_set()) {
         max_rx_rate.set_value(qos.max_rx_rate.get_value());
+    }
+
+    if (qos.max_tx_rate.is_set()) {
+        max_tx_rate.set_value(qos.max_tx_rate.get_value());
     }
 }
 
@@ -212,6 +221,7 @@ std::ostream& operator <<(
         ";depth(" << qos.history_depth << ")" <<
         ";downsampling(" << qos.downsampling << ")" <<
         ";max_rx_rate(" << qos.max_rx_rate << ")" <<
+        ";max_tx_rate(" << qos.max_tx_rate << ")" <<
         "}";
 
     return os;

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -33,10 +33,12 @@ TopicQoS::TopicQoS()
 {
     // Set history by default
     history_depth = default_history_depth;
+
     // Set downsampling by default
-    downsampling = default_downsampling;
+    downsampling.set_value(default_downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
+
     // Set max reception rate by default
-    max_reception_rate = default_max_reception_rate;
+    max_reception_rate.set_value(default_max_reception_rate, utils::FuzzyLevelValues::fuzzy_level_default);
 }
 
 bool TopicQoS::operator ==(

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -27,8 +27,33 @@ namespace types {
 
 utils::Fuzzy<TopicQoS> TopicQoS::default_topic_qos{};
 
-TopicQoS::TopicQoS()
+TopicQoS::TopicQoS(
+        DurabilityKind durability_qos /*= DEFAULT_DURABILITY_QOS */,
+        ReliabilityKind reliability_qos /*= DEFAULT_RELIABILITY_QOS */,
+        OwnershipQosPolicyKind ownership_qos /*= DEFAULT_OWNERSHIP_QOS */,
+        bool use_partitions /*= DEFAULT_USE_PARTITIONS */,
+        bool keyed /*= DEFAULT_KEYED */,
+        HistoryDepthType history_depth /*= DEFAULT_HISTORY_DEPTH */,
+        float max_tx_rate /*= DEFAULT_MAX_TX_RATE */,
+        float max_rx_rate /*= DEFAULT_MAX_RX_RATE */,
+        unsigned int downsampling /*= DEFAULT_DOWNSAMPLING */)
 {
+    /**
+     * @note The default values must be set here. Otherwise, Ubuntu 20.04 Debug does not compile.
+     */
+    this->durability_qos.set_value(durability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->reliability_qos.set_value(reliability_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->ownership_qos.set_value(ownership_qos, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->use_partitions.set_value(use_partitions, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->history_depth.set_value(history_depth, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->keyed.set_value(keyed, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->max_tx_rate.set_value(max_tx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->max_rx_rate.set_value(max_rx_rate, utils::FuzzyLevelValues::fuzzy_level_default);
+    this->downsampling.set_value(downsampling, utils::FuzzyLevelValues::fuzzy_level_default);
+
+    /**
+     * @note This check must be done. If not, the constructor of the default Topic QoS would enter into a loop.
+     */
     if (default_topic_qos.is_set())
     {
         set_qos(default_topic_qos, utils::FuzzyLevelValues::fuzzy_level_default);

--- a/ddspipe_core/src/cpp/types/topic/Topic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/Topic.cpp
@@ -86,7 +86,8 @@ bool Topic::is_valid(
 
 utils::Heritable<ITopic> Topic::copy() const noexcept
 {
-    return utils::Heritable<Topic>::make_heritable(*this);
+    Topic topic = *this;
+    return utils::Heritable<Topic>::make_heritable(topic);
 }
 
 /////////////////////////
@@ -118,10 +119,10 @@ std::ostream& operator <<(
 Topic& Topic::operator = (
         const Topic& other) noexcept
 {
-    this->m_topic_name = m_topic_name;
-    this->m_internal_type_discriminator = m_internal_type_discriminator;
-    this->m_topic_discoverer = m_topic_discoverer;
-    this->topic_qos = topic_qos;
+    this->m_topic_name = other.m_topic_name;
+    this->m_internal_type_discriminator = other.m_internal_type_discriminator;
+    this->m_topic_discoverer = other.m_topic_discoverer;
+    this->topic_qos = other.topic_qos;
 
     return *this;
 }

--- a/ddspipe_core/src/cpp/types/topic/Topic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/Topic.cpp
@@ -84,6 +84,11 @@ bool Topic::is_valid(
     return true;
 }
 
+utils::Heritable<ITopic> Topic::copy() const noexcept
+{
+    return utils::Heritable<Topic>::make_heritable(*this);
+}
+
 /////////////////////////
 // METHODS TO OVERRIDE
 /////////////////////////
@@ -104,6 +109,21 @@ std::ostream& operator <<(
 {
     os << t.serialize();
     return os;
+}
+
+/////////////////////////
+// OPERATORS
+/////////////////////////
+
+Topic& Topic::operator = (
+        const Topic& other) noexcept
+{
+    this->m_topic_name = m_topic_name;
+    this->m_internal_type_discriminator = m_internal_type_discriminator;
+    this->m_topic_discoverer = m_topic_discoverer;
+    this->topic_qos = topic_qos;
+
+    return *this;
 }
 
 } /* namespace types */

--- a/ddspipe_core/src/cpp/types/topic/Topic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/Topic.cpp
@@ -31,8 +31,7 @@ namespace types {
 bool Topic::operator ==(
         const ITopic& other) const noexcept
 {
-    return
-        topic_unique_name() == other.topic_unique_name();
+    return topic_unique_name() == other.topic_unique_name();
 }
 
 bool Topic::operator <(

--- a/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
@@ -63,7 +63,8 @@ std::string DdsTopic::serialize() const noexcept
 
 utils::Heritable<ITopic> DdsTopic::copy() const noexcept
 {
-    return utils::Heritable<DdsTopic>::make_heritable(*this);
+    DdsTopic topic = *this;
+    return utils::Heritable<DdsTopic>::make_heritable(topic);
 }
 
 /////////////////////////
@@ -119,7 +120,7 @@ DdsTopic& DdsTopic::operator = (
 {
     Topic::operator=(other);
 
-    this->type_name = type_name;
+    this->type_name = other.type_name;
 
     return *this;
 }

--- a/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
@@ -61,6 +61,11 @@ std::string DdsTopic::serialize() const noexcept
     return ss.str();
 }
 
+utils::Heritable<ITopic> DdsTopic::copy() const noexcept
+{
+    return utils::Heritable<DdsTopic>::make_heritable(*this);
+}
+
 /////////////////////////
 // STATIC METHODS
 /////////////////////////
@@ -103,6 +108,20 @@ bool DdsTopic::is_valid_dds_topic(
     }
 
     return true;
+}
+
+/////////////////////////
+// OPERATORS
+/////////////////////////
+
+DdsTopic& DdsTopic::operator = (
+        const DdsTopic& other) noexcept
+{
+    Topic::operator=(other);
+
+    this->type_name = type_name;
+
+    return *this;
 }
 
 } /* namespace types */

--- a/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
@@ -118,7 +118,7 @@ bool DdsTopic::is_valid_dds_topic(
 DdsTopic& DdsTopic::operator = (
         const DdsTopic& other) noexcept
 {
-    Topic::operator=(other);
+    Topic::operator =(other);
 
     this->type_name = other.type_name;
 

--- a/ddspipe_core/test/unittest/core/ddspipe/CMakeLists.txt
+++ b/ddspipe_core/test/unittest/core/ddspipe/CMakeLists.txt
@@ -22,6 +22,7 @@ all_library_sources("${TEST_SOURCES}")
 set(TEST_LIST
         default_initialization
         enable_disable
+        allowed_blocked_topics
     )
 
 set(TEST_EXTRA_LIBRARIES

--- a/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
+++ b/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
@@ -17,6 +17,7 @@
 
 #include <cpp_utils/time/time_utils.hpp>
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/core/DdsPipe.hpp>
 #include <ddspipe_core/efficiency/payload/FastPayloadPool.hpp>
 
@@ -103,9 +104,12 @@ struct DdsPipe : public eprosima::ddspipe::core::DdsPipe
  */
 TEST(DdsPipeTest, default_initialization)
 {
+    DdsPipeConfiguration ddspipe_configuration;
+
     // default
     {
         test::DdsPipe ddspipe(
+            ddspipe_configuration,
             std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
@@ -119,6 +123,7 @@ TEST(DdsPipeTest, default_initialization)
     // enable
     {
         test::DdsPipe ddspipe(
+            ddspipe_configuration,
             std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
@@ -140,6 +145,7 @@ TEST(DdsPipeTest, default_initialization)
                 eprosima::utils::Heritable<types::DdsTopic>::make_heritable(topic_1);
 
         test::DdsPipe ddspipe(
+            ddspipe_configuration,
             std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
@@ -166,6 +172,7 @@ TEST(DdsPipeTest, default_initialization)
                 eprosima::utils::Heritable<types::DdsTopic>::make_heritable(topic_1);
 
         test::DdsPipe ddspipe(
+            ddspipe_configuration,
             std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
@@ -194,10 +201,14 @@ TEST(DdsPipeTest, default_initialization)
  */
 TEST(DdsPipeTest, enable_disable)
 {
+    DdsPipeConfiguration ddspipe_configuration;
+
     // enable discovered topic
     {
         auto discovery_database = std::make_shared<DiscoveryDatabase>();
+
         test::DdsPipe ddspipe(
+            ddspipe_configuration,
             std::make_shared<AllowedTopicList>(),
             discovery_database,
             std::make_shared<FastPayloadPool>(),
@@ -249,8 +260,8 @@ TEST(DdsPipeTest, enable_disable)
         eprosima::utils::Heritable<types::DistributedTopic> htopic_1 =
                 eprosima::utils::Heritable<types::DdsTopic>::make_heritable(topic_1);
 
-        auto discovery_database = std::make_shared<DiscoveryDatabase>();
         test::DdsPipe ddspipe(
+            ddspipe_configuration,
             std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),

--- a/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
+++ b/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
@@ -321,6 +321,18 @@ TEST(DdsPipeTest, allowed_blocked_topics)
         ASSERT_FALSE(ddspipe.is_topic_active(htopic_1));
         ASSERT_FALSE(ddspipe.is_bridge_created(htopic_1));
 
+        // Create a wildcard topic
+        types::WildcardDdsFilterTopic topic_2;
+        topic_2.topic_name.set_value("t*");
+
+        eprosima::utils::Heritable<types::IFilterTopic> htopic_2 =
+                eprosima::utils::Heritable<types::WildcardDdsFilterTopic>::make_heritable(topic_2);
+
+        // Add the Topic to the blocklist
+        DdsPipeConfiguration new_ddspipe_configuration;
+        new_ddspipe_configuration.blocklist.insert(htopic_2);
+        ddspipe.reload_configuration(new_ddspipe_configuration);
+
         types::Endpoint endpoint_1;
         endpoint_1.kind = types::EndpointKind::reader;
         endpoint_1.topic = topic_1;
@@ -331,25 +343,32 @@ TEST(DdsPipeTest, allowed_blocked_topics)
         eprosima::utils::sleep_for(10u);
 
         ASSERT_TRUE(ddspipe.is_topic_discovered(htopic_1));
+        ASSERT_FALSE(ddspipe.is_topic_active(htopic_1));
+        ASSERT_FALSE(ddspipe.is_bridge_created(htopic_1));
+
+        // Remove the Topic from the blocklist
+        new_ddspipe_configuration.blocklist.erase(htopic_2);
+        ddspipe.reload_configuration(new_ddspipe_configuration);
+
+        ASSERT_TRUE(ddspipe.is_topic_discovered(htopic_1));
         ASSERT_TRUE(ddspipe.is_topic_active(htopic_1));
         ASSERT_TRUE(ddspipe.is_bridge_created(htopic_1));
 
         // Create two Wildcard Topics
-        types::WildcardDdsFilterTopic topic_2;
-        topic_2.topic_name.set_value("topic*");
-
-        eprosima::utils::Heritable<types::IFilterTopic> htopic_2 =
-                eprosima::utils::Heritable<types::WildcardDdsFilterTopic>::make_heritable(topic_2);
-
         types::WildcardDdsFilterTopic topic_3;
-        topic_3.topic_name.set_value("top*");
+        topic_3.topic_name.set_value("topic*");
 
         eprosima::utils::Heritable<types::IFilterTopic> htopic_3 =
                 eprosima::utils::Heritable<types::WildcardDdsFilterTopic>::make_heritable(topic_3);
 
+        types::WildcardDdsFilterTopic topic_4;
+        topic_4.topic_name.set_value("top*");
+
+        eprosima::utils::Heritable<types::IFilterTopic> htopic_4 =
+                eprosima::utils::Heritable<types::WildcardDdsFilterTopic>::make_heritable(topic_4);
+
         // Add the Topic to the allowlist
-        DdsPipeConfiguration new_ddspipe_configuration;
-        new_ddspipe_configuration.allowlist.insert(htopic_2);
+        new_ddspipe_configuration.allowlist.insert(htopic_3);
         ddspipe.reload_configuration(new_ddspipe_configuration);
 
         ASSERT_TRUE(ddspipe.is_topic_discovered(htopic_1));
@@ -357,7 +376,7 @@ TEST(DdsPipeTest, allowed_blocked_topics)
         ASSERT_TRUE(ddspipe.is_bridge_created(htopic_1));
 
         // Add the Topic to the blocklist
-        new_ddspipe_configuration.blocklist.insert(htopic_3);
+        new_ddspipe_configuration.blocklist.insert(htopic_4);
         ddspipe.reload_configuration(new_ddspipe_configuration);
 
         ASSERT_TRUE(ddspipe.is_topic_discovered(htopic_1));
@@ -365,7 +384,7 @@ TEST(DdsPipeTest, allowed_blocked_topics)
         ASSERT_TRUE(ddspipe.is_bridge_created(htopic_1));
 
         // Remove the Topic from the blocklist
-        new_ddspipe_configuration.blocklist.erase(htopic_3);
+        new_ddspipe_configuration.blocklist.erase(htopic_4);
         ddspipe.reload_configuration(new_ddspipe_configuration);
 
         ASSERT_TRUE(ddspipe.is_topic_discovered(htopic_1));

--- a/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
+++ b/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
@@ -293,14 +293,6 @@ TEST(DdsPipeTest, allowed_blocked_topics)
     // TODO
 }
 
-/**
- * TODO
- */
-TEST(DdsPipeTest, reload)
-{
-    // TODO
-}
-
 int main(
         int argc,
         char** argv)

--- a/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
+++ b/ddspipe_core/test/unittest/core/ddspipe/DdsPipeTest.cpp
@@ -104,13 +104,12 @@ struct DdsPipe : public eprosima::ddspipe::core::DdsPipe
  */
 TEST(DdsPipeTest, default_initialization)
 {
-    DdsPipeConfiguration ddspipe_configuration;
-
     // default
     {
+        DdsPipeConfiguration ddspipe_configuration;
+
         test::DdsPipe ddspipe(
             ddspipe_configuration,
-            std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
             std::make_shared<ParticipantsDatabase>(),
@@ -122,15 +121,15 @@ TEST(DdsPipeTest, default_initialization)
 
     // enable
     {
+        DdsPipeConfiguration ddspipe_configuration;
+        ddspipe_configuration.init_enabled = true;
+
         test::DdsPipe ddspipe(
             ddspipe_configuration,
-            std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
             std::make_shared<ParticipantsDatabase>(),
-            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS),
-            {},
-            true
+            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS)
             );
 
         ASSERT_TRUE(ddspipe.is_enabled());
@@ -144,16 +143,15 @@ TEST(DdsPipeTest, default_initialization)
         eprosima::utils::Heritable<types::DistributedTopic> htopic_1 =
                 eprosima::utils::Heritable<types::DdsTopic>::make_heritable(topic_1);
 
+        DdsPipeConfiguration ddspipe_configuration;
+        ddspipe_configuration.builtin_topics.insert(htopic_1);
+
         test::DdsPipe ddspipe(
             ddspipe_configuration,
-            std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
             std::make_shared<ParticipantsDatabase>(),
-            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS),
-        {
-            htopic_1
-        }
+            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS)
             );
 
         ASSERT_FALSE(ddspipe.is_enabled());
@@ -171,17 +169,16 @@ TEST(DdsPipeTest, default_initialization)
         eprosima::utils::Heritable<types::DistributedTopic> htopic_1 =
                 eprosima::utils::Heritable<types::DdsTopic>::make_heritable(topic_1);
 
+        DdsPipeConfiguration ddspipe_configuration;
+        ddspipe_configuration.builtin_topics.insert(htopic_1);
+        ddspipe_configuration.init_enabled = true;
+
         test::DdsPipe ddspipe(
             ddspipe_configuration,
-            std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
             std::make_shared<ParticipantsDatabase>(),
-            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS),
-        {
-            htopic_1
-        },
-            true
+            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS)
             );
 
         ASSERT_TRUE(ddspipe.is_enabled());
@@ -201,15 +198,14 @@ TEST(DdsPipeTest, default_initialization)
  */
 TEST(DdsPipeTest, enable_disable)
 {
-    DdsPipeConfiguration ddspipe_configuration;
-
     // enable discovered topic
     {
+        DdsPipeConfiguration ddspipe_configuration;
+
         auto discovery_database = std::make_shared<DiscoveryDatabase>();
 
         test::DdsPipe ddspipe(
             ddspipe_configuration,
-            std::make_shared<AllowedTopicList>(),
             discovery_database,
             std::make_shared<FastPayloadPool>(),
             std::make_shared<ParticipantsDatabase>(),
@@ -260,14 +256,15 @@ TEST(DdsPipeTest, enable_disable)
         eprosima::utils::Heritable<types::DistributedTopic> htopic_1 =
                 eprosima::utils::Heritable<types::DdsTopic>::make_heritable(topic_1);
 
+        DdsPipeConfiguration ddspipe_configuration;
+        ddspipe_configuration.builtin_topics.insert(htopic_1);
+
         test::DdsPipe ddspipe(
             ddspipe_configuration,
-            std::make_shared<AllowedTopicList>(),
             std::make_shared<DiscoveryDatabase>(),
             std::make_shared<FastPayloadPool>(),
             std::make_shared<ParticipantsDatabase>(),
-            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS),
-            {htopic_1}
+            std::make_shared<eprosima::utils::SlotThreadPool>(test::N_THREADS)
             );
 
         ASSERT_TRUE(ddspipe.is_topic_discovered(htopic_1));

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -56,7 +56,7 @@ struct ParticipantConfiguration : public core::IConfiguration
     //! Participant max reception rate associated with this configuration.
     utils::Fuzzy<float> max_rx_rate{};
 
-    //! Participant max reception rate associated with this configuration.
+    //! Participant max transmission rate associated with this configuration.
     utils::Fuzzy<float> max_tx_rate{};
 };
 

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -16,9 +16,10 @@
 
 #include <cpp_utils/types/Fuzzy.hpp>
 
+#include <ddspipe_core/configuration/IConfiguration.hpp>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 
-#include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_participants/library/library_dll.h>
 
 namespace eprosima {
@@ -50,14 +51,8 @@ struct ParticipantConfiguration : public core::IConfiguration
     //! Whether this Participant should connect its readers with its writers.
     bool is_repeater {false};
 
-    //! Participant downsampling rate associated with this configuration.
-    utils::Fuzzy<unsigned int> downsampling{};
-
-    //! Participant max reception rate associated with this configuration.
-    utils::Fuzzy<float> max_rx_rate{};
-
-    //! Participant max transmission rate associated with this configuration.
-    utils::Fuzzy<float> max_tx_rate{};
+    //! Subset of fixed Topic QoS associated to the Participant
+    core::types::TopicQoS topic_qos{};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -55,6 +55,9 @@ struct ParticipantConfiguration : public core::IConfiguration
 
     //! Participant max reception rate associated with this configuration.
     utils::Fuzzy<float> max_rx_rate{};
+
+    //! Participant max reception rate associated with this configuration.
+    utils::Fuzzy<float> max_tx_rate{};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -54,7 +54,7 @@ struct ParticipantConfiguration : public core::IConfiguration
     utils::Fuzzy<unsigned int> downsampling{};
 
     //! Participant max reception rate associated with this configuration.
-    utils::Fuzzy<float> max_reception_rate{};
+    utils::Fuzzy<float> max_rx_rate{};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <cpp_utils/types/Fuzzy.hpp>
+
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 
 #include <ddspipe_core/configuration/IConfiguration.hpp>
@@ -47,6 +49,12 @@ struct ParticipantConfiguration : public core::IConfiguration
 
     //! Whether this Participant should connect its readers with its writers.
     bool is_repeater {false};
+
+    //! Participant downsampling rate associated with this configuration.
+    utils::Fuzzy<unsigned int> downsampling{};
+
+    //! Participant max reception rate associated with this configuration.
+    utils::Fuzzy<float> max_reception_rate{};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -45,13 +45,13 @@ struct ParticipantConfiguration : public core::IConfiguration
     virtual bool is_valid(
             utils::Formatter& error_msg) const noexcept override;
 
-    //! Participant Id associated with this configuration
+    //! Participant Id associated with this configuration.
     core::types::ParticipantId id {};
 
     //! Whether this Participant should connect its readers with its writers.
     bool is_repeater {false};
 
-    //! Subset of fixed Topic QoS associated to the Participant
+    //! The Topic QoS that have been manually configured for the Participant.
     core::types::TopicQoS topic_qos{};
 };
 

--- a/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/ParticipantConfiguration.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <cpp_utils/types/Fuzzy.hpp>
-
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>

--- a/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <ddspipe_core/interface/IParticipant.hpp>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 
 #include <ddspipe_participants/library/library_dll.h>
 
@@ -49,6 +50,10 @@ public:
     //! Override is_rtps_kind() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool is_rtps_kind() const noexcept override;
+
+    //! TODO
+    DDSPIPE_PARTICIPANTS_DllAPI
+    core::types::TopicQoS topic_qos() const noexcept override;
 
     //! Override create_writer() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI

--- a/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
@@ -51,7 +51,7 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     bool is_rtps_kind() const noexcept override;
 
-    //! TODO
+    //! Override topic_qos() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::TopicQoS topic_qos() const noexcept override;
 

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -18,6 +18,9 @@
 
 #include <cpp_utils/types/Atomicable.hpp>
 
+#include <cpp_utils/memory/Heritable.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
+
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 #include <fastdds/dds/domain/qos/DomainParticipantQos.hpp>

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -17,9 +17,7 @@
 #include <mutex>
 
 #include <cpp_utils/types/Atomicable.hpp>
-
 #include <cpp_utils/memory/Heritable.hpp>
-#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -31,6 +29,7 @@
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>
 #include <ddspipe_core/interface/IParticipant.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp>
 #include <ddspipe_participants/library/library_dll.h>

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -28,6 +28,7 @@
 #include <ddspipe_core/dynamic/DiscoveryDatabase.hpp>
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>
 #include <ddspipe_core/interface/IParticipant.hpp>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
@@ -81,6 +82,9 @@ public:
 
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual bool is_repeater() const noexcept override;
+
+    DDSPIPE_PARTICIPANTS_DllAPI
+    core::types::TopicQoS topic_qos() const noexcept override;
 
     /**
      * @brief Create a writer object

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -17,7 +17,6 @@
 #include <mutex>
 
 #include <cpp_utils/types/Atomicable.hpp>
-#include <cpp_utils/memory/Heritable.hpp>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
@@ -30,7 +29,6 @@
 #include <ddspipe_core/interface/IParticipant.hpp>
 #include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
-#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp>
 #include <ddspipe_participants/library/library_dll.h>

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
@@ -52,6 +52,10 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     bool is_rtps_kind() const noexcept override;
 
+    //! Override topic_qos() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    core::types::TopicQoS topic_qos() const noexcept override;
+
     //! Override create_writer_() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     std::shared_ptr<core::IWriter> create_writer(
@@ -63,6 +67,9 @@ public:
             const core::ITopic& topic) override;
 
 protected:
+
+    //! Participant Configuration
+    std::shared_ptr<ParticipantConfiguration> configuration_;
 
     //! Participant Id
     core::types::ParticipantId id_;

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -194,7 +194,8 @@ protected:
     /**
      * @brief Auxiliary method to set a set of Topic QoS.
      */
-    void set_topic_qos_(core::types::DdsTopic& dds_topic) noexcept;
+    void set_topic_qos_(
+            core::types::DdsTopic& dds_topic) noexcept;
 
     /////
     // RTPS specific methods

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <cpp_utils/memory/Heritable.hpp>
-#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
 #include <fastdds/rtps/reader/ReaderDiscoveryInfo.h>
@@ -29,6 +28,7 @@
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>
 #include <ddspipe_core/interface/IParticipant.hpp>
 #include <ddspipe_core/types/dds/DomainId.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <ddspipe_participants/configuration/ParticipantConfiguration.hpp>
 #include <ddspipe_participants/library/library_dll.h>
@@ -190,6 +190,11 @@ protected:
     void create_participant_(
             const core::types::DomainId& domain,
             const fastrtps::rtps::RTPSParticipantAttributes& participant_attributes);
+
+    /**
+     * @brief Auxiliary method to set a set of Topic QoS.
+     */
+    void set_topic_qos_(core::types::DdsTopic& dds_topic) noexcept;
 
     /////
     // RTPS specific methods

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -95,7 +95,7 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual bool is_rtps_kind() const noexcept override;
 
-    //! TODO
+    //! Implement parent method \c topic_qos .
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::TopicQoS topic_qos() const noexcept override;
 
@@ -195,12 +195,6 @@ protected:
     void create_participant_(
             const core::types::DomainId& domain,
             const fastrtps::rtps::RTPSParticipantAttributes& participant_attributes);
-
-    /**
-     * @brief Auxiliary method to set a set of Topic QoS.
-     */
-    void set_topic_qos_(
-            core::types::DdsTopic& dds_topic) noexcept;
 
     /////
     // RTPS specific methods

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -28,6 +28,7 @@
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>
 #include <ddspipe_core/interface/IParticipant.hpp>
 #include <ddspipe_core/types/dds/DomainId.hpp>
+#include <ddspipe_core/types/dds/TopicQoS.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
 
 #include <ddspipe_participants/configuration/ParticipantConfiguration.hpp>
@@ -93,6 +94,10 @@ public:
     //! Implement parent method \c is_rtps_kind .
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual bool is_rtps_kind() const noexcept override;
+
+    //! TODO
+    DDSPIPE_PARTICIPANTS_DllAPI
+    core::types::TopicQoS topic_qos() const noexcept override;
 
     /**
      * @brief Create a writer object

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <cpp_utils/memory/Heritable.hpp>
+#include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
+
 #include <fastdds/rtps/participant/ParticipantDiscoveryInfo.h>
 #include <fastdds/rtps/reader/ReaderDiscoveryInfo.h>
 #include <fastdds/rtps/rtps_fwd.h>
@@ -21,7 +24,6 @@
 #include <fastrtps/rtps/attributes/RTPSParticipantAttributes.h>
 #include <fastrtps/rtps/participant/RTPSParticipantListener.h>
 #include <fastrtps/rtps/RTPSDomain.h>
-
 
 #include <ddspipe_core/dynamic/DiscoveryDatabase.hpp>
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>

--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <mutex>
 
+#include <cpp_utils/time/time_utils.hpp>
+
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/interface/IReader.hpp>
 #include <ddspipe_core/interface/ITopic.hpp>
@@ -123,6 +125,10 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::ParticipantId participant_id() const noexcept override;
 
+    //! Whether a sample received should be processed
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual bool can_accept_sample_() noexcept;
+
     /////////////////////////
     // RPC REQUIRED METHODS
     /////////////////////////
@@ -156,7 +162,9 @@ protected:
      * @param participant_id parent participant id
      */
     BaseReader(
-            const core::types::ParticipantId& participant_id);
+            const core::types::ParticipantId& participant_id,
+            const float max_reception_rate = 0,
+            const unsigned int downsampling = 1);
 
     /////////////////////////
     // PROTECTED METHODS
@@ -215,6 +223,21 @@ protected:
 
     //! Mutex that guards every access to the Reader
     mutable std::recursive_mutex mutex_;
+
+    // Max reception rate
+    float max_reception_rate_;
+
+    //! Downsampling value
+    unsigned int downsampling_;
+
+    //! Counter used to keep only 1 sample of every N received, with N being the topic's downsampling factor.
+    unsigned int downsampling_idx_ = 0;
+
+    //! Reception timestamp of the last received (and processed) message, upon which max reception rate can be applied.
+    utils::Timestamp last_received_ts_ = utils::the_beginning_of_time();
+
+    //! Minimum time [ns] between received samples required to be processed (0 <=> no restriction).
+    std::chrono::nanoseconds min_intersample_period_ = std::chrono::nanoseconds(0);
 
     //! Default callback. It shows a warning that callback is not set
     static const std::function<void()> DEFAULT_ON_DATA_AVAILABLE_CALLBACK;

--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
@@ -215,6 +215,12 @@ protected:
     //! Participant parent ID
     const core::types::ParticipantId participant_id_;
 
+    // Max reception rate
+    float max_rx_rate_;
+
+    //! Downsampling value
+    unsigned int downsampling_;
+
     //! Lambda to call the callback whenever a new data arrives
     std::function<void()> on_data_available_lambda_;
 
@@ -226,12 +232,6 @@ protected:
 
     //! Mutex that guards every access to the Reader
     mutable std::recursive_mutex mutex_;
-
-    // Max reception rate
-    float max_rx_rate_;
-
-    //! Downsampling value
-    unsigned int downsampling_;
 
     //! Counter used to keep only 1 sample of every N received, with N being the topic's downsampling factor.
     unsigned int downsampling_idx_ = 0;

--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
@@ -215,7 +215,7 @@ protected:
     //! Participant parent ID
     const core::types::ParticipantId participant_id_;
 
-    // Max reception rate
+    //! Max reception rate
     float max_rx_rate_;
 
     //! Downsampling value

--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
@@ -201,9 +201,12 @@ protected:
     virtual utils::ReturnCode take_nts_(
             std::unique_ptr<core::IRoutingData>& data) noexcept = 0;
 
-    //! Whether a sample received should be processed
-    DDSPIPE_PARTICIPANTS_DllAPI
-    virtual bool can_accept_sample_() noexcept;
+    /**
+     * @brief Check the \c max_rx_rate and the \c downsampling to decide whether a sample should be processed.
+     *
+     * Implement this method in every inherited Reader class with take functionality.
+     */
+    virtual bool should_accept_sample_() noexcept;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
@@ -163,7 +163,7 @@ protected:
      */
     BaseReader(
             const core::types::ParticipantId& participant_id,
-            const float max_reception_rate = 0,
+            const float max_rx_rate = 0,
             const unsigned int downsampling = 1);
 
     /////////////////////////
@@ -225,7 +225,7 @@ protected:
     mutable std::recursive_mutex mutex_;
 
     // Max reception rate
-    float max_reception_rate_;
+    float max_rx_rate_;
 
     //! Downsampling value
     unsigned int downsampling_;

--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/BaseReader.hpp
@@ -125,10 +125,6 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::ParticipantId participant_id() const noexcept override;
 
-    //! Whether a sample received should be processed
-    DDSPIPE_PARTICIPANTS_DllAPI
-    virtual bool can_accept_sample_() noexcept;
-
     /////////////////////////
     // RPC REQUIRED METHODS
     /////////////////////////
@@ -204,6 +200,10 @@ protected:
      */
     virtual utils::ReturnCode take_nts_(
             std::unique_ptr<core::IRoutingData>& data) noexcept = 0;
+
+    //! Whether a sample received should be processed
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual bool can_accept_sample_() noexcept;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -137,7 +137,7 @@ protected:
     reckon_reader_qos_() const;
 
     //! Whether a change received should be processed
-    virtual bool should_accept_change_(
+    virtual bool should_accept_sample_(
             const fastdds::dds::SampleInfo& info) noexcept;
 
     virtual void fill_received_data_(

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -136,6 +136,10 @@ protected:
     fastdds::dds::DataReaderQos
     reckon_reader_qos_() const;
 
+    //! Whether a change received should be processed
+    virtual bool should_accept_change_(
+            const fastdds::dds::SampleInfo& info) noexcept;
+
     virtual void fill_received_data_(
             const fastdds::dds::SampleInfo& info,
             core::types::RtpsPayloadData& data_to_fill) const noexcept;

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -136,7 +136,7 @@ protected:
     fastdds::dds::DataReaderQos
     reckon_reader_qos_() const;
 
-    //! Whether a change received should be processed
+    //! Whether a sample received should be processed
     virtual bool should_accept_sample_(
             const fastdds::dds::SampleInfo& info) noexcept;
 

--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -272,7 +272,7 @@ protected:
 
     //! Whether a change received should be processed
     DDSPIPE_PARTICIPANTS_DllAPI
-    virtual bool accept_change_(
+    virtual bool can_accept_change_(
             const fastrtps::rtps::CacheChange_t* change) noexcept;
 
     //! Whether a change received is from this Participant (to avoid auto-feedback)
@@ -317,15 +317,6 @@ protected:
 
     //! Reader QoS to create the internal RTPS Reader.
     fastrtps::ReaderQos reader_qos_;
-
-    //! Counter used to keep only 1 sample of every N received, with N being the topic's downsampling factor.
-    unsigned int downsampling_idx_ = 0;
-
-    // ! Reception timestamp of the last received (and processed) message, upon which max reception rate can be applied.
-    utils::Timestamp last_received_ts_ = utils::the_beginning_of_time();
-
-    //! Minimum time [ns] between received samples required to be processed (0 <=> no restriction).
-    std::chrono::nanoseconds min_intersample_period_ = std::chrono::nanoseconds(0);
 };
 
 } /* namespace rtps */

--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -272,7 +272,7 @@ protected:
 
     //! Whether a change received should be processed
     DDSPIPE_PARTICIPANTS_DllAPI
-    virtual bool can_accept_change_(
+    virtual bool should_accept_change_(
             const fastrtps::rtps::CacheChange_t* change) noexcept;
 
     //! Whether a change received is from this Participant (to avoid auto-feedback)

--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -271,7 +271,6 @@ protected:
     // CommonReader specific methods
 
     //! Whether a change received should be processed
-    DDSPIPE_PARTICIPANTS_DllAPI
     virtual bool should_accept_change_(
             const fastrtps::rtps::CacheChange_t* change) noexcept;
 

--- a/ddspipe_participants/include/ddspipe_participants/testing/entities/mock_entities.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/testing/entities/mock_entities.hpp
@@ -17,8 +17,9 @@
 #include <mutex>
 #include <queue>
 
-#include <cpp_utils/wait/CounterWaitHandler.hpp>
+#include <cpp_utils/memory/Heritable.hpp>
 #include <cpp_utils/types/Atomicable.hpp>
+#include <cpp_utils/wait/CounterWaitHandler.hpp>
 
 #include <ddspipe_core/interface/IReader.hpp>
 #include <ddspipe_core/interface/IWriter.hpp>
@@ -152,6 +153,9 @@ public:
 
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::TopicInternalTypeDiscriminator internal_type_discriminator() const noexcept override;
+
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual utils::Heritable<core::ITopic> copy() const noexcept override;
 };
 
 class MockFilterAllTopic : public core::types::IFilterTopic

--- a/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
@@ -134,9 +134,9 @@ protected:
             core::IRoutingData& data) noexcept  = 0;
 
     /**
-     * @brief Check the \c max_rx_rate to decide whether a sample should be sent.
+     * @brief Check the \c max_tx_rate to decide whether a sample should be sent.
      */
-    bool can_send_sample_() noexcept;
+    bool should_send_sample_() noexcept;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
@@ -145,14 +145,14 @@ protected:
     //! Participant parent ID
     const core::types::ParticipantId participant_id_;
 
+    // Max transmission rate
+    float max_tx_rate_;
+
     //! Whether the Writer is currently enabled
     std::atomic<bool> enabled_;
 
     //! Mutex that guards every access to the Writer
     mutable std::recursive_mutex mutex_;
-
-    // Max transmission rate
-    float max_tx_rate_;
 
     //! Timestamp of the last sent message.
     utils::Timestamp last_sent_ts_ = utils::the_beginning_of_time();

--- a/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
@@ -133,8 +133,9 @@ protected:
     virtual utils::ReturnCode write_nts_(
             core::IRoutingData& data) noexcept  = 0;
 
-    //! Whether enough time has passed to send a sample
-    DDSPIPE_PARTICIPANTS_DllAPI
+    /**
+     * @brief Check the \c max_rx_rate to decide whether a sample should be sent.
+     */
     bool can_send_sample_() noexcept;
 
     /////////////////////////

--- a/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/BaseWriter.hpp
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <mutex>
 
+#include <cpp_utils/time/time_utils.hpp>
+
 #include <ddspipe_core/interface/IWriter.hpp>
 #include <ddspipe_core/interface/IRoutingData.hpp>
 #include <ddspipe_core/interface/ITopic.hpp>
@@ -100,7 +102,8 @@ protected:
      */
     DDSPIPE_PARTICIPANTS_DllAPI
     BaseWriter(
-            const core::types::ParticipantId& participant_id);
+            const core::types::ParticipantId& participant_id,
+            const float max_tx_rate = 0);
 
     /////////////////////////
     // METHODS TO IMPLEMENT BY SUBCLASSES
@@ -130,6 +133,10 @@ protected:
     virtual utils::ReturnCode write_nts_(
             core::IRoutingData& data) noexcept  = 0;
 
+    //! Whether enough time has passed to send a sample
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool can_send_sample_() noexcept;
+
     /////////////////////////
     // INTERNAL VARIABLES
     /////////////////////////
@@ -142,6 +149,15 @@ protected:
 
     //! Mutex that guards every access to the Writer
     mutable std::recursive_mutex mutex_;
+
+    // Max transmission rate
+    float max_tx_rate_;
+
+    //! Timestamp of the last sent message.
+    utils::Timestamp last_sent_ts_ = utils::the_beginning_of_time();
+
+    //! Minimum time [ns] between sent samples required to be processed (0 <=> no restriction).
+    std::chrono::nanoseconds min_intersample_period_ = std::chrono::nanoseconds(0);
 
     // Allow operator << to use private variables
     friend std::ostream& operator <<(

--- a/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
@@ -42,6 +42,12 @@ bool BlankParticipant::is_rtps_kind() const noexcept
     return false;
 }
 
+core::types::TopicQoS BlankParticipant::topic_qos() const noexcept
+{
+    core::types::TopicQoS m_topic_qos;
+    return m_topic_qos;
+}
+
 std::shared_ptr<core::IWriter> BlankParticipant::create_writer(
         const core::ITopic& topic)
 {

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -111,7 +111,8 @@ bool CommonParticipant::is_repeater() const noexcept
     return false;
 }
 
-core::types::TopicQoS CommonParticipant::topic_qos() const noexcept {
+core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
+{
     return configuration_->topic_qos;
 }
 

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -111,6 +111,10 @@ bool CommonParticipant::is_repeater() const noexcept
     return false;
 }
 
+core::types::TopicQoS CommonParticipant::topic_qos() const noexcept {
+    return configuration_->topic_qos;
+}
+
 std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
         const core::ITopic& topic)
 {

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -162,11 +162,13 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
 {
     // Can only create DDS Topics
     const core::types::DdsTopic* topic_ptr = dynamic_cast<const core::types::DdsTopic*>(&topic);
+
     if (!topic_ptr)
     {
         logDebug(DDSPIPE_DDS_PARTICIPANT, "Not creating Reader for topic " << topic.topic_name());
         return std::make_shared<BlankReader>();
     }
+
     const core::types::DdsTopic& dds_topic = *topic_ptr;
 
     // Check that it is RTPS topic

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
@@ -41,7 +41,8 @@ SchemaParticipant::SchemaParticipant(
         std::shared_ptr<PayloadPool> payload_pool,
         std::shared_ptr<DiscoveryDatabase> discovery_database,
         std::shared_ptr<ISchemaHandler> schema_handler)
-    : id_(participant_configuration->id)
+    : configuration_(participant_configuration)
+    , id_(participant_configuration->id)
     , payload_pool_(payload_pool)
     , discovery_database_(discovery_database)
     , schema_handler_(schema_handler)
@@ -80,6 +81,11 @@ bool SchemaParticipant::is_repeater() const noexcept
 bool SchemaParticipant::is_rtps_kind() const noexcept
 {
     return false;
+}
+
+core::types::TopicQoS SchemaParticipant::topic_qos() const noexcept
+{
+    return configuration_->topic_qos;
 }
 
 std::shared_ptr<IWriter> SchemaParticipant::create_writer(

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -478,6 +478,10 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
 
 void CommonParticipant::set_topic_qos_(core::types::DdsTopic& dds_topic) noexcept
 {
+    // The Topic QoS are now set to the values in Specs on the level DEFAULT.
+    // They will remain as configured in specs unless they are overriden.
+
+    // 1. Manual Topic QoS.
     for (const auto& manual_topic : manual_topics)
     {
         if (manual_topic->matches(dds_topic))
@@ -486,20 +490,8 @@ void CommonParticipant::set_topic_qos_(core::types::DdsTopic& dds_topic) noexcep
         }
     }
 
-    if (!dds_topic.topic_qos.max_rx_rate.is_set() && configuration_->max_rx_rate.is_set())
-    {
-        dds_topic.topic_qos.max_rx_rate.set_value(configuration_->max_rx_rate.get_value());
-    }
-
-    if (!dds_topic.topic_qos.max_tx_rate.is_set() && configuration_->max_tx_rate.is_set())
-    {
-        dds_topic.topic_qos.max_tx_rate.set_value(configuration_->max_tx_rate.get_value());
-    }
-
-    if (!dds_topic.topic_qos.downsampling.is_set() && configuration_->downsampling.is_set())
-    {
-        dds_topic.topic_qos.downsampling.set_value(configuration_->downsampling.get_value());
-    }
+    // 2. Participant Topic QoS.
+    dds_topic.topic_qos.set_qos(configuration_->topic_qos);
 }
 
 fastrtps::rtps::RTPSParticipantAttributes

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -476,7 +476,8 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
     }
 }
 
-void CommonParticipant::set_topic_qos_(core::types::DdsTopic& dds_topic) noexcept
+void CommonParticipant::set_topic_qos_(
+        core::types::DdsTopic& dds_topic) noexcept
 {
     // The Topic QoS are now set to the values in Specs on the level DEFAULT.
     // They will remain as configured in specs unless they are overriden.

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -360,21 +360,11 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
         logDebug(DDSPIPE_RTPS_PARTICIPANT, "Not creating Writer for topic " << topic.topic_name());
         return std::make_shared<BlankWriter>();
     }
-    
+
+    // Make a copy to modify the Topic QoS
     core::types::DdsTopic dds_topic = *dds_topic_ptr;
 
-    for (const auto& manual_topic : manual_topics)
-    {
-        if (manual_topic->matches(dds_topic))
-        {
-            dds_topic.topic_qos.set_qos(manual_topic->topic_qos);
-        }
-    }
-
-    if (!dds_topic.topic_qos.max_tx_rate.is_set() && configuration_->max_tx_rate.is_set())
-    {
-        dds_topic.topic_qos.max_tx_rate.set_value(configuration_->max_tx_rate.get_value());
-    }
+    set_topic_qos_(dds_topic);
 
     if (topic.internal_type_discriminator() == core::types::INTERNAL_TOPIC_TYPE_RPC)
     {
@@ -434,25 +424,10 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
         return std::make_shared<BlankReader>();
     }
 
+    // Make a copy to modify the Topic QoS
     core::types::DdsTopic dds_topic = *dds_topic_ptr;
 
-    for (const auto& manual_topic : manual_topics)
-    {
-        if (manual_topic->matches(dds_topic))
-        {
-            dds_topic.topic_qos.set_qos(manual_topic->topic_qos);
-        }
-    }
-
-    if (!dds_topic.topic_qos.max_rx_rate.is_set() && configuration_->max_rx_rate.is_set())
-    {
-        dds_topic.topic_qos.max_rx_rate.set_value(configuration_->max_rx_rate.get_value());
-    }
-
-    if (!dds_topic.topic_qos.downsampling.is_set() && configuration_->downsampling.is_set())
-    {
-        dds_topic.topic_qos.downsampling.set_value(configuration_->downsampling.get_value());
-    }
+    set_topic_qos_(dds_topic);
 
     if (topic.internal_type_discriminator() == core::types::INTERNAL_TOPIC_TYPE_RPC)
     {
@@ -498,6 +473,32 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
     {
         logDevError(DDSPIPE_RTPS_PARTICIPANT, "Incorrect dds Topic in Reader creation.");
         return std::make_shared<BlankReader>();
+    }
+}
+
+void CommonParticipant::set_topic_qos_(core::types::DdsTopic& dds_topic) noexcept
+{
+    for (const auto& manual_topic : manual_topics)
+    {
+        if (manual_topic->matches(dds_topic))
+        {
+            dds_topic.topic_qos.set_qos(manual_topic->topic_qos);
+        }
+    }
+
+    if (!dds_topic.topic_qos.max_rx_rate.is_set() && configuration_->max_rx_rate.is_set())
+    {
+        dds_topic.topic_qos.max_rx_rate.set_value(configuration_->max_rx_rate.get_value());
+    }
+
+    if (!dds_topic.topic_qos.max_tx_rate.is_set() && configuration_->max_tx_rate.is_set())
+    {
+        dds_topic.topic_qos.max_tx_rate.set_value(configuration_->max_tx_rate.get_value());
+    }
+
+    if (!dds_topic.topic_qos.downsampling.is_set() && configuration_->downsampling.is_set())
+    {
+        dds_topic.topic_qos.downsampling.set_value(configuration_->downsampling.get_value());
     }
 }
 

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -324,6 +324,10 @@ bool CommonParticipant::is_rtps_kind() const noexcept
     return true;
 }
 
+core::types::TopicQoS CommonParticipant::topic_qos() const noexcept {
+    return configuration_->topic_qos;
+}
+
 void CommonParticipant::create_participant_(
         const core::types::DomainId& domain,
         const fastrtps::rtps::RTPSParticipantAttributes& participant_attributes)
@@ -361,10 +365,7 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
         return std::make_shared<BlankWriter>();
     }
 
-    // Make a copy to modify the Topic QoS
-    core::types::DdsTopic dds_topic = *dds_topic_ptr;
-
-    set_topic_qos_(dds_topic);
+    const core::types::DdsTopic& dds_topic = *dds_topic_ptr;
 
     if (topic.internal_type_discriminator() == core::types::INTERNAL_TOPIC_TYPE_RPC)
     {
@@ -424,10 +425,7 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
         return std::make_shared<BlankReader>();
     }
 
-    // Make a copy to modify the Topic QoS
-    core::types::DdsTopic dds_topic = *dds_topic_ptr;
-
-    set_topic_qos_(dds_topic);
+    const core::types::DdsTopic& dds_topic = *dds_topic_ptr;
 
     if (topic.internal_type_discriminator() == core::types::INTERNAL_TOPIC_TYPE_RPC)
     {
@@ -474,25 +472,6 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
         logDevError(DDSPIPE_RTPS_PARTICIPANT, "Incorrect dds Topic in Reader creation.");
         return std::make_shared<BlankReader>();
     }
-}
-
-void CommonParticipant::set_topic_qos_(
-        core::types::DdsTopic& dds_topic) noexcept
-{
-    // The Topic QoS are now set to the values in Specs on the level DEFAULT.
-    // They will remain as configured in specs unless they are overriden.
-
-    // 1. Manual Topic QoS.
-    for (const auto& manual_topic : manual_topics)
-    {
-        if (manual_topic->matches(dds_topic))
-        {
-            dds_topic.topic_qos.set_qos(manual_topic->topic_qos);
-        }
-    }
-
-    // 2. Participant Topic QoS.
-    dds_topic.topic_qos.set_qos(configuration_->topic_qos);
 }
 
 fastrtps::rtps::RTPSParticipantAttributes

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -324,7 +324,8 @@ bool CommonParticipant::is_rtps_kind() const noexcept
     return true;
 }
 
-core::types::TopicQoS CommonParticipant::topic_qos() const noexcept {
+core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
+{
     return configuration_->topic_qos;
 }
 

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -422,11 +422,20 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
 
     core::types::DdsTopic dds_topic = *dds_topic_ptr;
 
-    if (!dds_topic.topic_qos.max_reception_rate.is_set() && configuration_->max_reception_rate.is_set())
+    for (const auto& manual_topic : manual_topics)
+    {
+        if (manual_topic->matches(dds_topic))
+        {
+            dds_topic.topic_qos.set_qos(manual_topic->topic_qos);
+            // dds_topic.topic_qos.max_rx_rate.set_value(manual_topic->max_rx_rate);
+        }
+    }
+
+    if (!dds_topic.topic_qos.max_rx_rate.is_set() && configuration_->max_rx_rate.is_set())
     {
         // The hirearchy level for the max reception rate is:
         // Topic > Participant > Specs > Default
-        dds_topic.topic_qos.max_reception_rate.set_value(configuration_->max_reception_rate.get_value());
+        dds_topic.topic_qos.max_rx_rate.set_value(configuration_->max_rx_rate.get_value());
     }
 
     if (!dds_topic.topic_qos.downsampling.is_set() && configuration_->downsampling.is_set())

--- a/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
@@ -31,10 +31,10 @@ const std::function<void()> BaseReader::DEFAULT_ON_DATA_AVAILABLE_CALLBACK =
 
 BaseReader::BaseReader(
         const core::types::ParticipantId& participant_id,
-        const float max_reception_rate /* = 0 */,
+        const float max_rx_rate /* = 0 */,
         const unsigned int downsampling /* = 1 */)
     : participant_id_(participant_id)
-    , max_reception_rate_(max_reception_rate)
+    , max_rx_rate_(max_rx_rate)
     , downsampling_(downsampling)
     , on_data_available_lambda_(DEFAULT_ON_DATA_AVAILABLE_CALLBACK)
     , on_data_available_lambda_set_(false)
@@ -42,9 +42,9 @@ BaseReader::BaseReader(
 {
     logDebug(DDSPIPE_BASEREADER, "Creating Reader " << *this << ".");
 
-    // Calculate min_intersample_period_ from topic's max_reception_rate only once to lighten hot path
-    assert(max_reception_rate_ >= 0);
-    min_intersample_period_ = std::chrono::nanoseconds((unsigned int)(1e9 / max_reception_rate_));
+    // Calculate min_intersample_period_ from topic's max_rx_rate only once to lighten hot path
+    assert(max_rx_rate_ >= 0);
+    min_intersample_period_ = std::chrono::nanoseconds((unsigned int)(1e9 / max_rx_rate_));
 }
 
 void BaseReader::enable() noexcept
@@ -132,7 +132,7 @@ bool BaseReader::can_accept_sample_() noexcept
     auto now = utils::now();
 
     // Max Reception Rate
-    if (max_reception_rate_ > 0)
+    if (max_rx_rate_ > 0)
     {
         auto threshold = last_received_ts_ + min_intersample_period_;
         if (now < threshold)

--- a/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
@@ -126,7 +126,7 @@ core::types::ParticipantId BaseReader::participant_id() const noexcept
     return participant_id_;
 }
 
-bool BaseReader::can_accept_sample_() noexcept
+bool BaseReader::should_accept_sample_() noexcept
 {
     // Get reception timestamp
     auto now = utils::now();

--- a/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
@@ -44,7 +44,11 @@ BaseReader::BaseReader(
 
     // Calculate min_intersample_period_ from topic's max_rx_rate only once to lighten hot path
     assert(max_rx_rate_ >= 0);
-    min_intersample_period_ = std::chrono::nanoseconds((unsigned int)(1e9 / max_rx_rate_));
+
+    if (max_rx_rate_ > 0)
+    {
+        min_intersample_period_ = std::chrono::nanoseconds((unsigned int)(1e9 / max_rx_rate_));
+    }
 }
 
 void BaseReader::enable() noexcept

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -92,7 +92,7 @@ void CommonReader::on_data_available(
 {
     logInfo(DDSPIPE_DDS_READER, "On data available in reader in " << participant_id_ << " for topic " << topic_ << ".");
 
-    if (can_accept_sample_())
+    if (should_accept_sample_())
     {
         on_data_available_();
     }
@@ -171,7 +171,7 @@ void CommonReader::enable_nts_() noexcept
 {
     // If the topic is reliable, the reader will keep the samples received when it was disabled.
     // However, if the topic is best_effort, the reader will discard the samples received when it was disabled.
-    if (topic_.topic_qos.is_reliable() && can_accept_sample_())
+    if (topic_.topic_qos.is_reliable() && should_accept_sample_())
     {
         on_data_available_();
     }

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -91,7 +91,11 @@ void CommonReader::on_data_available(
         fastdds::dds::DataReader* /* reader */)
 {
     logInfo(DDSPIPE_DDS_READER, "On data available in reader in " << participant_id_ << " for topic " << topic_ << ".");
-    on_data_available_();
+
+    if (can_accept_sample_())
+    {
+        on_data_available_();
+    }
 }
 
 CommonReader::CommonReader(
@@ -100,7 +104,7 @@ CommonReader::CommonReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity)
-    : BaseReader(participant_id)
+    : BaseReader(participant_id, topic.topic_qos.max_reception_rate, topic.topic_qos.downsampling)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(payload_pool)
@@ -167,7 +171,7 @@ void CommonReader::enable_nts_() noexcept
 {
     // If the topic is reliable, the reader will keep the samples received when it was disabled.
     // However, if the topic is best_effort, the reader will discard the samples received when it was disabled.
-    if (topic_.topic_qos.is_reliable())
+    if (topic_.topic_qos.is_reliable() && can_accept_sample_())
     {
         on_data_available_();
     }

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -104,7 +104,7 @@ CommonReader::CommonReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity)
-    : BaseReader(participant_id, topic.topic_qos.max_reception_rate, topic.topic_qos.downsampling)
+    : BaseReader(participant_id, topic.topic_qos.max_rx_rate, topic.topic_qos.downsampling)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(payload_pool)

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -168,20 +168,6 @@ void CommonReader::enable_nts_() noexcept
     }
 }
 
-bool CommonReader::should_accept_change_(
-        const fastdds::dds::SampleInfo& info) noexcept
-{
-    // Reject samples sent by a Writer from the same Participant this Reader belongs to
-    if (detail::come_from_same_participant_(
-                detail::guid_from_instance_handle(info.publication_handle),
-                this->dds_participant_->guid()))
-    {
-        return false;
-    }
-
-    return should_accept_sample_();
-}
-
 fastdds::dds::SubscriberQos CommonReader::reckon_subscriber_qos_() const
 {
     fastdds::dds::SubscriberQos qos = dds_participant_->get_default_subscriber_qos();
@@ -233,6 +219,20 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
     }
 
     return qos;
+}
+
+bool CommonReader::should_accept_change_(
+        const fastdds::dds::SampleInfo& info) noexcept
+{
+    // Reject samples sent by a Writer from the same Participant this Reader belongs to
+    if (detail::come_from_same_participant_(
+                detail::guid_from_instance_handle(info.publication_handle),
+                this->dds_participant_->guid()))
+    {
+        return false;
+    }
+
+    return should_accept_sample_();
 }
 
 void CommonReader::fill_received_data_(

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -144,8 +144,8 @@ utils::ReturnCode CommonReader::take_nts_(
             return ret;
         }
 
-        // Check if the change is acceptable
-        if (should_accept_change_(info))
+        // Check if the sample is acceptable
+        if (should_accept_sample_(info))
         {
             break;
         }
@@ -221,7 +221,7 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
     return qos;
 }
 
-bool CommonReader::should_accept_change_(
+bool CommonReader::should_accept_sample_(
         const fastdds::dds::SampleInfo& info) noexcept
 {
     // Reject samples sent by a Writer from the same Participant this Reader belongs to
@@ -232,7 +232,7 @@ bool CommonReader::should_accept_change_(
         return false;
     }
 
-    return should_accept_sample_();
+    return BaseReader::should_accept_sample_();
 }
 
 void CommonReader::fill_received_data_(

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -168,7 +168,8 @@ void CommonReader::enable_nts_() noexcept
     }
 }
 
-bool CommonReader::should_accept_change_(const fastdds::dds::SampleInfo& info) noexcept
+bool CommonReader::should_accept_change_(
+        const fastdds::dds::SampleInfo& info) noexcept
 {
     // Reject samples sent by a Writer from the same Participant this Reader belongs to
     if (detail::come_from_same_participant_(

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -217,7 +217,7 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
             ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
             : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
 
-    if (topic_.topic_qos.history_depth == 0)
+    if (topic_.topic_qos.history_depth == 0U)
     {
         qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
     }

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -41,7 +41,7 @@ CommonReader::CommonReader(
         const fastrtps::rtps::ReaderAttributes& reader_attributes,
         const fastrtps::TopicAttributes& topic_attributes,
         const fastrtps::ReaderQos& reader_qos)
-    : BaseReader(participant_id, topic.topic_qos.max_reception_rate, topic.topic_qos.downsampling)
+    : BaseReader(participant_id, topic.topic_qos.max_rx_rate, topic.topic_qos.downsampling)
     , rtps_participant_(rtps_participant)
     , payload_pool_(payload_pool)
     , topic_(topic)

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -255,9 +255,6 @@ void CommonReader::enable_nts_() noexcept
 bool CommonReader::should_accept_change_(
         const fastrtps::rtps::CacheChange_t* change) noexcept
 {
-    // Get reception timestamp
-    auto now = utils::now();
-
     // Reject samples sent by a Writer from the same Participant this Reader belongs to
     if (come_from_this_participant_(change))
     {

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -17,7 +17,6 @@
 
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/Log.hpp>
-#include <cpp_utils/math/math_extension.hpp>
 
 #include <ddspipe_core/interface/IRoutingData.hpp>
 #include <ddspipe_core/types/data/RtpsPayloadData.hpp>
@@ -253,7 +252,7 @@ void CommonReader::enable_nts_() noexcept
     }
 }
 
-bool CommonReader::can_accept_change_(
+bool CommonReader::should_accept_change_(
         const fastrtps::rtps::CacheChange_t* change) noexcept
 {
     // Get reception timestamp
@@ -265,7 +264,7 @@ bool CommonReader::can_accept_change_(
         return false;
     }
 
-    return can_accept_sample_();
+    return should_accept_sample_();
 }
 
 bool CommonReader::come_from_this_participant_(
@@ -380,7 +379,7 @@ void CommonReader::onNewCacheChangeAdded(
         fastrtps::rtps::RTPSReader* reader,
         const fastrtps::rtps::CacheChange_t* const change) noexcept
 {
-    if (can_accept_change_(change))
+    if (should_accept_change_(change))
     {
         // Do not remove previous received changes so they can be read when the reader is enabled
         if (enabled_)

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -405,7 +405,11 @@ void CommonReader::onNewCacheChangeAdded(
             "Rejected received data in reader " << *this << ".");
 
         // Change rejected, do not send it forward and remove it
-        // TODO: do this more elegant
+        // TODO: do this more elegantly
+
+        // WARNING: Removing an unacceptable change here is valid given that Fast-DDS internal reader's mutex is locked.
+        // If the mutex wasn't locked, the track's transmit thread could take an unacceptable sample before it gets
+        // deleted here.
         reader->getHistory()->remove_change((fastrtps::rtps::CacheChange_t*)change);
     }
 }

--- a/ddspipe_participants/src/cpp/testing/entities/mock_entities.cpp
+++ b/ddspipe_participants/src/cpp/testing/entities/mock_entities.cpp
@@ -207,6 +207,12 @@ core::types::TopicInternalTypeDiscriminator MockTopic::internal_type_discriminat
     return INTERNAL_TOPIC_TYPE_MOCK_TEST;
 }
 
+utils::Heritable<core::ITopic> MockTopic::copy() const noexcept
+{
+    MockTopic topic = *this;
+    return utils::Heritable<MockTopic>::make_heritable(topic);
+}
+
 core::types::TopicInternalTypeDiscriminator MockRoutingData::internal_type_discriminator() const noexcept
 {
     return INTERNAL_TOPIC_TYPE_MOCK_TEST;

--- a/ddspipe_participants/src/cpp/utils/utils.cpp
+++ b/ddspipe_participants/src/cpp/utils/utils.cpp
@@ -38,15 +38,15 @@ core::types::Endpoint create_common_endpoint_from_info_(
 
     // Parse TopicQoS
     // Durability
-    endpoint.topic.topic_qos.durability_qos = info.info.m_qos.m_durability.durabilityKind();
+    endpoint.topic.topic_qos.durability_qos.set_value(info.info.m_qos.m_durability.durabilityKind());
     // Reliability
     if (info.info.m_qos.m_reliability.kind == fastdds::dds::BEST_EFFORT_RELIABILITY_QOS)
     {
-        endpoint.topic.topic_qos.reliability_qos = fastrtps::rtps::BEST_EFFORT;
+        endpoint.topic.topic_qos.reliability_qos.set_value(fastrtps::rtps::BEST_EFFORT);
     }
     else if (info.info.m_qos.m_reliability.kind == fastdds::dds::RELIABLE_RELIABILITY_QOS)
     {
-        endpoint.topic.topic_qos.reliability_qos = fastrtps::rtps::RELIABLE;
+        endpoint.topic.topic_qos.reliability_qos.set_value(fastrtps::rtps::RELIABLE);
     }
     else
     {
@@ -55,11 +55,11 @@ core::types::Endpoint create_common_endpoint_from_info_(
                 "Invalid ReliabilityQoS value found while parsing DiscoveryInfo for Endpoint creation.");
     }
     // Set Topic with Partitions
-    endpoint.topic.topic_qos.use_partitions = !info.info.m_qos.m_partition.empty();
+    endpoint.topic.topic_qos.use_partitions.set_value(!info.info.m_qos.m_partition.empty());
     // Set Topic with ownership
-    endpoint.topic.topic_qos.ownership_qos = info.info.m_qos.m_ownership.kind;
+    endpoint.topic.topic_qos.ownership_qos.set_value(info.info.m_qos.m_ownership.kind);
     // Set Topic key
-    endpoint.topic.topic_qos.keyed = info.info.topicKind() == eprosima::fastrtps::rtps::TopicKind_t::WITH_KEY;
+    endpoint.topic.topic_qos.keyed.set_value(info.info.topicKind() == eprosima::fastrtps::rtps::TopicKind_t::WITH_KEY);
 
     // Parse Topic
     core::types::DdsTopic info_topic;

--- a/ddspipe_participants/src/cpp/writer/auxiliar/BaseWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/auxiliar/BaseWriter.cpp
@@ -31,7 +31,11 @@ BaseWriter::BaseWriter(
 
     // Calculate min_intersample_period_ from topic's max_tx_rate only once to lighten hot path
     assert(max_tx_rate_ >= 0);
-    min_intersample_period_ = std::chrono::nanoseconds((unsigned int)(1e9 / max_tx_rate_));
+
+    if (max_tx_rate_ > 0)
+    {
+        min_intersample_period_ = std::chrono::nanoseconds((unsigned int)(1e9 / max_tx_rate_));
+    }
 }
 
 void BaseWriter::enable() noexcept
@@ -69,7 +73,7 @@ utils::ReturnCode BaseWriter::write(
 
     if (enabled_.load())
     {
-        if (!can_send_sample_())
+        if (!should_send_sample_())
         {
             return utils::ReturnCode::RETCODE_OK;
         }
@@ -97,7 +101,7 @@ void BaseWriter::disable_() noexcept
     // It does nothing. Override this method so it has functionality.
 }
 
-bool BaseWriter::can_send_sample_() noexcept
+bool BaseWriter::should_send_sample_() noexcept
 {
     // Get transmission timestamp
     auto now = utils::now();

--- a/ddspipe_participants/src/cpp/writer/auxiliar/BaseWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/auxiliar/BaseWriter.cpp
@@ -21,11 +21,17 @@ namespace ddspipe {
 namespace participants {
 
 BaseWriter::BaseWriter(
-        const core::types::ParticipantId& participant_id)
+        const core::types::ParticipantId& participant_id,
+        const float max_tx_rate /* = 0 */)
     : participant_id_(participant_id)
+    , max_tx_rate_(max_tx_rate)
     , enabled_(false)
 {
     logDebug(DDSPIPE_BASEWRITER, "Creating Writer " << *this << ".");
+
+    // Calculate min_intersample_period_ from topic's max_tx_rate only once to lighten hot path
+    assert(max_tx_rate_ >= 0);
+    min_intersample_period_ = std::chrono::nanoseconds((unsigned int)(1e9 / max_tx_rate_));
 }
 
 void BaseWriter::enable() noexcept
@@ -63,7 +69,15 @@ utils::ReturnCode BaseWriter::write(
 
     if (enabled_.load())
     {
-        return write_nts_(data);
+        if (!can_send_sample_())
+        {
+            return utils::ReturnCode::RETCODE_OK;
+        }
+        else
+        {
+            return write_nts_(data);
+        }
+
     }
     else
     {
@@ -81,6 +95,27 @@ void BaseWriter::enable_() noexcept
 void BaseWriter::disable_() noexcept
 {
     // It does nothing. Override this method so it has functionality.
+}
+
+bool BaseWriter::can_send_sample_() noexcept
+{
+    // Get reception timestamp
+    auto now = utils::now();
+
+    // Max Transmission Rate
+    if (max_tx_rate_ > 0)
+    {
+        auto threshold = last_sent_ts_ + min_intersample_period_;
+        if (now < threshold)
+        {
+            return false;
+        }
+    }
+
+    // All filters passed -> Update last received timestamp with this sample's reception timestamp
+    last_sent_ts_ = now;
+
+    return true;
 }
 
 std::ostream& operator <<(

--- a/ddspipe_participants/src/cpp/writer/auxiliar/BaseWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/auxiliar/BaseWriter.cpp
@@ -99,7 +99,7 @@ void BaseWriter::disable_() noexcept
 
 bool BaseWriter::can_send_sample_() noexcept
 {
-    // Get reception timestamp
+    // Get transmission timestamp
     auto now = utils::now();
 
     // Max Transmission Rate
@@ -112,7 +112,7 @@ bool BaseWriter::can_send_sample_() noexcept
         }
     }
 
-    // All filters passed -> Update last received timestamp with this sample's reception timestamp
+    // All filters passed -> Update last sent timestamp with this sample's transmission timestamp
     last_sent_ts_ = now;
 
     return true;

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -88,7 +88,7 @@ CommonWriter::CommonWriter(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity)
-    : BaseWriter(participant_id)
+    : BaseWriter(participant_id, topic.topic_qos.max_tx_rate)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(payload_pool)
@@ -160,7 +160,7 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
             ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
             : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
 
-    if (topic_.topic_qos.history_depth == 0)
+    if (topic_.topic_qos.history_depth == 0U)
     {
         qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
     }

--- a/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
@@ -48,7 +48,7 @@ CommonWriter::CommonWriter(
         const fastrtps::TopicAttributes& topic_attributes,
         const fastrtps::WriterQos& writer_qos,
         const utils::PoolConfiguration& pool_configuration)
-    : BaseWriter(participant_id)
+    : BaseWriter(participant_id, topic.topic_qos.max_tx_rate)
     , rtps_participant_(rtps_participant)
     , repeater_(repeater)
     , topic_(topic)

--- a/ddspipe_participants/test/blackbox/mock_core/DdsPipeCommunicationMockTest.cpp
+++ b/ddspipe_participants/test/blackbox/mock_core/DdsPipeCommunicationMockTest.cpp
@@ -17,6 +17,7 @@
 
 #include <cpp_utils/time/time_utils.hpp>
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/core/DdsPipe.hpp>
 #include <ddspipe_core/dynamic/AllowedTopicList.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
@@ -69,7 +70,10 @@ TEST(DdsPipeCommunicationMockTest, mock_communication_trivial)
     part_db->add_participant(part_2_id, part_2);
 
     // Create DDS Pipe
+    core::DdsPipeConfiguration ddspipe_configuration;
+
     core::DdsPipe ddspipe(
+        ddspipe_configuration,
         std::make_shared<core::AllowedTopicList>(),
         std::make_shared<core::DiscoveryDatabase>(),
         std::make_shared<core::FastPayloadPool>(),
@@ -137,7 +141,10 @@ TEST(DdsPipeCommunicationMockTest, mock_communication_before_enabling)
     part_db->add_participant(part_2_id, part_2);
 
     // Create DDS Pipe
+    core::DdsPipeConfiguration ddspipe_configuration;
+
     core::DdsPipe ddspipe(
+        ddspipe_configuration,
         std::make_shared<core::AllowedTopicList>(),
         std::make_shared<core::DiscoveryDatabase>(),
         std::make_shared<core::FastPayloadPool>(),
@@ -236,7 +243,10 @@ TEST(DdsPipeCommunicationMockTest, mock_communication_topic_discovery)
     part_db->add_participant(part_2_id, part_2);
 
     // Create DDS Pipe
+    core::DdsPipeConfiguration ddspipe_configuration;
+
     core::DdsPipe ddspipe(
+        ddspipe_configuration,
         std::make_shared<core::AllowedTopicList>(),
         disc_db,
         std::make_shared<core::FastPayloadPool>(),
@@ -325,7 +335,10 @@ TEST(DdsPipeCommunicationMockTest, mock_communication_topic_allow)
     // );
 
     // Create DDS Pipe
+    core::DdsPipeConfiguration ddspipe_configuration;
+
     core::DdsPipe ddspipe(
+        ddspipe_configuration,
         atl,
         std::make_shared<core::DiscoveryDatabase>(),
         std::make_shared<core::FastPayloadPool>(),
@@ -406,7 +419,10 @@ TEST(DdsPipeCommunicationMockTest, mock_communication_multiple_participant_topic
     }
 
     // Create DDS Pipe
+    core::DdsPipeConfiguration ddspipe_configuration;
+
     core::DdsPipe ddspipe(
+        ddspipe_configuration,
         std::make_shared<core::AllowedTopicList>(),
         std::make_shared<core::DiscoveryDatabase>(),
         std::make_shared<core::FastPayloadPool>(),

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -17,6 +17,7 @@
 
 #include <cpp_utils/time/time_utils.hpp>
 
+#include <ddspipe_core/configuration/DdsPipeConfiguration.hpp>
 #include <ddspipe_core/core/DdsPipe.hpp>
 #include <ddspipe_core/efficiency/payload/FastPayloadPool.hpp>
 
@@ -210,7 +211,10 @@ TEST(ParticipantsCreationgTest, ddspipe_all_creation_builtin_topic)
             eprosima::utils::Heritable<core::types::DdsTopic>::make_heritable(topic_2);
 
     // Create DDS Pipe
+    core::DdsPipeConfiguration ddspipe_configuration;
+
     core::DdsPipe ddspipe(
+        ddspipe_configuration,
         atl,
         discovery_database,
         payload_pool,

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -121,7 +121,6 @@ TEST(ParticipantsCreationgTest, creation_trivial)
 TEST(ParticipantsCreationgTest, ddspipe_all_creation_builtin_topic)
 {
     // Auxiliar objects
-    std::shared_ptr<core::AllowedTopicList> atl(new core::AllowedTopicList());
     std::shared_ptr<core::DiscoveryDatabase> discovery_database(new core::DiscoveryDatabase());
     std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
     std::shared_ptr<core::ParticipantsDatabase> part_db(new core::ParticipantsDatabase());
@@ -212,19 +211,19 @@ TEST(ParticipantsCreationgTest, ddspipe_all_creation_builtin_topic)
 
     // Create DDS Pipe
     core::DdsPipeConfiguration ddspipe_configuration;
+    ddspipe_configuration.builtin_topics.insert(htopic_1);
+    ddspipe_configuration.builtin_topics.insert(htopic_2);
+    ddspipe_configuration.init_enabled = true;
 
     core::DdsPipe ddspipe(
         ddspipe_configuration,
-        atl,
         discovery_database,
         payload_pool,
         part_db,
-        thread_pool,
-        {htopic_1, htopic_2},
-        true
+        thread_pool
         );
 
-    // Let everything destroy by itself
+    // Let everything destroy itself
 }
 
 int main(

--- a/ddspipe_yaml/include/ddspipe_yaml/YamlReader.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/YamlReader.hpp
@@ -56,7 +56,7 @@ enum YamlReaderVersion
     V_1_0,
 
     /**
-     * @brief  Version 2.0
+     * @brief Version 2.0
      *
      * @version 0.3.0
      *
@@ -68,7 +68,7 @@ enum YamlReaderVersion
     V_2_0,
 
     /**
-     * @brief  Version 3.0
+     * @brief Version 3.0
      *
      * @version 0.4.0
      *
@@ -78,7 +78,7 @@ enum YamlReaderVersion
     V_3_0,
 
     /**
-     * @brief  Latest version.
+     * @brief Version 3.1.
      *
      * @version 0.5.0
      *
@@ -86,6 +86,21 @@ enum YamlReaderVersion
      * - Add xml participant
      */
     V_3_1,
+
+    /**
+     * @brief Latest version.
+     *
+     * @version 0.6.0
+     *
+     * - Forwarding Routes.
+     * - Remove Unused Entities.
+     * - Manual Topics.
+     * - Max Transmission Rate.
+     * - Max Reception Rate.
+     * - Downsampling.
+     * - Rename the `max-depth` under the `specs` tag to `history-depth`.
+     */
+    V_4_0,
 
     /**
      * @brief  Main version.

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -49,6 +49,7 @@ constexpr const char* QOS_OWNERSHIP_TAG("ownership"); //! The Endpoints of that 
 constexpr const char* QOS_KEYED_TAG("keyed"); //! Kind of a topic (with or without key)
 constexpr const char* QOS_DOWNSAMPLING_TAG("downsampling"); //! Topic specific downsampling factor
 constexpr const char* QOS_MAX_RX_RATE_TAG("max-rx-rate"); //! Topic specific max reception rate
+constexpr const char* QOS_MAX_TX_RATE_TAG("max-tx-rate"); //! Topic specific max transmission rate
 
 // Participant related tags
 constexpr const char* PARTICIPANT_KIND_TAG("kind");   //! Participant Kind
@@ -57,6 +58,7 @@ constexpr const char* COLLECTION_PARTICIPANTS_TAG("participants"); //! TODO: add
 constexpr const char* IS_REPEATER_TAG("repeater");   //! Is participant a repeater
 constexpr const char* PARTICIPANT_DOWNSAMPLING_TAG("downsampling");   //! Participant specific downsampling factor
 constexpr const char* PARTICIPANT_MAX_RX_RATE_TAG("max-rx-rate");   //! Participant specific max reception rate
+constexpr const char* PARTICIPANT_MAX_TX_RATE_TAG("max-tx-rate");   //! Participant specific max transmission rate
 
 // Echo related tags
 constexpr const char* ECHO_DATA_TAG("data");            //! Echo Data received
@@ -140,6 +142,7 @@ constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to co
 constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (number of stored cache changes) for RTPS History instances
 constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
 constexpr const char* MAX_RX_RATE_TAG("max-rx-rate"); //! Process up to *max_rx_rate* samples in a 1 second bin
+constexpr const char* MAX_TX_RATE_TAG("max-tx-rate"); //! Transmit up to *max_tx_rate* samples in a 1 second bin
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
 

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -31,10 +31,14 @@ constexpr const char* VERSION_TAG_V_3_1("v3.1");    //! Version v3.1
 // Topics related tags
 constexpr const char* ALLOWLIST_TAG("allowlist");     //! List of allowed topics
 constexpr const char* BLOCKLIST_TAG("blocklist");     //! List of blocked topics
-constexpr const char* BUILTIN_TAG("builtin-topics");  //! List of builtin topics
-constexpr const char* TOPIC_NAME_TAG("name");         //! Name of a topic
-constexpr const char* TOPIC_TYPE_NAME_TAG("type");    //! Type name of a topic
-constexpr const char* TOPIC_QOS_TAG("qos");           //! QoS of a topic
+
+constexpr const char* BUILTIN_TAG("builtin-topics");          //! List of builtin topics
+
+constexpr const char* TOPICS_TAG("topics");                     //! List of manual topics to configure
+constexpr const char* TOPIC_NAME_TAG("name");                   //! Name of a topic
+constexpr const char* TOPIC_TYPE_NAME_TAG("type");              //! Type name of a topic
+constexpr const char* TOPIC_QOS_TAG("qos");                     //! QoS of a topic
+constexpr const char* TOPIC_PARTICIPANTS_TAG("participants");   //! List of participants of a topic
 
 // QoS related tags
 constexpr const char* QOS_RELIABLE_TAG("reliability"); //! The Endpoints of that topic will be configured as RELIABLE

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -56,9 +56,7 @@ constexpr const char* PARTICIPANT_KIND_TAG("kind");   //! Participant Kind
 constexpr const char* PARTICIPANT_NAME_TAG("name");   //! Participant Name
 constexpr const char* COLLECTION_PARTICIPANTS_TAG("participants"); //! TODO: add comment
 constexpr const char* IS_REPEATER_TAG("repeater");   //! Is participant a repeater
-constexpr const char* PARTICIPANT_MAX_TX_RATE_TAG("max-tx-rate");   //! Participant specific max transmission rate
-constexpr const char* PARTICIPANT_MAX_RX_RATE_TAG("max-rx-rate");   //! Participant specific max reception rate
-constexpr const char* PARTICIPANT_DOWNSAMPLING_TAG("downsampling");   //! Participant specific downsampling factor
+constexpr const char* PARTICIPANT_QOS_TAG("qos");    //! Participant Topic QoSs
 
 // Echo related tags
 constexpr const char* ECHO_DATA_TAG("data");            //! Echo Data received

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -51,6 +51,8 @@ constexpr const char* PARTICIPANT_KIND_TAG("kind");   //! Participant Kind
 constexpr const char* PARTICIPANT_NAME_TAG("name");   //! Participant Name
 constexpr const char* COLLECTION_PARTICIPANTS_TAG("participants"); //! TODO: add comment
 constexpr const char* IS_REPEATER_TAG("repeater");   //! Is participant a repeater
+constexpr const char* PARTICIPANT_DOWNSAMPLING_TAG("downsampling");   //! Participant specific downsampling factor
+constexpr const char* PARTICIPANT_MAX_RECEPTION_RATE_TAG("max-reception-rate");   //! Participant specific max reception rate
 
 // Echo related tags
 constexpr const char* ECHO_DATA_TAG("data");            //! Echo Data received

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -47,18 +47,18 @@ constexpr const char* QOS_HISTORY_DEPTH_TAG("depth"); //! The Endpoints of that 
 constexpr const char* QOS_PARTITION_TAG("partitions"); //! The Endpoints of that topic will be configured with partitions
 constexpr const char* QOS_OWNERSHIP_TAG("ownership"); //! The Endpoints of that topic will be configured with partitions
 constexpr const char* QOS_KEYED_TAG("keyed"); //! Kind of a topic (with or without key)
-constexpr const char* QOS_DOWNSAMPLING_TAG("downsampling"); //! Topic specific downsampling factor
-constexpr const char* QOS_MAX_RX_RATE_TAG("max-rx-rate"); //! Topic specific max reception rate
 constexpr const char* QOS_MAX_TX_RATE_TAG("max-tx-rate"); //! Topic specific max transmission rate
+constexpr const char* QOS_MAX_RX_RATE_TAG("max-rx-rate"); //! Topic specific max reception rate
+constexpr const char* QOS_DOWNSAMPLING_TAG("downsampling"); //! Topic specific downsampling factor
 
 // Participant related tags
 constexpr const char* PARTICIPANT_KIND_TAG("kind");   //! Participant Kind
 constexpr const char* PARTICIPANT_NAME_TAG("name");   //! Participant Name
 constexpr const char* COLLECTION_PARTICIPANTS_TAG("participants"); //! TODO: add comment
 constexpr const char* IS_REPEATER_TAG("repeater");   //! Is participant a repeater
-constexpr const char* PARTICIPANT_DOWNSAMPLING_TAG("downsampling");   //! Participant specific downsampling factor
-constexpr const char* PARTICIPANT_MAX_RX_RATE_TAG("max-rx-rate");   //! Participant specific max reception rate
 constexpr const char* PARTICIPANT_MAX_TX_RATE_TAG("max-tx-rate");   //! Participant specific max transmission rate
+constexpr const char* PARTICIPANT_MAX_RX_RATE_TAG("max-rx-rate");   //! Participant specific max reception rate
+constexpr const char* PARTICIPANT_DOWNSAMPLING_TAG("downsampling");   //! Participant specific downsampling factor
 
 // Echo related tags
 constexpr const char* ECHO_DATA_TAG("data");            //! Echo Data received
@@ -140,9 +140,9 @@ constexpr const char* TOPIC_ROUTES_TAG("topic-routes"); // Topic specific forwar
 constexpr const char* SPECS_TAG("specs"); //! Specs options for DDS Router configuration
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (number of stored cache changes) for RTPS History instances
-constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
-constexpr const char* MAX_RX_RATE_TAG("max-rx-rate"); //! Process up to *max_rx_rate* samples in a 1 second bin
 constexpr const char* MAX_TX_RATE_TAG("max-tx-rate"); //! Transmit up to *max_tx_rate* samples in a 1 second bin
+constexpr const char* MAX_RX_RATE_TAG("max-rx-rate"); //! Process up to *max_rx_rate* samples in a 1 second bin
+constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
 

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -56,7 +56,7 @@ constexpr const char* PARTICIPANT_KIND_TAG("kind");   //! Participant Kind
 constexpr const char* PARTICIPANT_NAME_TAG("name");   //! Participant Name
 constexpr const char* COLLECTION_PARTICIPANTS_TAG("participants"); //! TODO: add comment
 constexpr const char* IS_REPEATER_TAG("repeater");   //! Is participant a repeater
-constexpr const char* PARTICIPANT_QOS_TAG("qos");    //! Participant Topic QoSs
+constexpr const char* PARTICIPANT_QOS_TAG("qos");    //! Participant Topic QoS
 
 // Echo related tags
 constexpr const char* ECHO_DATA_TAG("data");            //! Echo Data received
@@ -139,7 +139,7 @@ constexpr const char* SPECS_TAG("specs"); //! Specs options for DDS Router confi
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
-constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoSs
+constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoS
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -44,7 +44,7 @@ constexpr const char* QOS_PARTITION_TAG("partitions"); //! The Endpoints of that
 constexpr const char* QOS_OWNERSHIP_TAG("ownership"); //! The Endpoints of that topic will be configured with partitions
 constexpr const char* QOS_KEYED_TAG("keyed"); //! Kind of a topic (with or without key)
 constexpr const char* QOS_DOWNSAMPLING_TAG("downsampling"); //! Topic specific downsampling factor
-constexpr const char* QOS_MAX_RECEPTION_RATE_TAG("max-reception-rate"); //! Topic specific max reception rate
+constexpr const char* QOS_MAX_RX_RATE_TAG("max-rx-rate"); //! Topic specific max reception rate
 
 // Participant related tags
 constexpr const char* PARTICIPANT_KIND_TAG("kind");   //! Participant Kind
@@ -52,7 +52,7 @@ constexpr const char* PARTICIPANT_NAME_TAG("name");   //! Participant Name
 constexpr const char* COLLECTION_PARTICIPANTS_TAG("participants"); //! TODO: add comment
 constexpr const char* IS_REPEATER_TAG("repeater");   //! Is participant a repeater
 constexpr const char* PARTICIPANT_DOWNSAMPLING_TAG("downsampling");   //! Participant specific downsampling factor
-constexpr const char* PARTICIPANT_MAX_RECEPTION_RATE_TAG("max-reception-rate");   //! Participant specific max reception rate
+constexpr const char* PARTICIPANT_MAX_RX_RATE_TAG("max-rx-rate");   //! Participant specific max reception rate
 
 // Echo related tags
 constexpr const char* ECHO_DATA_TAG("data");            //! Echo Data received
@@ -135,7 +135,7 @@ constexpr const char* SPECS_TAG("specs"); //! Specs options for DDS Router confi
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (number of stored cache changes) for RTPS History instances
 constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
-constexpr const char* MAX_RECEPTION_RATE_TAG("max-reception-rate"); //! Process up to *max_reception_rate* samples in a 1 second bin
+constexpr const char* MAX_RX_RATE_TAG("max-rx-rate"); //! Process up to *max_rx_rate* samples in a 1 second bin
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
 

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -27,6 +27,7 @@ constexpr const char* VERSION_TAG_V_1_0("v1.0");    //! Version v1.0
 constexpr const char* VERSION_TAG_V_2_0("v2.0");    //! Version v2.0
 constexpr const char* VERSION_TAG_V_3_0("v3.0");    //! Version v3.0
 constexpr const char* VERSION_TAG_V_3_1("v3.1");    //! Version v3.1
+constexpr const char* VERSION_TAG_V_4_0("v4.0");    //! Version v4.0
 
 // Topics related tags
 constexpr const char* ALLOWLIST_TAG("allowlist");     //! List of allowed topics
@@ -136,10 +137,10 @@ constexpr const char* TOPIC_ROUTES_TAG("topic-routes"); // Topic specific forwar
 
 // Advanced configuration
 constexpr const char* SPECS_TAG("specs"); //! Specs options for DDS Router configuration
+constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoS
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
-constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoS
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -43,7 +43,7 @@ constexpr const char* TOPIC_PARTICIPANTS_TAG("participants");   //! List of part
 // QoS related tags
 constexpr const char* QOS_RELIABLE_TAG("reliability"); //! The Endpoints of that topic will be configured as RELIABLE
 constexpr const char* QOS_TRANSIENT_TAG("durability"); //! The Endpoints of that topic will be configured as TRANSIENT_LOCAL
-constexpr const char* QOS_HISTORY_DEPTH_TAG("depth"); //! The Endpoints of that topic will be configured as this History Depth
+constexpr const char* QOS_HISTORY_DEPTH_TAG("history-depth"); //! The Endpoints of that topic will be configured as this History Depth
 constexpr const char* QOS_PARTITION_TAG("partitions"); //! The Endpoints of that topic will be configured with partitions
 constexpr const char* QOS_OWNERSHIP_TAG("ownership"); //! The Endpoints of that topic will be configured with partitions
 constexpr const char* QOS_KEYED_TAG("keyed"); //! Kind of a topic (with or without key)
@@ -137,7 +137,6 @@ constexpr const char* TOPIC_ROUTES_TAG("topic-routes"); // Topic specific forwar
 // Advanced configuration
 constexpr const char* SPECS_TAG("specs"); //! Specs options for DDS Router configuration
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
-constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (number of stored cache changes) for RTPS History instances
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
 constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoSs

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -138,11 +138,9 @@ constexpr const char* TOPIC_ROUTES_TAG("topic-routes"); // Topic specific forwar
 constexpr const char* SPECS_TAG("specs"); //! Specs options for DDS Router configuration
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* MAX_HISTORY_DEPTH_TAG("max-depth"); //! Maximum size (number of stored cache changes) for RTPS History instances
-constexpr const char* MAX_TX_RATE_TAG("max-tx-rate"); //! Transmit up to *max_tx_rate* samples in a 1 second bin
-constexpr const char* MAX_RX_RATE_TAG("max-rx-rate"); //! Process up to *max_rx_rate* samples in a 1 second bin
-constexpr const char* DOWNSAMPLING_TAG("downsampling"); //! Keep 1 out of every *downsampling* samples received
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
+constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoSs
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -172,6 +172,12 @@ void YamlReader::fill(
     {
         object.max_rx_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_RX_RATE_TAG, version));
     }
+
+    // Optional max transmission rate
+    if (YamlReader::is_tag_present(yml, PARTICIPANT_MAX_TX_RATE_TAG))
+    {
+        object.max_tx_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_TX_RATE_TAG, version));
+    }
 }
 
 template <>

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -160,6 +160,18 @@ void YamlReader::fill(
     {
         object.ignore_participant_flags = core::types::IgnoreParticipantFlags::no_filter;
     }
+
+    // Optional downsampling
+    if (YamlReader::is_tag_present(yml, PARTICIPANT_DOWNSAMPLING_TAG))
+    {
+        object.downsampling.set_value(YamlReader::get<unsigned int>(yml, PARTICIPANT_DOWNSAMPLING_TAG, version));
+    }
+
+    // Optional max reception rate
+    if (YamlReader::is_tag_present(yml, PARTICIPANT_MAX_RECEPTION_RATE_TAG))
+    {
+        object.max_reception_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_RECEPTION_RATE_TAG, version));
+    }
 }
 
 template <>

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -162,21 +162,9 @@ void YamlReader::fill(
     }
 
     // Optional downsampling
-    if (YamlReader::is_tag_present(yml, PARTICIPANT_DOWNSAMPLING_TAG))
+    if (YamlReader::is_tag_present(yml, TOPIC_QOS_TAG))
     {
-        object.downsampling.set_value(YamlReader::get<unsigned int>(yml, PARTICIPANT_DOWNSAMPLING_TAG, version));
-    }
-
-    // Optional max reception rate
-    if (YamlReader::is_tag_present(yml, PARTICIPANT_MAX_RX_RATE_TAG))
-    {
-        object.max_rx_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_RX_RATE_TAG, version));
-    }
-
-    // Optional max transmission rate
-    if (YamlReader::is_tag_present(yml, PARTICIPANT_MAX_TX_RATE_TAG))
-    {
-        object.max_tx_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_TX_RATE_TAG, version));
+        fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, TOPIC_QOS_TAG), version);
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -161,10 +161,10 @@ void YamlReader::fill(
         object.ignore_participant_flags = core::types::IgnoreParticipantFlags::no_filter;
     }
 
-    // Optional Topic QoS
-    if (YamlReader::is_tag_present(yml, TOPIC_QOS_TAG))
+    // Optional Praticipant Topic QoSs
+    if (YamlReader::is_tag_present(yml, PARTICIPANT_QOS_TAG))
     {
-        fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, TOPIC_QOS_TAG), version);
+        fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, PARTICIPANT_QOS_TAG), version);
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -161,7 +161,7 @@ void YamlReader::fill(
         object.ignore_participant_flags = core::types::IgnoreParticipantFlags::no_filter;
     }
 
-    // Optional downsampling
+    // Optional Topic QoS
     if (YamlReader::is_tag_present(yml, TOPIC_QOS_TAG))
     {
         fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, TOPIC_QOS_TAG), version);

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -168,9 +168,9 @@ void YamlReader::fill(
     }
 
     // Optional max reception rate
-    if (YamlReader::is_tag_present(yml, PARTICIPANT_MAX_RECEPTION_RATE_TAG))
+    if (YamlReader::is_tag_present(yml, PARTICIPANT_MAX_RX_RATE_TAG))
     {
-        object.max_reception_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_RECEPTION_RATE_TAG, version));
+        object.max_rx_rate.set_value(YamlReader::get<float>(yml, PARTICIPANT_MAX_RX_RATE_TAG, version));
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -161,7 +161,7 @@ void YamlReader::fill(
         object.ignore_participant_flags = core::types::IgnoreParticipantFlags::no_filter;
     }
 
-    // Optional Praticipant Topic QoSs
+    // Optional Praticipant Topic QoS
     if (YamlReader::is_tag_present(yml, PARTICIPANT_QOS_TAG))
     {
         fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, PARTICIPANT_QOS_TAG), version);

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -473,7 +473,17 @@ void YamlReader::fill(
         object.type_name.set_value(get<std::string>(yml, TOPIC_TYPE_NAME_TAG, version));
     }
 
-    // TODO: decide whether we want to use QoS as filtering
+    // Optional QoS
+    if (is_tag_present(yml, TOPIC_QOS_TAG))
+    {
+        fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, TOPIC_QOS_TAG), version);
+    }
+
+    // Optional participants tag
+    if (is_tag_present(yml, TOPIC_PARTICIPANTS_TAG))
+    {
+        object.participants.set_value(get_set<ParticipantId>(yml, TOPIC_PARTICIPANTS_TAG, version));
+    }
 }
 
 template <>

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -354,11 +354,11 @@ void YamlReader::fill(
     {
         if (get<bool>(yml, QOS_TRANSIENT_TAG, version))
         {
-            object.durability_qos = eprosima::ddspipe::core::types::DurabilityKind::TRANSIENT_LOCAL;
+            object.durability_qos.set_value(eprosima::ddspipe::core::types::DurabilityKind::TRANSIENT_LOCAL);
         }
         else
         {
-            object.durability_qos = eprosima::ddspipe::core::types::DurabilityKind::VOLATILE;
+            object.durability_qos.set_value(eprosima::ddspipe::core::types::DurabilityKind::VOLATILE);
         }
     }
 
@@ -367,11 +367,11 @@ void YamlReader::fill(
     {
         if (get<bool>(yml, QOS_RELIABLE_TAG, version))
         {
-            object.reliability_qos = eprosima::ddspipe::core::types::ReliabilityKind::RELIABLE;
+            object.reliability_qos.set_value(eprosima::ddspipe::core::types::ReliabilityKind::RELIABLE);
         }
         else
         {
-            object.reliability_qos = eprosima::ddspipe::core::types::ReliabilityKind::BEST_EFFORT;
+            object.reliability_qos.set_value(eprosima::ddspipe::core::types::ReliabilityKind::BEST_EFFORT);
         }
     }
 
@@ -380,48 +380,48 @@ void YamlReader::fill(
     {
         if (get<bool>(yml, QOS_OWNERSHIP_TAG, version))
         {
-            object.ownership_qos = eprosima::ddspipe::core::types::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS;
+            object.ownership_qos.set_value(eprosima::ddspipe::core::types::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS);
         }
         else
         {
-            object.ownership_qos = eprosima::ddspipe::core::types::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+            object.ownership_qos.set_value(eprosima::ddspipe::core::types::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS);
         }
     }
 
     // Use partitions optional
     if (is_tag_present(yml, QOS_PARTITION_TAG))
     {
-        object.use_partitions = get<bool>(yml, QOS_PARTITION_TAG, version);
+        object.use_partitions.set_value(get<bool>(yml, QOS_PARTITION_TAG, version));
     }
 
     // History depth optional
     if (is_tag_present(yml, QOS_HISTORY_DEPTH_TAG))
     {
-        object.history_depth = get<HistoryDepthType>(yml, QOS_HISTORY_DEPTH_TAG, version);
+        object.history_depth.set_value(get<HistoryDepthType>(yml, QOS_HISTORY_DEPTH_TAG, version));
     }
 
     // Keyed optional
     if (is_tag_present(yml, QOS_KEYED_TAG))
     {
-        object.keyed = get<bool>(yml, QOS_KEYED_TAG, version);
+        object.keyed.set_value(get<bool>(yml, QOS_KEYED_TAG, version));
     }
 
     // Max Transmission Rate optional
     if (is_tag_present(yml, QOS_MAX_TX_RATE_TAG))
     {
-        object.max_tx_rate = get<float>(yml, QOS_MAX_TX_RATE_TAG, version);
+        object.max_tx_rate.set_value(get<float>(yml, QOS_MAX_TX_RATE_TAG, version));
     }
 
     // Max Reception Rate optional
     if (is_tag_present(yml, QOS_MAX_RX_RATE_TAG))
     {
-        object.max_rx_rate = get<float>(yml, QOS_MAX_RX_RATE_TAG, version);
+        object.max_rx_rate.set_value(get<float>(yml, QOS_MAX_RX_RATE_TAG, version));
     }
 
     // Downsampling optional
     if (is_tag_present(yml, QOS_DOWNSAMPLING_TAG))
     {
-        object.downsampling = get_positive_int(yml, QOS_DOWNSAMPLING_TAG);
+        object.downsampling.set_value(get_positive_int(yml, QOS_DOWNSAMPLING_TAG));
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -413,9 +413,9 @@ void YamlReader::fill(
     }
 
     // Max Reception Rate optional
-    if (is_tag_present(yml, QOS_MAX_RECEPTION_RATE_TAG))
+    if (is_tag_present(yml, QOS_MAX_RX_RATE_TAG))
     {
-        object.max_reception_rate = get<unsigned int>(yml, QOS_MAX_RECEPTION_RATE_TAG, version);
+        object.max_rx_rate = get<unsigned int>(yml, QOS_MAX_RX_RATE_TAG, version);
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -415,13 +415,13 @@ void YamlReader::fill(
     // Max Reception Rate optional
     if (is_tag_present(yml, QOS_MAX_RX_RATE_TAG))
     {
-        object.max_rx_rate = get<unsigned int>(yml, QOS_MAX_RX_RATE_TAG, version);
+        object.max_rx_rate = get<float>(yml, QOS_MAX_RX_RATE_TAG, version);
     }
 
     // Max Transmission Rate optional
     if (is_tag_present(yml, QOS_MAX_TX_RATE_TAG))
     {
-        object.max_tx_rate = get<unsigned int>(yml, QOS_MAX_TX_RATE_TAG, version);
+        object.max_tx_rate = get<float>(yml, QOS_MAX_TX_RATE_TAG, version);
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -417,6 +417,12 @@ void YamlReader::fill(
     {
         object.max_rx_rate = get<unsigned int>(yml, QOS_MAX_RX_RATE_TAG, version);
     }
+
+    // Max Transmission Rate optional
+    if (is_tag_present(yml, QOS_MAX_TX_RATE_TAG))
+    {
+        object.max_tx_rate = get<unsigned int>(yml, QOS_MAX_TX_RATE_TAG, version);
+    }
 }
 
 /************************

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -96,6 +96,7 @@ YamlReaderVersion YamlReader::get<YamlReaderVersion>(
                     {VERSION_TAG_V_2_0, YamlReaderVersion::V_2_0},
                     {VERSION_TAG_V_3_0, YamlReaderVersion::V_3_0},
                     {VERSION_TAG_V_3_1, YamlReaderVersion::V_3_1},
+                    {VERSION_TAG_V_4_0, YamlReaderVersion::V_4_0},
                 });
 }
 
@@ -411,13 +412,13 @@ void YamlReader::fill(
     // Max Transmission Rate optional
     if (is_tag_present(yml, QOS_MAX_TX_RATE_TAG))
     {
-        object.max_tx_rate.set_value(get<float>(yml, QOS_MAX_TX_RATE_TAG, version));
+        object.max_tx_rate.set_value(get_nonnegative_float(yml, QOS_MAX_TX_RATE_TAG));
     }
 
     // Max Reception Rate optional
     if (is_tag_present(yml, QOS_MAX_RX_RATE_TAG))
     {
-        object.max_rx_rate.set_value(get<float>(yml, QOS_MAX_RX_RATE_TAG, version));
+        object.max_rx_rate.set_value(get_nonnegative_float(yml, QOS_MAX_RX_RATE_TAG));
     }
 
     // Downsampling optional

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -27,6 +27,7 @@
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 #include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 #include <ddspipe_core/types/topic/filter/WildcardDdsFilterTopic.hpp>
+#include <ddspipe_core/types/topic/filter/ManualTopic.hpp>
 
 #include <ddspipe_participants/types/address/Address.hpp>
 #include <ddspipe_participants/types/address/DiscoveryServerConnectionAddress.hpp>
@@ -476,12 +477,6 @@ void YamlReader::fill(
     {
         fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, TOPIC_QOS_TAG), version);
     }
-
-    // Optional participants tag
-    if (is_tag_present(yml, TOPIC_PARTICIPANTS_TAG))
-    {
-        object.participants.set_value(get_set<ParticipantId>(yml, TOPIC_PARTICIPANTS_TAG, version));
-    }
 }
 
 template <>
@@ -492,6 +487,36 @@ WildcardDdsFilterTopic YamlReader::get(
 {
     WildcardDdsFilterTopic object;
     fill<WildcardDdsFilterTopic>(object, yml, version);
+    return object;
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
+void YamlReader::fill(
+        ManualTopic& object,
+        const Yaml& yml,
+        const YamlReaderVersion version)
+{
+    auto manual_topic = YamlReader::get<WildcardDdsFilterTopic>(yml, version);
+    object.first = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
+
+    // Optional participants tag
+    if (is_tag_present(yml, TOPIC_PARTICIPANTS_TAG))
+    {
+        object.second = get_set<ParticipantId>(yml, TOPIC_PARTICIPANTS_TAG, version);
+    }
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
+ManualTopic YamlReader::get(
+        const Yaml& yml,
+        const YamlReaderVersion version)
+{
+    auto topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable();
+    std::set<ParticipantId> participants;
+    ManualTopic object = std::make_pair(topic, participants);
+    fill<ManualTopic>(object, yml, version);
     return object;
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -655,8 +655,12 @@ std::ostream& operator <<(
             break;
 
         case V_3_1:
-        case LATEST:
             os << VERSION_TAG_V_3_1;
+            break;
+
+        case V_4_0:
+        case LATEST:
+            os << VERSION_TAG_V_4_0;
             break;
 
         default:

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -349,19 +349,6 @@ void YamlReader::fill(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
-    // Reliability optional
-    if (is_tag_present(yml, QOS_RELIABLE_TAG))
-    {
-        if (get<bool>(yml, QOS_RELIABLE_TAG, version))
-        {
-            object.reliability_qos = eprosima::ddspipe::core::types::ReliabilityKind::RELIABLE;
-        }
-        else
-        {
-            object.reliability_qos = eprosima::ddspipe::core::types::ReliabilityKind::BEST_EFFORT;
-        }
-    }
-
     // Durability optional
     if (is_tag_present(yml, QOS_TRANSIENT_TAG))
     {
@@ -375,22 +362,17 @@ void YamlReader::fill(
         }
     }
 
-    // History depth optional
-    if (is_tag_present(yml, QOS_HISTORY_DEPTH_TAG))
+    // Optional Reliability Tag
+    if (is_tag_present(yml, QOS_RELIABLE_TAG))
     {
-        object.history_depth = get<HistoryDepthType>(yml, QOS_HISTORY_DEPTH_TAG, version);
-    }
-
-    // Durability optional
-    if (is_tag_present(yml, QOS_PARTITION_TAG))
-    {
-        object.use_partitions = get<bool>(yml, QOS_PARTITION_TAG, version);
-    }
-
-    // Optional keyed
-    if (is_tag_present(yml, QOS_KEYED_TAG))
-    {
-        object.keyed = get<bool>(yml, QOS_KEYED_TAG, version);
+        if (get<bool>(yml, QOS_RELIABLE_TAG, version))
+        {
+            object.reliability_qos = eprosima::ddspipe::core::types::ReliabilityKind::RELIABLE;
+        }
+        else
+        {
+            object.reliability_qos = eprosima::ddspipe::core::types::ReliabilityKind::BEST_EFFORT;
+        }
     }
 
     // Ownership optional
@@ -406,10 +388,28 @@ void YamlReader::fill(
         }
     }
 
-    // Downsampling optional
-    if (is_tag_present(yml, QOS_DOWNSAMPLING_TAG))
+    // Use partitions optional
+    if (is_tag_present(yml, QOS_PARTITION_TAG))
     {
-        object.downsampling = get_positive_int(yml, QOS_DOWNSAMPLING_TAG);
+        object.use_partitions = get<bool>(yml, QOS_PARTITION_TAG, version);
+    }
+
+    // History depth optional
+    if (is_tag_present(yml, QOS_HISTORY_DEPTH_TAG))
+    {
+        object.history_depth = get<HistoryDepthType>(yml, QOS_HISTORY_DEPTH_TAG, version);
+    }
+
+    // Keyed optional
+    if (is_tag_present(yml, QOS_KEYED_TAG))
+    {
+        object.keyed = get<bool>(yml, QOS_KEYED_TAG, version);
+    }
+
+    // Max Transmission Rate optional
+    if (is_tag_present(yml, QOS_MAX_TX_RATE_TAG))
+    {
+        object.max_tx_rate = get<float>(yml, QOS_MAX_TX_RATE_TAG, version);
     }
 
     // Max Reception Rate optional
@@ -418,10 +418,10 @@ void YamlReader::fill(
         object.max_rx_rate = get<float>(yml, QOS_MAX_RX_RATE_TAG, version);
     }
 
-    // Max Transmission Rate optional
-    if (is_tag_present(yml, QOS_MAX_TX_RATE_TAG))
+    // Downsampling optional
+    if (is_tag_present(yml, QOS_DOWNSAMPLING_TAG))
     {
-        object.max_tx_rate = get<float>(yml, QOS_MAX_TX_RATE_TAG, version);
+        object.downsampling = get_positive_int(yml, QOS_DOWNSAMPLING_TAG);
     }
 }
 
@@ -467,11 +467,8 @@ void YamlReader::fill(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
-    // Optional name
-    if (is_tag_present(yml, TOPIC_NAME_TAG))
-    {
-        object.topic_name.set_value(get<std::string>(yml, TOPIC_NAME_TAG, version));
-    }
+    // Name required
+    object.topic_name = get<std::string>(yml, TOPIC_NAME_TAG, version);
 
     // Optional data type
     if (is_tag_present(yml, TOPIC_TYPE_NAME_TAG))

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -380,7 +380,8 @@ void YamlReader::fill(
     {
         if (get<bool>(yml, QOS_OWNERSHIP_TAG, version))
         {
-            object.ownership_qos.set_value(eprosima::ddspipe::core::types::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS);
+            object.ownership_qos.set_value(
+                eprosima::ddspipe::core::types::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS);
         }
         else
         {
@@ -441,12 +442,6 @@ void YamlReader::fill(
 
     // Data Type required
     object.type_name = get<std::string>(yml, TOPIC_TYPE_NAME_TAG, version);
-
-    // Optional QoS
-    if (is_tag_present(yml, TOPIC_QOS_TAG))
-    {
-        fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, TOPIC_QOS_TAG), version);
-    }
 }
 
 template <>

--- a/ddspipe_yaml/test/unittest/entities/topic/YamlGetEntityTopicTest.cpp
+++ b/ddspipe_yaml/test/unittest/entities/topic/YamlGetEntityTopicTest.cpp
@@ -209,27 +209,6 @@ TEST(YamlGetEntityTopicTest, get_wildcard_topic)
         ASSERT_EQ(topic, w_topic);
     }
 
-    // Topic without name
-    {
-        core::types::WildcardDdsFilterTopic w_topic;
-        w_topic.type_name.set_value(test::TOPIC_TYPE);
-
-        Yaml yml_topic;
-        filter_topic_to_yaml(
-            yml_topic,
-            w_topic);
-
-        Yaml yml;
-        yml["topic"] = yml_topic;
-
-        core::types::WildcardDdsFilterTopic topic = YamlReader::get<core::types::WildcardDdsFilterTopic>(yml, "topic",
-                        LATEST);
-
-        ASSERT_EQ(topic, w_topic);
-        ASSERT_TRUE(topic.type_name.is_set());
-        ASSERT_FALSE(topic.topic_name.is_set());
-    }
-
     // Topic without type
     {
         core::types::WildcardDdsFilterTopic w_topic;

--- a/ddspipe_yaml/test/unittest/entities/topic/YamlGetEntityTopicTest.cpp
+++ b/ddspipe_yaml/test/unittest/entities/topic/YamlGetEntityTopicTest.cpp
@@ -109,30 +109,6 @@ TEST(YamlGetEntityTopicTest, get_real_topic)
 
         ASSERT_EQ(topic, real_topic);
     }
-
-    // Checks that a topic yaml object has been parsed correctly with the topic reliable tag set to true.
-    // A topic configured as reliable creates RELIABLE-TRANSIENT_LOCAL RTPS Readers in order to ensure
-    // that no data is lost in the information relay.
-    // TODO: extend for other QoS
-    {
-        core::types::DdsTopic real_topic;
-        real_topic.m_topic_name = test::TOPIC_NAME;
-        real_topic.type_name = test::TOPIC_TYPE;
-        real_topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
-
-        Yaml yml_topic;
-        real_topic_to_yaml(
-            yml_topic,
-            real_topic);
-
-        Yaml yml;
-        yml["topic"] = yml_topic;
-
-        core::types::DdsTopic topic = YamlReader::get<core::types::DdsTopic>(yml, "topic", LATEST);
-
-        ASSERT_EQ(topic, real_topic);
-        ASSERT_TRUE(topic.topic_qos.is_reliable());
-    }
 }
 
 /**


### PR DESCRIPTION
In this version, topics' QoS are configurable. The set of predefined topics' QoS takes precedence over the discovered topics' QoS.

The following features have also been implemented:
- max-tx-rate (max transmission rate): the transmission frequency for sent samples.
- max-rx-rate (max reception rate): the processing frequency for received samples.
- downsampling: the proportion of samples to process for received samples.

These features can be configured generically, per participant, and per topic.

Merge after:
- https://github.com/eProsima/DDS-Pipe/pull/57