### PR TITLE
Make the trigger of the DDS Pipe callbacks configurable

### DIFF
--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -32,6 +32,13 @@ namespace eprosima {
 namespace ddspipe {
 namespace core {
 
+enum EntityCreationTrigger
+{
+    ANY = 0,        //! The discovery of both readers and writers triggers the creation of entities.
+    READER = 1,     //! The discovery of readers triggers the creation of entities.
+    WRITER = 2      //! The discovery of writers triggers the creation of entities.
+};
+
 /**
  * Configuration structure encapsulating the configuration of a \c DdsPipe instance.
  */
@@ -108,6 +115,9 @@ struct DdsPipeConfiguration : public IConfiguration
 
     //! Whether the DDS Pipe should be initialized enabled.
     bool init_enabled = false;
+    
+    //! The entity type whose discovery should trigger the creation of entities.
+    EntityCreationTrigger entity_creation_trigger = EntityCreationTrigger::READER;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -33,7 +33,7 @@ namespace eprosima {
 namespace ddspipe {
 namespace core {
 
-//! Possible kinds of the endpoint
+//! Possible kinds of discovery triggers
 ENUMERATION_BUILDER(
     DiscoveryTrigger,
     READER,     //! The discovery callbacks get triggered by the discovery of a reader.

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -34,9 +34,10 @@ namespace core {
 
 enum EntityCreationTrigger
 {
-    ANY = 0,        //! The discovery of both readers and writers triggers the creation of entities.
-    READER = 1,     //! The discovery of readers triggers the creation of entities.
-    WRITER = 2      //! The discovery of writers triggers the creation of entities.
+    READER = 0,     //! The discovery of readers triggers the creation of entities.
+    WRITER = 1,     //! The discovery of writers triggers the creation of entities.
+    NONE = 2,       //! The discovery of either readers and writers doesn't trigger the creation of entities.
+    ANY = 3         //! The discovery of both readers and writers triggers the creation of entities.
 };
 
 /**
@@ -115,7 +116,7 @@ struct DdsPipeConfiguration : public IConfiguration
 
     //! Whether the DDS Pipe should be initialized enabled.
     bool init_enabled = false;
-    
+
     //! The entity type whose discovery should trigger the creation of entities.
     EntityCreationTrigger entity_creation_trigger = EntityCreationTrigger::READER;
 };

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -32,12 +32,12 @@ namespace eprosima {
 namespace ddspipe {
 namespace core {
 
-enum EntityCreationTrigger
+enum DiscoveryTrigger
 {
-    READER = 0,     //! The discovery of readers triggers the creation of entities.
-    WRITER = 1,     //! The discovery of writers triggers the creation of entities.
-    NONE = 2,       //! The discovery of either readers and writers doesn't trigger the creation of entities.
-    ANY = 3         //! The discovery of both readers and writers triggers the creation of entities.
+    READER = 0,     //! The discovery callbacks get triggered by the discovery of a reader.
+    WRITER = 1,     //! The discovery callbacks get triggered by the discovery of a writer.
+    NONE = 2,       //! The discovery callbacks don't get triggered by the discovery of readers or writers.
+    ANY = 3         //! The discovery callbacks get triggered by the discovery of either a reader or a writer.
 };
 
 /**
@@ -117,8 +117,8 @@ struct DdsPipeConfiguration : public IConfiguration
     //! Whether the DDS Pipe should be initialized enabled.
     bool init_enabled = false;
 
-    //! The entity type whose discovery should trigger the creation of entities.
-    EntityCreationTrigger entity_creation_trigger = EntityCreationTrigger::READER;
+    //! The type of the entity whose discovery should trigger the discovery callbacks.
+    DiscoveryTrigger discovery_trigger = DiscoveryTrigger::READER;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
+++ b/ddspipe_core/include/ddspipe_core/configuration/DdsPipeConfiguration.hpp
@@ -18,6 +18,7 @@
 #include <set>
 
 #include <cpp_utils/Formatter.hpp>
+#include <cpp_utils/macros/custom_enumeration.hpp>
 
 #include <ddspipe_core/configuration/IConfiguration.hpp>
 #include <ddspipe_core/configuration/RoutesConfiguration.hpp>
@@ -32,13 +33,14 @@ namespace eprosima {
 namespace ddspipe {
 namespace core {
 
-enum DiscoveryTrigger
-{
-    READER = 0,     //! The discovery callbacks get triggered by the discovery of a reader.
-    WRITER = 1,     //! The discovery callbacks get triggered by the discovery of a writer.
-    NONE = 2,       //! The discovery callbacks don't get triggered by the discovery of readers or writers.
-    ANY = 3         //! The discovery callbacks get triggered by the discovery of either a reader or a writer.
-};
+//! Possible kinds of the endpoint
+ENUMERATION_BUILDER(
+    DiscoveryTrigger,
+    READER,     //! The discovery callbacks get triggered by the discovery of a reader.
+    WRITER,     //! The discovery callbacks get triggered by the discovery of a writer.
+    NONE,       //! The discovery callbacks don't get triggered by the discovery of readers or writers.
+    ANY         //! The discovery callbacks get triggered by the discovery of either a reader or a writer.
+    );
 
 /**
  * Configuration structure encapsulating the configuration of a \c DdsPipe instance.

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -216,14 +216,18 @@ protected:
      * @brief Method called every time a new endpoint has been discovered, removed, or updated.
      *
      * @param [in] endpoint : endpoint discovered, removed, or updated.
+     *
+     * @return Whether the endpoint's kind matches the discovery trigger.
      */
-    bool is_endpoint_type_relevant_(
+    bool is_endpoint_kind_relevant_(
             const types::Endpoint& endpoint) noexcept;
 
     /**
      * @brief Method called every time a new endpoint has been discovered, removed, or updated.
      *
      * @param [in] endpoint : endpoint discovered, removed, or updated.
+     *
+     * @return Whether the DdsPipe's discovery callbacks need to process the endpoint.
      */
     bool is_endpoint_relevant_(
             const types::Endpoint& endpoint) noexcept;

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -213,7 +213,9 @@ protected:
             const types::Endpoint& endpoint) noexcept;
 
     /**
-     * @brief Method called every time a new endpoint has been discovered, removed, or updated.
+     * @brief Check whether the kind of an endpoint matches the discovery trigger kind.
+     *
+     * Method called every time a new endpoint has been discovered, removed, or updated.
      *
      * @param [in] endpoint : endpoint discovered, removed, or updated.
      *
@@ -223,7 +225,10 @@ protected:
             const types::Endpoint& endpoint) noexcept;
 
     /**
-     * @brief Method called every time a new endpoint has been discovered, removed, or updated.
+     * @brief Check whether an endpoint is the first endpoint discovered or the last removed.
+     *
+     * Method called every time a new endpoint has been discovered, removed, or updated.
+     * This method calls \c is_endpoint_kind_relevant_
      *
      * @param [in] endpoint : endpoint discovered, removed, or updated.
      *

--- a/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
+++ b/ddspipe_core/include/ddspipe_core/core/DdsPipe.hpp
@@ -217,6 +217,14 @@ protected:
      *
      * @param [in] endpoint : endpoint discovered, removed, or updated.
      */
+    bool is_endpoint_type_relevant_(
+            const types::Endpoint& endpoint) noexcept;
+
+    /**
+     * @brief Method called every time a new endpoint has been discovered, removed, or updated.
+     *
+     * @param [in] endpoint : endpoint discovered, removed, or updated.
+     */
     bool is_endpoint_relevant_(
             const types::Endpoint& endpoint) noexcept;
 

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -29,6 +29,11 @@ namespace core {
 bool DdsPipeConfiguration::is_valid(
         utils::Formatter& error_msg) const noexcept
 {
+    if (remove_unused_entities && discovery_trigger != DiscoveryTrigger::READER)
+    {
+        return false;
+    }
+
     return routes.is_valid(error_msg) && topic_routes.is_valid(error_msg);
 }
 

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -31,7 +31,7 @@ bool DdsPipeConfiguration::is_valid(
 {
     if (remove_unused_entities && discovery_trigger != DiscoveryTrigger::READER)
     {
-        error_msg << "A discovery-trigger different to reader is incompatible with remove-unused-entities.";
+        error_msg << "A discovery-trigger different from reader is incompatible with remove-unused-entities.";
         return false;
     }
 

--- a/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
+++ b/ddspipe_core/src/cpp/configuration/DdsPipeConfiguration.cpp
@@ -31,6 +31,7 @@ bool DdsPipeConfiguration::is_valid(
 {
     if (remove_unused_entities && discovery_trigger != DiscoveryTrigger::READER)
     {
+        error_msg << "A discovery-trigger different to reader is incompatible with remove-unused-entities.";
         return false;
     }
 

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -350,16 +350,14 @@ void DdsPipe::updated_endpoint_nts_(
 bool DdsPipe::is_endpoint_relevant_(
         const Endpoint& endpoint) noexcept
 {
-    const auto discovery_trigger = configuration_.discovery_trigger;
-
-    auto is_endpoint_type_relevant = [discovery_trigger](const Endpoint& endpoint)
+    auto is_endpoint_type_relevant = [&](const Endpoint& entity)
             {
-                switch (discovery_trigger)
+                switch (configuration_.discovery_trigger)
                 {
                     case DiscoveryTrigger::READER:
-                        return endpoint.is_reader();
+                        return entity.is_reader();
                     case DiscoveryTrigger::WRITER:
-                        return endpoint.is_writer();
+                        return entity.is_writer();
                     case DiscoveryTrigger::ANY:
                         return true;
                     case DiscoveryTrigger::NONE:

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -376,7 +376,7 @@ bool DdsPipe::is_endpoint_relevant_(
         return false;
     }
 
-    auto is_endpoint_relevant = [&, endpoint](const Endpoint& entity)
+    auto is_endpoint_relevant = [&](const Endpoint& entity)
             {
                 return entity.active &&
                        is_endpoint_kind_relevant_(entity) &&

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -362,6 +362,8 @@ bool DdsPipe::is_endpoint_relevant_(
                         return endpoint.is_writer();
                     case EntityCreationTrigger::ANY:
                         return true;
+                    case EntityCreationTrigger::NONE:
+                        return false;
                     default:
                         return false;
                 }

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -350,19 +350,19 @@ void DdsPipe::updated_endpoint_nts_(
 bool DdsPipe::is_endpoint_relevant_(
         const Endpoint& endpoint) noexcept
 {
-    const auto entity_creation_trigger = configuration_.entity_creation_trigger;
+    const auto discovery_trigger = configuration_.discovery_trigger;
 
-    auto is_endpoint_type_relevant = [entity_creation_trigger](const Endpoint& endpoint)
+    auto is_endpoint_type_relevant = [discovery_trigger](const Endpoint& endpoint)
             {
-                switch (entity_creation_trigger)
+                switch (discovery_trigger)
                 {
-                    case EntityCreationTrigger::READER:
+                    case DiscoveryTrigger::READER:
                         return endpoint.is_reader();
-                    case EntityCreationTrigger::WRITER:
+                    case DiscoveryTrigger::WRITER:
                         return endpoint.is_writer();
-                    case EntityCreationTrigger::ANY:
+                    case DiscoveryTrigger::ANY:
                         return true;
-                    case EntityCreationTrigger::NONE:
+                    case DiscoveryTrigger::NONE:
                         return false;
                     default:
                         return false;

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -350,7 +350,7 @@ void DdsPipe::updated_endpoint_nts_(
 bool DdsPipe::is_endpoint_relevant_(
         const Endpoint& endpoint) noexcept
 {
-    const auto entity_creation_trigger = ddspipe_config_.entity_creation_trigger;
+    const auto entity_creation_trigger = configuration_.entity_creation_trigger;
 
     auto is_endpoint_type_relevant = [entity_creation_trigger](const Endpoint& endpoint)
             {

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -282,7 +282,7 @@ void DdsPipe::discovered_endpoint_nts_(
 
     if (RpcTopic::is_service_topic(endpoint.topic))
     {
-        if (is_endpoint_type_relevant_(endpoint) && endpoint.is_server_endpoint())
+        if (is_endpoint_kind_relevant_(endpoint) && endpoint.is_server_endpoint())
         {
             // Service server discovered
             discovered_service_nts_(RpcTopic(
@@ -345,7 +345,7 @@ void DdsPipe::updated_endpoint_nts_(
     }
 }
 
-bool DdsPipe::is_endpoint_type_relevant_(
+bool DdsPipe::is_endpoint_kind_relevant_(
         const Endpoint& endpoint) noexcept
 {
     switch (configuration_.discovery_trigger)
@@ -371,7 +371,7 @@ bool DdsPipe::is_endpoint_type_relevant_(
 bool DdsPipe::is_endpoint_relevant_(
         const Endpoint& endpoint) noexcept
 {
-    if (!is_endpoint_type_relevant_(endpoint))
+    if (!is_endpoint_kind_relevant_(endpoint))
     {
         return false;
     }
@@ -379,7 +379,7 @@ bool DdsPipe::is_endpoint_relevant_(
     auto is_endpoint_relevant = [&, endpoint](const Endpoint& entity)
             {
                 return entity.active &&
-                       is_endpoint_type_relevant_(entity) &&
+                       is_endpoint_kind_relevant_(entity) &&
                        entity.topic == endpoint.topic &&
                        entity.discoverer_participant_id == endpoint.discoverer_participant_id;
             };

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -19,6 +19,7 @@
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/Log.hpp>
+#include <cpp_utils/utils.hpp>
 
 #include <ddspipe_core/core/DdsPipe.hpp>
 
@@ -80,9 +81,6 @@ DdsPipe::DdsPipe(
     }
 
     // Init discovery database
-    // The entities should not be added to the Discovery Database until the builtin topics have been created.
-    // This is due to the fact that the Participants endpoints start discovering topics with different configuration
-    // than the one specified in the yaml configuration file.
     discovery_database_->start();
 
     logDebug(DDSPIPE, "DDS Pipe created.");
@@ -284,7 +282,7 @@ void DdsPipe::discovered_endpoint_nts_(
 
     if (RpcTopic::is_service_topic(endpoint.topic))
     {
-        if (endpoint.is_reader() && endpoint.is_server_endpoint())
+        if (is_endpoint_type_relevant_(endpoint) && endpoint.is_server_endpoint())
         {
             // Service server discovered
             discovered_service_nts_(RpcTopic(
@@ -347,38 +345,44 @@ void DdsPipe::updated_endpoint_nts_(
     }
 }
 
+bool DdsPipe::is_endpoint_type_relevant_(
+        const Endpoint& endpoint) noexcept
+{
+    switch (configuration_.discovery_trigger)
+    {
+        case DiscoveryTrigger::READER:
+            return endpoint.is_reader();
+
+        case DiscoveryTrigger::WRITER:
+            return endpoint.is_writer();
+
+        case DiscoveryTrigger::ANY:
+            return true;
+
+        case DiscoveryTrigger::NONE:
+            return false;
+
+        default:
+            utils::tsnh(utils::Formatter() << "Invalid Discovery Trigger.");
+            return false;
+    }
+}
+
 bool DdsPipe::is_endpoint_relevant_(
         const Endpoint& endpoint) noexcept
 {
-    auto is_endpoint_type_relevant = [&](const Endpoint& entity)
-            {
-                switch (configuration_.discovery_trigger)
-                {
-                    case DiscoveryTrigger::READER:
-                        return entity.is_reader();
-                    case DiscoveryTrigger::WRITER:
-                        return entity.is_writer();
-                    case DiscoveryTrigger::ANY:
-                        return true;
-                    case DiscoveryTrigger::NONE:
-                        return false;
-                    default:
-                        return false;
-                }
-            };
-
-    auto is_endpoint_relevant = [endpoint, is_endpoint_type_relevant](const Endpoint& entity)
-            {
-                return entity.active &&
-                       is_endpoint_type_relevant(entity) &&
-                       entity.topic == endpoint.topic &&
-                       entity.discoverer_participant_id == endpoint.discoverer_participant_id;
-            };
-
-    if (!is_endpoint_type_relevant(endpoint))
+    if (!is_endpoint_type_relevant_(endpoint))
     {
         return false;
     }
+
+    auto is_endpoint_relevant = [&, endpoint](const Endpoint& entity)
+            {
+                return entity.active &&
+                       is_endpoint_type_relevant_(entity) &&
+                       entity.topic == endpoint.topic &&
+                       entity.discoverer_participant_id == endpoint.discoverer_participant_id;
+            };
 
     const auto& relevant_endpoints = discovery_database_->get_endpoints(is_endpoint_relevant);
 

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
@@ -51,21 +51,6 @@ SchemaParticipant::SchemaParticipant(
     discovery_database_->add_endpoint(
         rtps::CommonParticipant::simulate_endpoint(type_object_topic(), this->id())
         );
-
-    // Force for every topic found to create track by creating simulated readers
-    // NOTE: this could change for: in DDS Pipe change that only readers create track
-    discovery_database_->add_endpoint_discovered_callback(
-        [this](Endpoint endpoint_discovered)
-        {
-            if (endpoint_discovered.is_writer() && endpoint_discovered.discoverer_participant_id != this->id())
-            {
-                discovery_database_->add_endpoint(
-                    rtps::CommonParticipant::simulate_endpoint(endpoint_discovered.topic,
-                    endpoint_discovered.discoverer_participant_id)
-                    );
-            }
-        }
-        );
 }
 
 ParticipantId SchemaParticipant::id() const noexcept

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
@@ -47,10 +47,6 @@ SchemaParticipant::SchemaParticipant(
     , discovery_database_(discovery_database)
     , schema_handler_(schema_handler)
 {
-    // Simulate that there is a reader of type object to force this track creation
-    discovery_database_->add_endpoint(
-        rtps::CommonParticipant::simulate_endpoint(type_object_topic(), this->id())
-        );
 }
 
 ParticipantId SchemaParticipant::id() const noexcept

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -141,6 +141,7 @@ constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoS
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
+constexpr const char* ENTITY_CREATION_TRIGGER_TAG("entity-creation-trigger"); //! Dynamically create entities when the trigger is set off.
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -141,7 +141,7 @@ constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoS
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
-constexpr const char* ENTITY_CREATION_TRIGGER_TAG("entity-creation-trigger"); //! Dynamically create entities when the trigger is set off.
+constexpr const char* DISCOVERY_TRIGGER_TAG("discovery-trigger"); //! Dynamically trigger the discovery of entities.
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -141,7 +141,7 @@ constexpr const char* SPECS_QOS_TAG("qos"); //! Global Topic QoS
 constexpr const char* NUMBER_THREADS_TAG("threads"); //! Number of threads to configure the thread pool
 constexpr const char* WAIT_ALL_ACKED_TIMEOUT_TAG("wait-all-acked-timeout"); //! Wait for a maximum of *wait-all-acked-timeout* ms until all msgs sent by reliable writers are acknowledged by their matched readers
 constexpr const char* REMOVE_UNUSED_ENTITIES_TAG("remove-unused-entities"); //! Dynamically create and delete entities and tracks.
-constexpr const char* DISCOVERY_TRIGGER_TAG("discovery-trigger"); //! Dynamically trigger the discovery of entities.
+constexpr const char* DISCOVERY_TRIGGER_TAG("discovery-trigger"); //! Make the trigger of the DDS Pipe callbacks configurable.
 
 // XML configuration tags
 constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration


### PR DESCRIPTION
In the previous version, the DDS Pipe's callbacks were only triggered by the discovery of readers. In this version, the entity type that triggers the callbacks is configurable. They can be triggered by readers (by default), writers, both readers and writers, and neither readers nor writers.

Merge after:
- https://github.com/eProsima/DDS-Pipe/pull/57
- https://github.com/eProsima/DDS-Pipe/pull/64