### PR TITLE
Free the changes that have been acknowledged by all readers (on volatile topics) [19800]

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
@@ -98,7 +98,7 @@ public:
     /**
      * @brief CommonWriter Listener callback when a new Reader is matched or unmatched
      *
-     * This method is call every time a new Reader is matched or unmatched from this CommonWriter.
+     * This method is called every time a new Reader is matched or unmatched from this CommonWriter.
      * It only creates a log for matching and unmatching (in case it is not a reader from this same Participant)
      *
      * @param [in] info information about the matched Reader
@@ -107,6 +107,18 @@ public:
     void onWriterMatched(
             fastrtps::rtps::RTPSWriter*,
             fastrtps::rtps::MatchingInfo& info) noexcept override;
+
+    /**
+     * @brief CommonWriter Listener callback when all the Readers have received a change.
+     *
+     * This method is called when all the Readers subscribed to a Topic acknowledge that they have received a change.
+     * It removes the change from the Writer's history if the Writer is volatile.
+     *
+     * @param [in] ch the change that has been acknowledged by all the Readers.
+     */
+    void onWriterChangeReceivedByAll(
+        fastrtps::rtps::RTPSWriter*,
+        fastrtps::rtps::CacheChange_t* change) override;
 
     /**
      * This method is called when a new Reader is discovered, with a Topic that

--- a/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
@@ -116,9 +116,10 @@ public:
      *
      * @param [in] ch the change that has been acknowledged by all the Readers.
      */
+    DDSPIPE_PARTICIPANTS_DllAPI
     void onWriterChangeReceivedByAll(
-        fastrtps::rtps::RTPSWriter*,
-        fastrtps::rtps::CacheChange_t* change) override;
+            fastrtps::rtps::RTPSWriter*,
+            fastrtps::rtps::CacheChange_t* change) override;
 
     /**
      * This method is called when a new Reader is discovered, with a Topic that

--- a/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
@@ -112,7 +112,7 @@ public:
      * @brief CommonWriter Listener callback when all the Readers have received a change.
      *
      * This method is called when all the Readers subscribed to a Topic acknowledge that they have received a change.
-     * It removes the change from the Writer's history if the Writer is volatile.
+     * It removes the change from the Writer's history if the Writer is best-effort or volatile.
      *
      * @param [in] ch the change that has been acknowledged by all the Readers.
      */

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -287,9 +287,11 @@ CommonParticipant::CommonParticipant(
 fastdds::dds::DomainParticipantQos CommonParticipant::reckon_participant_qos_() const
 {
     auto qos = fastdds::dds::DomainParticipantFactory::get_instance()->get_default_participant_qos();
+
     qos.properties().properties().emplace_back(
         "fastdds.ignore_local_endpoints",
         "true");
+
     return qos;
 }
 

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -484,6 +484,11 @@ CommonParticipant::reckon_participant_attributes_(
     // Add Participant name
     params.setName(participant_configuration->id.c_str());
 
+    // Ignore the local endpoints so that the reader and writer of the same participant don't match.
+    params.properties.properties().emplace_back(
+        "fastdds.ignore_local_endpoints",
+        "true");
+
     return params;
 }
 

--- a/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
@@ -198,6 +198,12 @@ utils::ReturnCode CommonWriter::write_nts_(
         return ret;
     }
 
+    if (rtps_history_->isFull())
+    {
+        // Remove the oldest cache change when the max history size is reached.
+        rtps_history_->remove_min_change();
+    }
+
     // Send data by adding it to CommonWriter History
     rtps_history_->add_change(new_change, write_params);
 
@@ -209,11 +215,6 @@ utils::ReturnCode CommonWriter::write_nts_(
     {
         // Remove the change since it will never be resent.
         rtps_history_->remove_change(new_change);
-    }
-    else if (rtps_history_->isFull())
-    {
-        // Remove the oldest cache change when the max history size is reached.
-        rtps_history_->remove_min_change();
     }
 
     return utils::ReturnCode::RETCODE_OK;

--- a/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
@@ -131,7 +131,7 @@ void CommonWriter::onWriterChangeReceivedByAll(
 {
     if (topic_.topic_qos.keyed &&
             (fastrtps::rtps::NOT_ALIVE_UNREGISTERED == change->kind ||
-             fastrtps::rtps::NOT_ALIVE_DISPOSED_UNREGISTERED == change->kind))
+            fastrtps::rtps::NOT_ALIVE_DISPOSED_UNREGISTERED == change->kind))
     {
         // In Fast-DDS the DataWriterHistory keeps track of all the keyed changes and, when removing a keyed change, it
         // removes it from the list of keyed changes as well.
@@ -169,8 +169,8 @@ utils::ReturnCode CommonWriter::write_nts_(
     if (topic_.topic_qos.keyed)
     {
         new_change = rtps_writer_->new_change(
-                rtps_data.kind,
-                rtps_data.instanceHandle);
+            rtps_data.kind,
+            rtps_data.instanceHandle);
     }
     else
     {

--- a/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
@@ -129,15 +129,7 @@ void CommonWriter::onWriterChangeReceivedByAll(
         fastrtps::rtps::RTPSWriter* /*writer*/,
         fastrtps::rtps::CacheChange_t* change)
 {
-    if (topic_.topic_qos.keyed &&
-            (fastrtps::rtps::NOT_ALIVE_UNREGISTERED == change->kind ||
-            fastrtps::rtps::NOT_ALIVE_DISPOSED_UNREGISTERED == change->kind))
-    {
-        // In Fast-DDS the DataWriterHistory keeps track of all the keyed changes and, when removing a keyed change, it
-        // removes it from the list of keyed changes as well.
-        rtps_history_->remove_change_g(change);
-    }
-    else if (writer_qos_.m_durability.kind == fastdds::dds::VOLATILE_DURABILITY_QOS)
+    if (writer_qos_.m_durability.kind == fastdds::dds::VOLATILE_DURABILITY_QOS)
     {
         rtps_history_->remove_change_g(change);
     }
@@ -207,15 +199,10 @@ utils::ReturnCode CommonWriter::write_nts_(
     // Send data by adding it to CommonWriter History
     rtps_history_->add_change(new_change, write_params);
 
+    // In the case of BEST_EFFORT, add_change calls onWriterChangeReceivedByAll (which removes the change).
+
     // At this point, write params is now the output of adding change
     fill_sent_data_(write_params, rtps_data);
-
-    // TODO: check if we are async
-    if (!topic_.topic_qos.is_reliable())
-    {
-        // Remove the change since it will never be resent.
-        rtps_history_->remove_change(new_change);
-    }
 
     return utils::ReturnCode::RETCODE_OK;
 }
@@ -266,9 +253,7 @@ void CommonWriter::fill_sent_data_(
         const eprosima::fastrtps::rtps::WriteParams& params,
         core::types::RtpsPayloadData& data_to_fill) const noexcept
 {
-    // Set data output parameters
-    // TODO move to RPC
-    // data_to_fill->sent_sequence_number = params.sample_identity().sequence_number();
+    // Do nothing
 }
 
 void CommonWriter::internal_entities_creation_(

--- a/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
@@ -129,7 +129,8 @@ void CommonWriter::onWriterChangeReceivedByAll(
         fastrtps::rtps::RTPSWriter* /*writer*/,
         fastrtps::rtps::CacheChange_t* change)
 {
-    if (writer_qos_.m_durability.kind == fastdds::dds::VOLATILE_DURABILITY_QOS)
+    if (writer_qos_.m_reliability.kind == fastdds::dds::BEST_EFFORT_RELIABILITY_QOS ||
+            writer_qos_.m_durability.kind == fastdds::dds::VOLATILE_DURABILITY_QOS)
     {
         rtps_history_->remove_change_g(change);
     }


### PR DESCRIPTION
In the previous version, the changes on reliable-volatile topics were never removed from the RTPS writers' histories. This lead to the congestion of RTPS writers' histories and, at times, to memory exhaustion issues. In this version, RTPS writers free changes (on reliable-volatile topics) once they have been acknowledged by all readers.

In the following example, we launch a DDS Router with two RTPS participants, and publish a hundred 1MB messages on a reliable-volatile topic. Here's the heap memory consumption of the DDS Router before and after this update.

Before (Peak Heap Memory 99.5 MiB):
![rtps_rtps](https://github.com/eProsima/DDS-Pipe/assets/33602217/d1cc6501-a3f4-40cc-ac59-59c72b7ddf40)

After (Peak Heap Memory 5.9 MiB):
![rtps_rtps](https://github.com/eProsima/DDS-Pipe/assets/33602217/98ff64a5-0456-43db-a140-693c5d391c32)

This version also includes a **bugfix**. In the previous version, RTPS CommonWriters would free space in their full-histories after adding a change. This meant that when the depth of the history was set to 1, for example, TRANSIENT-LOCAL wouldn't work, since, after adding the change, the writer would identify its history as full and free space for another change (deleting the previous one). Now, however, freeing space in full histories is done before adding a change, which fixes the problem.