### PR TITLE
Set discoverer participant in simulated endpoint's topic

### DIFF
--- a/ddspipe_core/src/cpp/testing/random_values.cpp
+++ b/ddspipe_core/src/cpp/testing/random_values.cpp
@@ -97,6 +97,7 @@ Endpoint random_endpoint(
     endpoint.kind = random_endpoint_kind(seed);
     endpoint.topic = random_dds_topic(seed);
     endpoint.discoverer_participant_id = random_participant_id(seed);
+    endpoint.topic.m_topic_discoverer = endpoint.discoverer_participant_id;
 
     return endpoint;
 }

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -193,6 +193,7 @@ core::types::Endpoint CommonParticipant::simulate_endpoint(
     endpoint.guid = core::types::Guid::new_unique_guid();
     endpoint.topic = topic;
     endpoint.discoverer_participant_id = discoverer_id;
+    endpoint.topic.m_topic_discoverer = discoverer_id;
 
     return endpoint;
 }


### PR DESCRIPTION
PR https://github.com/eProsima/DDS-Pipe/pull/57 added to `Topic` class a participant discoverer attribute, but missed to copy this attribute to endpoints simulated via CommonParticipant::simulate_endpoint method, which may cause inconsistencies in some corner cases.