### PR TITLE
Make remove-unused-entities compatible with built-in topics

### DIFF
--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -39,9 +39,8 @@ DdsBridge::DdsBridge(
 
     routes_ = routes_config();
 
-    if (remove_unused_entities)
+    if (remove_unused_entities && topic->topic_discoverer() != DEFAULT_PARTICIPANT_ID)
     {
-        // The builtin participants and some tests use an empty topic discoverer participant id
         create_writer(topic->topic_discoverer());
     }
     else

--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -317,7 +317,7 @@ void DdsPipe::removed_endpoint_nts_(
         // Remove the subscriber from the topic.
         auto it_bridge = bridges_.find(topic);
 
-        if (it_bridge != bridges_.end())
+        if (it_bridge != bridges_.end() && endpoint.discoverer_participant_id != DEFAULT_PARTICIPANT_ID)
         {
             it_bridge->second->remove_writer(endpoint.discoverer_participant_id);
         }
@@ -429,7 +429,7 @@ void DdsPipe::discovered_topic_nts_(
             activate_topic_nts_(topic);
         }
     }
-    else if (configuration_.remove_unused_entities)
+    else if (configuration_.remove_unused_entities && topic->topic_discoverer() != DEFAULT_PARTICIPANT_ID)
     {
         // The bridge already exists. Create a writer in the participant who discovered it.
         it_bridge->second->create_writer(topic->topic_discoverer());


### PR DESCRIPTION
In the previous version, built-in topics were incompatible with `remove-unused-entities`. Now, `remove-unused-entities` only applies to topics that are discovered (i.e. topics that aren't built-in).

The documentation for this PR can be found at https://github.com/eProsima/DDS-Router/pull/413