### PR TITLE
Validate the YAML configuration file on parsing

### DIFF
--- a/ddspipe_yaml/include/ddspipe_yaml/YamlValidator.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/YamlValidator.hpp
@@ -1,0 +1,46 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <ddspipe_yaml/library/library_dll.h>
+#include <ddspipe_yaml/Yaml.hpp>
+#include <ddspipe_yaml/YamlReader.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace yaml {
+
+// TODO
+class YamlValidator
+{
+public:
+
+    //! TODO
+    template <typename T>
+    static bool validate(
+            const Yaml& yml,
+            const YamlReaderVersion& version = YamlReaderVersion::LATEST);
+
+protected:
+
+    //! TODO
+    static bool validate_tags_(
+            const Yaml& yml,
+            const std::set<TagType>& tags);
+};
+
+} /* namespace yaml */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_yaml/src/cpp/YamlReader_features.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_features.cpp
@@ -24,6 +24,7 @@
 
 #include <ddspipe_yaml/Yaml.hpp>
 #include <ddspipe_yaml/YamlReader.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
 #include <ddspipe_yaml/yaml_configuration_tags.hpp>
 
 namespace eprosima {
@@ -56,10 +57,25 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<participants::XmlHandlerConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        XML_RAW_TAG,
+        XML_FILES_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 participants::XmlHandlerConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<participants::XmlHandlerConfiguration>(yml, version);
+
     participants::XmlHandlerConfiguration object;
     fill<participants::XmlHandlerConfiguration>(object, yml, version);
     return object;
@@ -68,6 +84,19 @@ participants::XmlHandlerConfiguration YamlReader::get(
 /************************
 * Routes Configuration  *
 ************************/
+
+template <>
+DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<core::RoutesConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        ROUTES_SRC_TAG,
+        ROUTES_DST_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
 
 template <>
 DDSPIPE_YAML_DllAPI
@@ -87,25 +116,20 @@ void YamlReader::fill(
 
     for (const auto& route_yml : yml)
     {
+        // The validation has to be done here since the yml object is a list with the route
+        YamlValidator::validate<core::RoutesConfiguration>(route_yml, version);
+
         core::types::ParticipantId src;
         std::set<core::types::ParticipantId> dst;
 
         // Required route source
-        if (is_tag_present(route_yml, ROUTES_SRC_TAG))
-        {
-            src = get<core::types::ParticipantId>(route_yml, ROUTES_SRC_TAG, version);
-            if (object.routes.count(src) != 0)
-            {
-                throw eprosima::utils::ConfigurationException(
-                          utils::Formatter() <<
-                              "Multiple routes defined for participant " << src  << " : only one allowed.");
-            }
-        }
-        else
+        src = get<core::types::ParticipantId>(route_yml, ROUTES_SRC_TAG, version);
+
+        if (object.routes.count(src) != 0)
         {
             throw eprosima::utils::ConfigurationException(
-                      utils::Formatter() <<
-                          "Source participant required under tag " << ROUTES_SRC_TAG << " in route definition.");
+                        utils::Formatter() <<
+                            "Multiple routes defined for participant " << src  << " : only one allowed.");
         }
 
         // Optional route destination(s)
@@ -141,6 +165,20 @@ core::RoutesConfiguration YamlReader::get(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<core::TopicRoutesConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        TOPIC_NAME_TAG,
+        TOPIC_TYPE_NAME_TAG,
+        ROUTES_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 void YamlReader::fill(
         core::TopicRoutesConfiguration& object,
         const Yaml& yml,
@@ -157,44 +195,24 @@ void YamlReader::fill(
 
     for (const auto& topic_routes_yml : yml)
     {
+        YamlValidator::validate<core::TopicRoutesConfiguration>(topic_routes_yml, version);
+
         // utils::Heritable<ddspipe::core::types::DistributedTopic> topic;
         auto topic = utils::Heritable<ddspipe::core::types::DdsTopic>::make_heritable();
         core::RoutesConfiguration routes;
 
         // Required topic and type names
-        if (!(is_tag_present(topic_routes_yml,
-                TOPIC_NAME_TAG) && is_tag_present(topic_routes_yml, TOPIC_TYPE_NAME_TAG)))
+        fill<eprosima::ddspipe::core::types::DdsTopic>(topic.get_reference(), topic_routes_yml, version);
+
+        if (object.topic_routes.count(topic) != 0)
         {
             throw eprosima::utils::ConfigurationException(
-                      utils::Formatter() <<
-                          "Topic routes require topic and type names to be defined under tags " << TOPIC_NAME_TAG << " and " << TOPIC_TYPE_NAME_TAG <<
-                          ", respectively.");
-        }
-        else
-        {
-            topic = get<utils::Heritable<ddspipe::core::types::DistributedTopic>>(topic_routes_yml, version);
-            if (object.topic_routes.count(topic) != 0)
-            {
-                throw eprosima::utils::ConfigurationException(
-                          utils::Formatter() <<
-                              "Multiple routes defined for topic " << topic  << " : only one allowed.");
-            }
+                        utils::Formatter() <<
+                            "Multiple routes defined for topic " << topic  << " : only one allowed.");
         }
 
-        // Required routes
-        if (is_tag_present(topic_routes_yml, ROUTES_TAG))
-        {
-            routes = get<core::RoutesConfiguration>(topic_routes_yml, ROUTES_TAG, version);
-        }
-        else
-        {
-            throw eprosima::utils::ConfigurationException(
-                      utils::Formatter() <<
-                          "No routes found under tag " << ROUTES_TAG << " for topic " << topic << " .");
-        }
-
-        // Insert routes
-        object.topic_routes[topic] = routes;
+        // Required route
+        object.topic_routes[topic] = get<core::RoutesConfiguration>(topic_routes_yml, ROUTES_TAG, version);
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -37,6 +37,7 @@
 
 #include <ddspipe_yaml/Yaml.hpp>
 #include <ddspipe_yaml/YamlReader.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
 #include <ddspipe_yaml/yaml_configuration_tags.hpp>
 
 namespace eprosima {
@@ -65,10 +66,25 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<participants::ParticipantConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        PARTICIPANT_NAME_TAG,
+        PARTICIPANT_KIND_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 participants::ParticipantConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<participants::ParticipantConfiguration>(yml, version);
+
     participants::ParticipantConfiguration object;
     fill<participants::ParticipantConfiguration>(object, yml, version);
     return object;
@@ -107,10 +123,28 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<participants::EchoParticipantConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        PARTICIPANT_NAME_TAG,
+        PARTICIPANT_KIND_TAG,
+        ECHO_DATA_TAG,
+        ECHO_DISCOVERY_TAG,
+        ECHO_VERBOSE_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 participants::EchoParticipantConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<participants::EchoParticipantConfiguration>(yml, version);
+
     participants::EchoParticipantConfiguration object;
     fill<participants::EchoParticipantConfiguration>(object, yml, version);
     return object;
@@ -164,8 +198,26 @@ void YamlReader::fill(
     // Optional Praticipant Topic QoS
     if (YamlReader::is_tag_present(yml, PARTICIPANT_QOS_TAG))
     {
-        fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, PARTICIPANT_QOS_TAG), version);
+        object.topic_qos = get<TopicQoS>(yml, PARTICIPANT_QOS_TAG, version);
     }
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<participants::SimpleParticipantConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        PARTICIPANT_NAME_TAG,
+        PARTICIPANT_KIND_TAG,
+        DOMAIN_ID_TAG,
+        WHITELIST_INTERFACES_TAG,
+        TRANSPORT_DESCRIPTORS_TRANSPORT_TAG,
+        IGNORE_PARTICIPANT_FLAGS_TAG,
+        PARTICIPANT_QOS_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
 }
 
 template <>
@@ -174,6 +226,8 @@ participants::SimpleParticipantConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<participants::SimpleParticipantConfiguration>(yml, version);
+
     participants::SimpleParticipantConfiguration object;
     fill<participants::SimpleParticipantConfiguration>(object, yml, version);
     return object;
@@ -238,10 +292,34 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<participants::DiscoveryServerParticipantConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        PARTICIPANT_NAME_TAG,
+        PARTICIPANT_KIND_TAG,
+        DOMAIN_ID_TAG,
+        WHITELIST_INTERFACES_TAG,
+        TRANSPORT_DESCRIPTORS_TRANSPORT_TAG,
+        IGNORE_PARTICIPANT_FLAGS_TAG,
+        PARTICIPANT_QOS_TAG,
+        LISTENING_ADDRESSES_TAG,
+        CONNECTION_ADDRESSES_TAG,
+        TLS_TAG,
+        DISCOVERY_SERVER_GUID_PREFIX_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 participants::DiscoveryServerParticipantConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<participants::DiscoveryServerParticipantConfiguration>(yml, version);
+
     participants::DiscoveryServerParticipantConfiguration object;
     fill<participants::DiscoveryServerParticipantConfiguration>(object, yml, version);
     return object;
@@ -298,10 +376,34 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<participants::InitialPeersParticipantConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        PARTICIPANT_NAME_TAG,
+        PARTICIPANT_KIND_TAG,
+        DOMAIN_ID_TAG,
+        WHITELIST_INTERFACES_TAG,
+        TRANSPORT_DESCRIPTORS_TRANSPORT_TAG,
+        IGNORE_PARTICIPANT_FLAGS_TAG,
+        PARTICIPANT_QOS_TAG,
+        LISTENING_ADDRESSES_TAG,
+        CONNECTION_ADDRESSES_TAG,
+        TLS_TAG,
+        IS_REPEATER_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 participants::InitialPeersParticipantConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<participants::InitialPeersParticipantConfiguration>(yml, version);
+
     participants::InitialPeersParticipantConfiguration object;
     fill<participants::InitialPeersParticipantConfiguration>(object, yml, version);
     return object;
@@ -325,10 +427,31 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<participants::XmlParticipantConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        PARTICIPANT_NAME_TAG,
+        PARTICIPANT_KIND_TAG,
+        DOMAIN_ID_TAG,
+        WHITELIST_INTERFACES_TAG,
+        TRANSPORT_DESCRIPTORS_TRANSPORT_TAG,
+        IGNORE_PARTICIPANT_FLAGS_TAG,
+        PARTICIPANT_QOS_TAG,
+        XML_PARTICIPANT_PROFILE_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 participants::XmlParticipantConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<participants::XmlParticipantConfiguration>(yml, version);
+
     participants::XmlParticipantConfiguration object;
     fill<participants::XmlParticipantConfiguration>(object, yml, version);
     return object;

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -41,6 +41,7 @@
 
 #include <ddspipe_yaml/Yaml.hpp>
 #include <ddspipe_yaml/YamlReader.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
 #include <ddspipe_yaml/yaml_configuration_tags.hpp>
 
 namespace eprosima {
@@ -152,10 +153,26 @@ DomainId YamlReader::get<DomainId>(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<GuidPrefix>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        DISCOVERY_SERVER_GUID_TAG,
+        DISCOVERY_SERVER_ID_TAG,
+        DISCOVERY_SERVER_ID_ROS_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 GuidPrefix YamlReader::get<GuidPrefix>(
         const Yaml& yml,
         const YamlReaderVersion /* version */)
 {
+    YamlValidator::validate<GuidPrefix>(yml);
+
     // If guid exists, use it. Non mandatory.
     if (is_tag_present(yml, DISCOVERY_SERVER_GUID_TAG))
     {
@@ -187,10 +204,29 @@ GuidPrefix YamlReader::get<GuidPrefix>(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<Address>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        ADDRESS_IP_VERSION_TAG,
+        ADDRESS_IP_TAG,
+        ADDRESS_DNS_TAG,
+        ADDRESS_PORT_TAG,
+        ADDRESS_EXTERNAL_PORT_TAG,
+        ADDRESS_TRANSPORT_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 Address YamlReader::get<Address>(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<Address>(yml, version);
+
     // Optional get IP version
     IpVersion ip_version;
     bool ip_version_set = is_tag_present(yml, ADDRESS_IP_VERSION_TAG);
@@ -326,10 +362,34 @@ DiscoveryServerConnectionAddress _get_discovery_server_connection_address_latest
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<DiscoveryServerConnectionAddress>(
+        const Yaml& yml,
+        const YamlReaderVersion& version)
+{
+    std::set<TagType> tags{
+        COLLECTION_ADDRESSES_TAG};
+
+    switch (version)
+    {
+        case V_1_0:
+            break;
+
+        default:
+            tags.insert(DISCOVERY_SERVER_GUID_PREFIX_TAG);
+            break;
+    }
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 DiscoveryServerConnectionAddress YamlReader::get<DiscoveryServerConnectionAddress>(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<DiscoveryServerConnectionAddress>(yml, version);
+
     switch (version)
     {
         case V_1_0:
@@ -428,6 +488,39 @@ void YamlReader::fill(
     }
 }
 
+template <>
+DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<TopicQoS>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        QOS_TRANSIENT_TAG,
+        QOS_RELIABLE_TAG,
+        QOS_OWNERSHIP_TAG,
+        QOS_PARTITION_TAG,
+        QOS_HISTORY_DEPTH_TAG,
+        QOS_KEYED_TAG,
+        QOS_MAX_TX_RATE_TAG,
+        QOS_MAX_RX_RATE_TAG,
+        QOS_DOWNSAMPLING_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
+TopicQoS YamlReader::get<TopicQoS>(
+        const Yaml& yml,
+        const YamlReaderVersion version)
+{
+    YamlValidator::validate<TopicQoS>(yml, version);
+
+    TopicQoS object;
+    fill<TopicQoS>(object, yml, version);
+    return object;
+}
+
 /************************
 * TOPICS                *
 ************************/
@@ -448,10 +541,25 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<DdsTopic>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        TOPIC_NAME_TAG,
+        TOPIC_TYPE_NAME_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 DdsTopic YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<DdsTopic>(yml, version);
+
     DdsTopic object;
     fill<DdsTopic>(object, yml, version);
     return object;
@@ -476,8 +584,22 @@ void YamlReader::fill(
     // Optional QoS
     if (is_tag_present(yml, TOPIC_QOS_TAG))
     {
-        fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, TOPIC_QOS_TAG), version);
+        object.topic_qos = get<TopicQoS>(yml, TOPIC_QOS_TAG, version);
     }
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<WildcardDdsFilterTopic>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        TOPIC_NAME_TAG,
+        TOPIC_TYPE_NAME_TAG,
+        TOPIC_QOS_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
 }
 
 template <>
@@ -486,6 +608,8 @@ WildcardDdsFilterTopic YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<WildcardDdsFilterTopic>(yml, version);
+
     WildcardDdsFilterTopic object;
     fill<WildcardDdsFilterTopic>(object, yml, version);
     return object;
@@ -498,7 +622,10 @@ void YamlReader::fill(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
-    auto manual_topic = YamlReader::get<WildcardDdsFilterTopic>(yml, version);
+    // Avoid calling YamlReader::get to avoid validation at a lower level
+    WildcardDdsFilterTopic manual_topic;
+    YamlReader::fill<WildcardDdsFilterTopic>(manual_topic, yml, version);
+
     object.first = utils::Heritable<WildcardDdsFilterTopic>::make_heritable(manual_topic);
 
     // Optional participants tag
@@ -510,10 +637,27 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<ManualTopic>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        TOPIC_NAME_TAG,
+        TOPIC_TYPE_NAME_TAG,
+        TOPIC_QOS_TAG,
+        TOPIC_PARTICIPANTS_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 ManualTopic YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<ManualTopic>(yml, version);
+
     auto topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable();
     std::set<ParticipantId> participants;
     ManualTopic object = std::make_pair(topic, participants);
@@ -528,6 +672,8 @@ utils::Heritable<DistributedTopic> YamlReader::get(
         const YamlReaderVersion version)
 {
     // TODO: do not assume it is a Dds Topic
+    YamlValidator::validate<DdsTopic>(yml, version);
+
     auto topic = utils::Heritable<DdsTopic>::make_heritable();
     fill<DdsTopic>(topic.get_reference(), yml, version);
     return topic;
@@ -540,6 +686,8 @@ utils::Heritable<IFilterTopic> YamlReader::get(
         const YamlReaderVersion version)
 {
     // TODO: do not assume it is a Wildcard Topic
+    YamlValidator::validate<WildcardDdsFilterTopic>(yml, version);
+
     auto topic = utils::Heritable<WildcardDdsFilterTopic>::make_heritable();
     fill<WildcardDdsFilterTopic>(topic.get_reference(), yml, version);
     return topic;
@@ -627,10 +775,30 @@ void YamlReader::fill(
 
 template <>
 DDSPIPE_YAML_DllAPI
+bool YamlValidator::validate<TlsConfiguration>(
+        const Yaml& yml,
+        const YamlReaderVersion& /* version */)
+{
+    const std::set<TagType> tags{
+        TLS_PRIVATE_KEY_TAG,
+        TLS_PASSWORD_TAG,
+        TLS_CA_TAG,
+        TLS_CERT_TAG,
+        TLS_SNI_HOST_TAG,
+        TLS_DHPARAMS_TAG,
+        TLS_PEER_VERIFICATION_TAG};
+
+    return YamlValidator::validate_tags_(yml, tags);
+}
+
+template <>
+DDSPIPE_YAML_DllAPI
 TlsConfiguration YamlReader::get(
         const Yaml& yml,
         const YamlReaderVersion version)
 {
+    YamlValidator::validate<TlsConfiguration>(yml, version);
+
     TlsConfiguration object;
     fill<TlsConfiguration>(object, yml, version);
     return object;

--- a/ddspipe_yaml/src/cpp/YamlValidator.cpp
+++ b/ddspipe_yaml/src/cpp/YamlValidator.cpp
@@ -1,0 +1,54 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file YamlValidator.cpp
+ *
+ */
+
+#include <cpp_utils/Log.hpp>
+#include <ddspipe_yaml/YamlValidator.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace yaml {
+
+bool YamlValidator::validate_tags_(
+    const Yaml& yml,
+    const std::set<TagType>& tags)
+{
+    if (!yml.IsMap() && !yml.IsNull())
+    {
+        throw eprosima::utils::ConfigurationException(
+                  utils::Formatter() << "The yml: <" << yml << "> is not a yaml object map.");
+    }
+
+    // Check if there are any extra tags that are not in either list
+    for (const auto& tag_it : yml)
+    {
+        const auto& tag = tag_it.first.as<TagType>();
+
+        if (!tags.count(tag))
+        {
+            logWarning(DDSPIPE_YAML, "Tag <" << tag << "> is not a valid tag.");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} /* namespace yaml */
+} /* namespace ddspipe */
+} /* namespace eprosima */


### PR DESCRIPTION
In this version, the DDS Pipe throw a warning when a YAML tag is ignored to prevent typos, misplacements, and wrong configurations.