### PR TITLE
[19983] Report more warnings in the readers

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -83,8 +83,8 @@ public:
             const fastdds::dds::RequestedIncompatibleQosStatus& status);
 
     virtual void on_inconsistent_topic(
-            fadsdds::dds::Topic* topic,
-            fadsdds::dds::InconsistentTopicStatus status);
+            fastdds::dds::Topic* topic,
+            fastdds::dds::InconsistentTopicStatus status);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -73,6 +73,14 @@ public:
     virtual void on_data_available(
             fastdds::dds::DataReader* reader);
 
+    virtual void on_sample_lost(
+            fastdds::dds::DataReader* reader,
+            const fastdds::dds::SampleLostStatus& status);
+
+    virtual void on_requested_incompatible_qos(
+            fastdds::dds::DataReader* reader,
+            fastdds::dds::PolicyMask qos);
+
 protected:
 
     /////////////////////////

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -24,6 +24,7 @@
 #include <fastdds/dds/subscriber/qos/DataReaderQos.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
+#include <fastdds/dds/topic/TopicListener.hpp>
 
 #include <ddspipe_core/types/data/RtpsPayloadData.hpp>
 #include <ddspipe_core/types/dds/Guid.hpp>
@@ -45,7 +46,7 @@ namespace dds {
  *
  * @warning This object is not RAII and must be initialized before used.
  */
-class CommonReader : public BaseReader, public fastdds::dds::DataReaderListener
+class CommonReader : public BaseReader, public fastdds::dds::DataReaderListener, public fastdds::dds::TopicListener
 {
 public:
 
@@ -80,6 +81,10 @@ public:
     virtual void on_requested_incompatible_qos(
             fastdds::dds::DataReader* reader,
             const fastdds::dds::RequestedIncompatibleQosStatus& status);
+
+    virtual void on_inconsistent_topic(
+            fadsdds::dds::Topic* topic,
+            fadsdds::dds::InconsistentTopicStatus status);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -79,7 +79,7 @@ public:
 
     virtual void on_requested_incompatible_qos(
             fastdds::dds::DataReader* reader,
-            fastdds::dds::PolicyMask qos);
+            const fastdds::dds::RequestedIncompatibleQosStatus& status);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -155,7 +155,7 @@ public:
      */
     DDSPIPE_PARTICIPANTS_DllAPI
     void on_incompatible_type(
-        fastrtps::rtps::RTPSReader* reader) noexcept override;
+            fastrtps::rtps::RTPSReader* reader) noexcept override;
 
     /////////////////////////
     // RPC REQUIRED METHODS

--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -153,7 +153,6 @@ public:
      *
      * @param reader Pointer to the RTPSReader.
      */
-
     DDSPIPE_PARTICIPANTS_DllAPI
     void on_incompatible_type(
         fastrtps::rtps::RTPSReader* reader) noexcept override;

--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -147,6 +147,17 @@ public:
             eprosima::fastdds::dds::SampleRejectedStatusKind reason,
             const fastrtps::rtps::CacheChange_t* const change) noexcept override;
 
+    /**
+     * This method is called when a new Writer is discovered, with a Topic that
+     * matches the name of a local reader, but with an incompatible type
+     *
+     * @param reader Pointer to the RTPSReader.
+     */
+
+    DDSPIPE_PARTICIPANTS_DllAPI
+    void on_incompatible_type(
+        fastrtps::rtps::RTPSReader* reader) noexcept override;
+
     /////////////////////////
     // RPC REQUIRED METHODS
     /////////////////////////

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -116,10 +116,18 @@ void CommonReader::on_sample_lost(
 
 void CommonReader::on_requested_incompatible_qos(
         fastdds::dds::DataReader* reader,
-        const fastdds::dds::RequestedIncompatibleQosStatus& statuss)
+        const fastdds::dds::RequestedIncompatibleQosStatus& status)
 {
     logWarning(DDSPIPE_DDS_READER,
             "TOPIC_MISMATCH_QOS | Reader " << *this << " found a remote Writer with incompatible QoS");
+}
+
+void CommonReader::on_inconsistent_topic(
+        fadsdds::dds::Topic* topic,
+        fadsdds::dds::InconsistentTopicStatus status)
+{
+    logWarning(DDSPIPE_DDS_READER,
+            "TOPIC_MISMATCH_TYPE | Reader " << *this << " found a remote Writer with same topic name but incompatible type");
 }
 
 CommonReader::CommonReader(

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -106,6 +106,22 @@ void CommonReader::on_data_available(
     on_data_available_();
 }
 
+void CommonReader::on_sample_lost(
+        fastdds::dds::DataReader* reader,
+        const fastdds::dds::SampleLostStatus& status)
+{
+    logWarning(DDSPIPE_DDS_READER,
+            "On reader " << *this << " a data sample was lost and will not be received");
+}
+
+void CommonReader::on_requested_incompatible_qos(
+        fastdds::dds::DataReader* reader,
+        fastdds::dds::PolicyMask qos)
+{
+    logWarning(DDSPIPE_DDS_READER,
+            "Reader " << *this << " found a remote Writer with incompatible QoS: " << qos);
+}
+
 CommonReader::CommonReader(
         const ParticipantId& participant_id,
         const DdsTopic& topic,

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -127,7 +127,8 @@ void CommonReader::on_inconsistent_topic(
         fastdds::dds::InconsistentTopicStatus status)
 {
     logWarning(DDSPIPE_DDS_READER,
-            "TOPIC_MISMATCH_TYPE | Reader " << *this << " found a remote Writer with same topic name but incompatible type");
+            "TOPIC_MISMATCH_TYPE | Reader " << *this <<
+                            " found a remote Writer with same topic name but incompatible type");
 }
 
 CommonReader::CommonReader(

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -128,7 +128,7 @@ void CommonReader::on_inconsistent_topic(
 {
     logWarning(DDSPIPE_DDS_READER,
             "TOPIC_MISMATCH_TYPE | Reader " << *this <<
-                            " found a remote Writer with same topic name but incompatible type");
+            " found a remote Writer with same topic name but incompatible type");
 }
 
 CommonReader::CommonReader(

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -111,15 +111,15 @@ void CommonReader::on_sample_lost(
         const fastdds::dds::SampleLostStatus& status)
 {
     logWarning(DDSPIPE_DDS_READER,
-            "On reader " << *this << " a data sample was lost and will not be received");
+            "SAMPLE_LOST | On reader " << *this << " a data sample was lost and will not be received");
 }
 
 void CommonReader::on_requested_incompatible_qos(
         fastdds::dds::DataReader* reader,
-        fastdds::dds::PolicyMask qos)
+        const fastdds::dds::RequestedIncompatibleQosStatus& statuss)
 {
     logWarning(DDSPIPE_DDS_READER,
-            "Reader " << *this << " found a remote Writer with incompatible QoS: " << qos);
+            "TOPIC_MISMATCH_QOS | Reader " << *this << " found a remote Writer with incompatible QoS");
 }
 
 CommonReader::CommonReader(

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -123,8 +123,8 @@ void CommonReader::on_requested_incompatible_qos(
 }
 
 void CommonReader::on_inconsistent_topic(
-        fadsdds::dds::Topic* topic,
-        fadsdds::dds::InconsistentTopicStatus status)
+        fastdds::dds::Topic* topic,
+        fastdds::dds::InconsistentTopicStatus status)
 {
     logWarning(DDSPIPE_DDS_READER,
             "TOPIC_MISMATCH_TYPE | Reader " << *this << " found a remote Writer with same topic name but incompatible type");

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -446,7 +446,7 @@ void CommonReader::on_requested_incompatible_qos(
         eprosima::fastdds::dds::PolicyMask qos) noexcept
 {
     logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
-            "Reader " << *this << " found a remote Writer with incompatible QoS: " << qos);
+            "TOPIC_MISMATCH_QOS | Reader " << *this << " found a remote Writer with incompatible QoS: " << qos);
 }
 
 void CommonReader::on_sample_lost(
@@ -454,7 +454,7 @@ void CommonReader::on_sample_lost(
         int32_t sample_lost_since_last_update) noexcept
 {
     logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
-            "On reader " << *this << " a data sample was lost and will not be received");
+            "SAMPLE_LOST | On reader " << *this << " a data sample was lost and will not be received");
 }
 
 void CommonReader::on_sample_rejected(
@@ -490,7 +490,7 @@ void CommonReader::on_incompatible_type(
         fastrtps::rtps::RTPSReader* reader) noexcept
 {
     logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
-            "Reader " << *this << " shows incompatible type")
+            "TOPIC_MISMATCH_TYPE | Reader " << *this << " shows incompatible type")
 }
 
 utils::ReturnCode CommonReader::is_data_correct_(

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -490,7 +490,8 @@ void CommonReader::on_incompatible_type(
         fastrtps::rtps::RTPSReader* reader) noexcept
 {
     logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
-            "TOPIC_MISMATCH_TYPE | Reader " << *this << " discovered a Writer with a matching Topic name but with an incompatible type");
+            "TOPIC_MISMATCH_TYPE | Reader " << *this <<
+                            " discovered a Writer with a matching Topic name but with an incompatible type");
 }
 
 utils::ReturnCode CommonReader::is_data_correct_(

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -490,7 +490,7 @@ void CommonReader::on_incompatible_type(
         fastrtps::rtps::RTPSReader* reader) noexcept
 {
     logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
-            "TOPIC_MISMATCH_TYPE | Reader " << *this << " shows incompatible type")
+            "TOPIC_MISMATCH_TYPE | Reader " << *this << " discovered a Writer with a matching Topic name but with an incompatible type");
 }
 
 utils::ReturnCode CommonReader::is_data_correct_(

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -486,6 +486,13 @@ void CommonReader::on_sample_rejected(
                       << ". Reason: " << reason_str);
 }
 
+void CommonReader::on_incompatible_type(
+        fastrtps::rtps::RTPSReader* reader) noexcept
+{
+    logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
+            "Reader " << *this << " shows incompatible type")
+}
+
 utils::ReturnCode CommonReader::is_data_correct_(
         const fastrtps::rtps::CacheChange_t* received_change) const noexcept
 {

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -491,7 +491,7 @@ void CommonReader::on_incompatible_type(
 {
     logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
             "TOPIC_MISMATCH_TYPE | Reader " << *this <<
-                            " discovered a Writer with a matching Topic name but with an incompatible type");
+            " discovered a Writer with a matching Topic name but with an incompatible type");
 }
 
 utils::ReturnCode CommonReader::is_data_correct_(


### PR DESCRIPTION
**New warnings** reported:
1. **Topic with type mismatch:** [DDSRECORDER_MCAP_HANDLER Warning] TOPIC_MISMATCH_TYPE | Reader found a remote Writer with same topic name but incompatible type
2. **Topic with QoS mismatch:** [DDSRECORDER_MCAP_HANDLER Warning] TOPIC_MISMATCH_QOS | Reader found a remote Writer with incompatible QoS
3. **Missing samples:** [DDSRECORDER_MCAP_HANDLER Warning] SAMPLE_LOST | On readers a data sample was lost and will not be received