### PR TITLE
Avoid potential neverending closure

### DIFF
--- a/ddspipe_core/src/cpp/core/DdsPipe.cpp
+++ b/ddspipe_core/src/cpp/core/DdsPipe.cpp
@@ -93,11 +93,11 @@ DdsPipe::~DdsPipe()
     // Stop Discovery Database
     discovery_database_->stop();
 
-    // Disable thread pool
-    thread_pool_->disable();
-
     // Stop all communications
     disable();
+
+    // Disable thread pool
+    thread_pool_->disable();
 
     // Destroy Bridges, so Writers and Readers are destroyed before the Databases
     bridges_.clear();


### PR DESCRIPTION
This small PR pretends to avoid the following situation: when the rate of reception for a topic is greater than the rate these messages can be processed in the ThreadPool's working threads, a DDS-Pipe instance might get stuck in its destructor. The reason for this is that before disabling internal entities (which would prevent receiving new samples, and abort ongoing tracks' transmission tasks), the thread pool is disabled. Disabling the thread pool makes it wait until all threads are joined (which occurs when all ongoing tasks are completed), but this may never happen in the described scenario.

NOTE: this problem would not happen if applications using DDS-Pipe would always call `DdsPipe::disable` before destroying the object. However DDS-Pipe should be as resilient as possible to the way it is used above, hence this proposal.