### PR TITLE
Echo participant undiscovery + Discovery callbacks update

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/EchoParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/EchoParticipant.hpp
@@ -41,6 +41,11 @@ public:
     void echo_discovery(
             core::types::Endpoint endpoint_discovered) const noexcept;
 
+    //! Print discovery information from endpoint updated
+    DDSPIPE_PARTICIPANTS_DllAPI
+    void echo_updated(
+            core::types::Endpoint endpoint_updated) const noexcept;
+
     //! Override create_writer() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     std::shared_ptr<core::IWriter> create_writer(

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -106,6 +106,10 @@ public:
     // LISTENER METHODS
     /////////////////////////
 
+    virtual void on_participant_discovery(
+            fastdds::dds::DomainParticipant* participant,
+            fastrtps::rtps::ParticipantDiscoveryInfo&& info) override;
+
     virtual void on_subscriber_discovery(
             fastdds::dds::DomainParticipant* participant,
             fastrtps::rtps::ReaderDiscoveryInfo&& info) override;

--- a/ddspipe_participants/src/cpp/participant/auxiliar/EchoParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/auxiliar/EchoParticipant.cpp
@@ -43,6 +43,7 @@ EchoParticipant::EchoParticipant(
                 this->echo_discovery(endpoint_discovered);
             });
 
+        // Register in Discovery DB a callback to be notified each time an endpoint is updated
         discovery_database->add_endpoint_updated_callback(
             [this](const core::types::Endpoint& endpoint_updated)
             {
@@ -63,7 +64,13 @@ void EchoParticipant::echo_discovery(
 void EchoParticipant::echo_updated(
         core::types::Endpoint endpoint_updated) const noexcept
 {
-    if (!endpoint_updated.active)
+    if (endpoint_updated.active)
+    {
+        logUser(
+            DDSPIPE_ECHO_DISCOVERY,
+            "Endpoint updated: " << endpoint_updated << ".");
+    }
+    else
     {
         logUser(
             DDSPIPE_ECHO_DISCOVERY,

--- a/ddspipe_participants/src/cpp/participant/auxiliar/EchoParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/auxiliar/EchoParticipant.cpp
@@ -67,7 +67,7 @@ void EchoParticipant::echo_updated(
     {
         logUser(
             DDSPIPE_ECHO_DISCOVERY,
-            "Endpoint undiscovered: " << endpoint_updated << ".");
+            "Endpoint removed: " << endpoint_updated << ".");
     }
 }
 

--- a/ddspipe_participants/src/cpp/participant/auxiliar/EchoParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/auxiliar/EchoParticipant.cpp
@@ -42,6 +42,12 @@ EchoParticipant::EchoParticipant(
             {
                 this->echo_discovery(endpoint_discovered);
             });
+
+        discovery_database->add_endpoint_updated_callback(
+            [this](const core::types::Endpoint& endpoint_updated)
+            {
+                this->echo_updated(endpoint_updated);
+            });
     }
 }
 
@@ -52,6 +58,17 @@ void EchoParticipant::echo_discovery(
     logUser(
         DDSPIPE_ECHO_DISCOVERY,
         "New endpoint discovered: " << endpoint_discovered << ".");
+}
+
+void EchoParticipant::echo_updated(
+        core::types::Endpoint endpoint_updated) const noexcept
+{
+    if (!endpoint_updated.active)
+    {
+        logUser(
+            DDSPIPE_ECHO_DISCOVERY,
+            "Endpoint undiscovered: " << endpoint_updated << ".");
+    }
 }
 
 std::shared_ptr<core::IWriter> EchoParticipant::create_writer(

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -99,9 +99,13 @@ void CommonParticipant::onParticipantDiscovery(
         {
             logInfo(DDSPIPE_DISCOVERY, "Participant " << info.info.m_guid << " removed.");
         }
-        else
+        else if (info.status == fastrtps::rtps::ParticipantDiscoveryInfo::DROPPED_PARTICIPANT)
         {
             logInfo(DDSPIPE_DISCOVERY, "Participant " << info.info.m_guid << " dropped.");
+        }
+        else if (info.status == fastrtps::rtps::ParticipantDiscoveryInfo::IGNORED_PARTICIPANT)
+        {
+            logInfo(DDSPIPE_DISCOVERY, "Participant " << info.info.m_guid << " ignored.");
         }
     }
 }
@@ -135,12 +139,11 @@ void CommonParticipant::onReaderDiscovery(
             info_reader.active = false;
             this->discovery_database_->update_endpoint(info_reader);
         }
-        else
+        else if (info.status == fastrtps::rtps::ReaderDiscoveryInfo::IGNORED_READER)
         {
-            logInfo(DDSPIPE_DISCOVERY, "Reader " << info.info.guid() << " dropped.");
+            logInfo(DDSPIPE_DISCOVERY, "Reader " << info.info.guid() << " ignored.");
 
-            info_reader.active = false;
-            this->discovery_database_->update_endpoint(info_reader);
+            // Do not notify discovery database (design choice that might be changed in the future)
         }
     }
 }
@@ -174,12 +177,11 @@ void CommonParticipant::onWriterDiscovery(
             info_writer.active = false;
             this->discovery_database_->update_endpoint(info_writer);
         }
-        else
+        else if (info.status == fastrtps::rtps::WriterDiscoveryInfo::IGNORED_WRITER)
         {
-            logInfo(DDSPIPE_DISCOVERY, "Writer " << info.info.guid() << " dropped.");
+            logInfo(DDSPIPE_DISCOVERY, "Writer " << info.info.guid() << " ignored.");
 
-            info_writer.active = false;
-            this->discovery_database_->update_endpoint(info_writer);
+            // Do not notify discovery database (design choice that might be changed in the future)
         }
     }
 }


### PR DESCRIPTION
Echo participant only advised participant discovery.
With this PR it also advises participant undiscovery when participant has been updated and it is not active.

In addition, participant discovery callback is now also implemented in DdsCommonParticipant, and already implemented discovery callbacks (both for RTPS and DDS) updated to adapt to changes introduced in Fast-DDS middleware (e.g. ignore participant/endpoint feature). 