### PR TITLE
Empty XTSAN tests list

### DIFF
--- a/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
+++ b/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
@@ -38,8 +38,6 @@ add_blackbox_executable(
 # TODO: use a cmake_utils macro
 set(
     XTSAN_TEST_LIST
-        "ParticipantsCreationgTest.creation_trivial"
-        "ParticipantsCreationgTest.ddspipe_all_creation_builtin_topic"
 )
 
 foreach(XTSAN_TEST ${XTSAN_TEST_LIST})


### PR DESCRIPTION
Up to https://github.com/eProsima/eProsima-CI/pull/77 , almost every test using Fast-DDS was reporting multiple TSAN warnings that were in fact false positives. For this reason these tests were categorized as flaky when running the TSAN action, but after the update in eProsima-CI they should no longer fail.