### PR TITLE
Test if commenting the logs fixes the tests in Windows 2022

### DIFF
--- a/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_ip_and_domain.ipp
+++ b/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_ip_and_domain.ipp
@@ -38,7 +38,7 @@ TEST(YamlGetEntityAddressTest, ip_and_domain)
 {
     // Check a warning is shown
     // eprosima::ddspipe::core::TestLogHandler log_handler(utils::Log::Kind::Warning, 1);
-    INSTANTIATE_LOG_TESTER(eprosima::utils::Log::Kind::Warning, 1, 0);
+    // INSTANTIATE_LOG_TESTER(eprosima::utils::Log::Kind::Warning, 1, 0);
 
     // Set address
     Yaml yml_address;


### PR DESCRIPTION
We have modified the YamlGetEntityAddressTest.ip_and_domain test to check our hypothesis that the logs are making the tests fail in Windows 2022 with: `unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.`