### PR TITLE
[21227] Print PolicyMasks as strings

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/rtps/CommonReader.hpp
@@ -121,7 +121,7 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     void on_requested_incompatible_qos(
             fastrtps::rtps::RTPSReader*,
-            eprosima::fastdds::dds::PolicyMask qos) noexcept override;
+            fastdds::dds::PolicyMask qos) noexcept override;
 
     /**
      * This method is called when the reader detects that one or more samples have been lost.

--- a/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
@@ -130,7 +130,7 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     void on_offered_incompatible_qos(
             fastrtps::rtps::RTPSWriter*,
-            eprosima::fastdds::dds::PolicyMask qos) noexcept override;
+            fastdds::dds::PolicyMask qos) noexcept override;
 
     /////////////////////
     // STATIC ATTRIBUTES

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -17,6 +17,7 @@
 
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/Log.hpp>
+#include <cpp_utils/qos/qos_utils.hpp>
 
 #include <ddspipe_core/interface/IRoutingData.hpp>
 #include <ddspipe_core/monitoring/producers/StatusMonitorProducer.hpp>
@@ -447,10 +448,11 @@ void CommonReader::onReaderMatched(
 
 void CommonReader::on_requested_incompatible_qos(
         fastrtps::rtps::RTPSReader*,
-        eprosima::fastdds::dds::PolicyMask qos) noexcept
+        fastdds::dds::PolicyMask qos) noexcept
 {
     logWarning(DDSPIPE_RTPS_COMMONREADER_LISTENER,
-            "TOPIC_MISMATCH_QOS | Reader " << *this << " found a remote Writer with incompatible QoS: " << qos);
+            "TOPIC_MISMATCH_QOS | Reader " << *this << " found a remote Writer with incompatible QoS: " <<
+            utils::qos_policy_mask_to_string(qos));
 
     monitor_qos_mismatch(topic_);
     monitor_error("QOS_MISMATCH");

--- a/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
@@ -19,6 +19,7 @@
 
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/Log.hpp>
+#include <cpp_utils/qos/qos_utils.hpp>
 #include <cpp_utils/time/time_utils.hpp>
 
 #include <ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp>
@@ -138,10 +139,11 @@ void CommonWriter::onWriterChangeReceivedByAll(
 
 void CommonWriter::on_offered_incompatible_qos(
         fastrtps::rtps::RTPSWriter*,
-        eprosima::fastdds::dds::PolicyMask qos) noexcept
+        fastdds::dds::PolicyMask qos) noexcept
 {
     logWarning(DDSPIPE_RTPS_COMMONWRITER_LISTENER,
-            "Writer " << *this << " found a remote Reader with incompatible QoS: " << qos);
+            "Writer " << *this << " found a remote Reader with incompatible QoS: " <<
+            utils::qos_policy_mask_to_string(qos));
 }
 
 bool CommonWriter::come_from_this_participant_(


### PR DESCRIPTION
In the previous version, `PolicyMasks` were being printed as bitsets, making them unreadable to humans. In this version, they use dev-utils methods to convert them to strings and make them readable.

Merge after:
- https://github.com/eProsima/dev-utils/pull/118