### PR TITLE
Accept v6 interfaces and interface names in whitelist [21531]

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp
@@ -51,7 +51,7 @@ public:
 
     core::types::DomainId domain {0u};
 
-    std::set<participants::types::IpType> whitelist {};
+    std::set<participants::types::WhitelistType> whitelist {};
 
     core::types::TransportDescriptors transport {core::types::TransportDescriptors::builtin};
 

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -181,7 +181,7 @@ public:
     template<typename T>
     DDSPIPE_PARTICIPANTS_DllAPI
     static std::shared_ptr<T> create_descriptor(
-            std::set<types::IpType> whitelist = {});
+            std::set<types::WhitelistType> whitelist = {});
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/types/address/Address.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/types/address/Address.hpp
@@ -29,6 +29,8 @@ namespace types {
 using LocatorType = uint32_t;
 // Data Type for IP
 using IpType = std::string;
+// Data Type for an interfaces whitelist entry
+using WhitelistType = std::string;
 // Data Type for Domain name (DNS)
 using DomainType = std::string;
 // Data Type for Port

--- a/ddspipe_participants/src/cpp/configuration/SimpleParticipantConfiguration.cpp
+++ b/ddspipe_participants/src/cpp/configuration/SimpleParticipantConfiguration.cpp
@@ -35,16 +35,6 @@ bool SimpleParticipantConfiguration::is_valid(
         return false;
     }
 
-    // Check whitelist interfaces
-    for (types::IpType ip : whitelist)
-    {
-        if (!types::Address::is_ipv4_correct(ip))
-        {
-            error_msg << "Incorrect IPv4 address " << ip << " in whitelist interfaces. ";
-            return false;
-        }
-    }
-
     return true;
 }
 

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -211,25 +211,16 @@ template<>
 DDSPIPE_PARTICIPANTS_DllAPI
 std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor>
 CommonParticipant::create_descriptor(
-        std::set<types::IpType> whitelist)
+        std::set<types::WhitelistType> whitelist)
 {
     std::shared_ptr<eprosima::fastdds::rtps::UDPv4TransportDescriptor> udp_transport =
             std::make_shared<eprosima::fastdds::rtps::UDPv4TransportDescriptor>();
 
-    for (const types::IpType& ip : whitelist)
+    for (const types::WhitelistType& iface : whitelist)
     {
-        if (types::Address::is_ipv4_correct(ip))
-        {
-            udp_transport->interfaceWhiteList.emplace_back(ip);
-            EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
-                    "Adding " << ip << " to UDP whitelist interfaces.");
-        }
-        else
-        {
-            // Invalid address, continue with next one
-            EPROSIMA_LOG_WARNING(DDSPIPE_COMMON_PARTICIPANT,
-                    "Not valid IPv4. Discarding UDP whitelist interface " << ip << ".");
-        }
+        udp_transport->interfaceWhiteList.emplace_back(iface);
+        EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
+                "Adding " << iface << " to UDP whitelist interfaces.");
     }
 
     return udp_transport;
@@ -239,25 +230,16 @@ template<>
 DDSPIPE_PARTICIPANTS_DllAPI
 std::shared_ptr<eprosima::fastdds::rtps::UDPv6TransportDescriptor>
 CommonParticipant::create_descriptor(
-        std::set<types::IpType> whitelist)
+        std::set<types::WhitelistType> whitelist)
 {
     std::shared_ptr<eprosima::fastdds::rtps::UDPv6TransportDescriptor> udp_transport =
             std::make_shared<eprosima::fastdds::rtps::UDPv6TransportDescriptor>();
 
-    for (const types::IpType& ip : whitelist)
+    for (const types::WhitelistType& iface : whitelist)
     {
-        if (types::Address::is_ipv6_correct(ip))
-        {
-            udp_transport->interfaceWhiteList.emplace_back(ip);
-            EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
-                    "Adding " << ip << " to UDP whitelist interfaces.");
-        }
-        else
-        {
-            // Invalid address, continue with next one
-            EPROSIMA_LOG_WARNING(DDSPIPE_COMMON_PARTICIPANT,
-                    "Not valid IPv6. Discarding UDP whitelist interface " << ip << ".");
-        }
+        udp_transport->interfaceWhiteList.emplace_back(iface);
+        EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
+                "Adding " << iface << " to UDP whitelist interfaces.");
     }
 
     return udp_transport;
@@ -267,25 +249,16 @@ template<>
 DDSPIPE_PARTICIPANTS_DllAPI
 std::shared_ptr<eprosima::fastdds::rtps::TCPv4TransportDescriptor>
 CommonParticipant::create_descriptor(
-        std::set<types::IpType> whitelist)
+        std::set<types::WhitelistType> whitelist)
 {
     std::shared_ptr<eprosima::fastdds::rtps::TCPv4TransportDescriptor> tcp_transport =
             std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
 
-    for (const types::IpType& ip : whitelist)
+    for (const types::WhitelistType& iface : whitelist)
     {
-        if (types::Address::is_ipv4_correct(ip))
-        {
-            tcp_transport->interfaceWhiteList.emplace_back(ip);
-            EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
-                    "Adding " << ip << " to TCP whitelist interfaces.");
-        }
-        else
-        {
-            // Invalid address, continue with next one
-            EPROSIMA_LOG_WARNING(DDSPIPE_COMMON_PARTICIPANT,
-                    "Not valid IPv4. Discarding TCP whitelist interface " << ip << ".");
-        }
+        tcp_transport->interfaceWhiteList.emplace_back(iface);
+        EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
+                "Adding " << iface << " to TCP whitelist interfaces.");
     }
 
     return tcp_transport;
@@ -295,25 +268,16 @@ template<>
 DDSPIPE_PARTICIPANTS_DllAPI
 std::shared_ptr<eprosima::fastdds::rtps::TCPv6TransportDescriptor>
 CommonParticipant::create_descriptor(
-        std::set<types::IpType> whitelist)
+        std::set<types::WhitelistType> whitelist)
 {
     std::shared_ptr<eprosima::fastdds::rtps::TCPv6TransportDescriptor> tcp_transport =
             std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
 
-    for (const types::IpType& ip : whitelist)
+    for (const types::WhitelistType& iface : whitelist)
     {
-        if (types::Address::is_ipv6_correct(ip))
-        {
-            tcp_transport->interfaceWhiteList.emplace_back(ip);
-            EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
-                    "Adding " << ip << " to TCP whitelist interfaces.");
-        }
-        else
-        {
-            // Invalid address, continue with next one
-            EPROSIMA_LOG_WARNING(DDSPIPE_COMMON_PARTICIPANT,
-                    "Not valid IPv6. Discarding TCP whitelist interface " << ip << ".");
-        }
+        tcp_transport->interfaceWhiteList.emplace_back(iface);
+        EPROSIMA_LOG_INFO(DDSPIPE_COMMON_PARTICIPANT,
+                "Adding " << iface << " to TCP whitelist interfaces.");
     }
 
     return tcp_transport;

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -137,7 +137,8 @@ void YamlReader::fill(
     // Optional whitelist interfaces
     if (YamlReader::is_tag_present(yml, WHITELIST_INTERFACES_TAG))
     {
-        object.whitelist = YamlReader::get_set<participants::types::IpType>(yml, WHITELIST_INTERFACES_TAG, version);
+        object.whitelist = YamlReader::get_set<participants::types::WhitelistType>(yml, WHITELIST_INTERFACES_TAG,
+                        version);
     }
 
     // Optional get Transport descriptors
@@ -194,7 +195,8 @@ void YamlReader::fill(
     // Optional whitelist interfaces
     if (YamlReader::is_tag_present(yml, WHITELIST_INTERFACES_TAG))
     {
-        object.whitelist = YamlReader::get_set<participants::types::IpType>(yml, WHITELIST_INTERFACES_TAG, version);
+        object.whitelist = YamlReader::get_set<participants::types::WhitelistType>(yml, WHITELIST_INTERFACES_TAG,
+                        version);
     }
 
     // Optional listening addresses
@@ -262,7 +264,8 @@ void YamlReader::fill(
     // Optional whitelist interfaces
     if (YamlReader::is_tag_present(yml, WHITELIST_INTERFACES_TAG))
     {
-        object.whitelist = YamlReader::get_set<participants::types::IpType>(yml, WHITELIST_INTERFACES_TAG, version);
+        object.whitelist = YamlReader::get_set<participants::types::WhitelistType>(yml, WHITELIST_INTERFACES_TAG,
+                        version);
     }
 
     // Optional listening addresses


### PR DESCRIPTION
This PR removes the constraint of whitelist elements to be IPv4 addresses, accepting now IPv6 ones as well (for WAN and DiscoverServer participants only) and device names.