### PR TITLE
Make DiscoveryServer servers' guid prefix optional

### DIFF
--- a/ddspipe_core/include/ddspipe_core/types/dds/GuidPrefix.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/GuidPrefix.hpp
@@ -75,12 +75,12 @@ public:
      *
      * @todo use the seed of \c id to modify the whole guid and not only one of the 12 values.
      *
-     * @param ros : whether to use the Discovery Server ROS2 specific guid [Default: false]
+     * @param ros : whether to use the Discovery Server ROS2 specific guid
      * @param id : number to seed for the final Guid Prefix [Default: 0]
      */
     DDSPIPE_CORE_DllAPI
     GuidPrefix (
-            bool ros = false,
+            bool ros,
             uint32_t id = 0) noexcept;
 
     /**

--- a/ddspipe_core/src/cpp/types/dds/GuidPrefix.cpp
+++ b/ddspipe_core/src/cpp/types/dds/GuidPrefix.cpp
@@ -41,7 +41,7 @@ GuidPrefix::GuidPrefix (
 }
 
 GuidPrefix::GuidPrefix (
-        bool ros /*= false*/,
+        bool ros,
         uint32_t id /*= 0*/) noexcept
 {
     if (ros)

--- a/ddspipe_participants/src/cpp/configuration/DiscoveryServerParticipantConfiguration.cpp
+++ b/ddspipe_participants/src/cpp/configuration/DiscoveryServerParticipantConfiguration.cpp
@@ -33,13 +33,6 @@ bool DiscoveryServerParticipantConfiguration::is_valid(
         return false;
     }
 
-    // Check DS Guid Prefix
-    if (!discovery_server_guid_prefix.is_valid())
-    {
-        error_msg << "Non valid Participant Guid Prefix " << discovery_server_guid_prefix << ". ";
-        return false;
-    }
-
     // Check listening addresses
     for (types::Address address : listening_addresses)
     {

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -230,19 +230,24 @@ void CommonParticipant::on_participant_discovery(
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::CHANGED_QOS_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " changed QoS.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid <<
+                    " changed QoS.");
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::REMOVED_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " removed.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid << " removed.");
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::DROPPED_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " dropped.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid << " dropped.");
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::IGNORED_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " ignored.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid << " ignored.");
         }
     }
 }
@@ -275,20 +280,23 @@ void CommonParticipant::on_data_reader_discovery(
     }
     else if (reason == fastdds::rtps::ReaderDiscoveryStatus::CHANGED_QOS_READER)
     {
-        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Reader " << info.guid << " changed TopicQoS.");
+        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                configuration_->id << " participant : " << "Reader " << info.guid << " changed TopicQoS.");
 
         this->discovery_database_->update_endpoint(info_reader);
     }
     else if (reason == fastdds::rtps::ReaderDiscoveryStatus::REMOVED_READER)
     {
-        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Reader " << info.guid << " removed.");
+        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                configuration_->id << " participant : " << "Reader " << info.guid << " removed.");
 
         info_reader.active = false;
         this->discovery_database_->update_endpoint(info_reader);
     }
     else if (reason == fastdds::rtps::ReaderDiscoveryStatus::IGNORED_READER)
     {
-        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Reader " << info.guid << " ignored.");
+        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                configuration_->id << " participant : " << "Reader " << info.guid << " ignored.");
 
         // Do not notify discovery database (design choice that might be changed in the future)
     }
@@ -322,20 +330,23 @@ void CommonParticipant::on_data_writer_discovery(
     }
     else if (reason == fastdds::rtps::WriterDiscoveryStatus::CHANGED_QOS_WRITER)
     {
-        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Writer " << info.guid << " changed TopicQoS.");
+        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                configuration_->id << " participant : " << "Writer " << info.guid << " changed TopicQoS.");
 
         this->discovery_database_->update_endpoint(info_writer);
     }
     else if (reason == fastdds::rtps::WriterDiscoveryStatus::REMOVED_WRITER)
     {
-        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Writer " << info.guid << " removed.");
+        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                configuration_->id << " participant : " << "Writer " << info.guid << " removed.");
 
         info_writer.active = false;
         this->discovery_database_->update_endpoint(info_writer);
     }
     else if (reason == fastdds::rtps::WriterDiscoveryStatus::IGNORED_WRITER)
     {
-        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Writer " << info.guid << " ignored.");
+        EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                configuration_->id << " participant : " << "Writer " << info.guid << " ignored.");
 
         // Do not notify discovery database (design choice that might be changed in the future)
     }

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -94,19 +94,24 @@ void CommonParticipant::on_participant_discovery(
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::CHANGED_QOS_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " changed QoS.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid <<
+                    " changed QoS.");
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::REMOVED_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " removed.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid << " removed.");
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::DROPPED_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " dropped.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid << " dropped.");
         }
         else if (reason == fastdds::rtps::ParticipantDiscoveryStatus::IGNORED_PARTICIPANT)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Participant " << info.guid << " ignored.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Participant " << info.guid << " ignored.");
         }
     }
 }
@@ -132,20 +137,24 @@ void CommonParticipant::on_reader_discovery(
         }
         else if (reason == fastdds::rtps::ReaderDiscoveryStatus::CHANGED_QOS_READER)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Reader " << info.guid << " changed TopicQoS.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Reader " << info.guid <<
+                    " changed TopicQoS.");
 
             this->discovery_database_->update_endpoint(info_reader);
         }
         else if (reason == fastdds::rtps::ReaderDiscoveryStatus::REMOVED_READER)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Reader " << info.guid << " removed.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Reader " << info.guid << " removed.");
 
             info_reader.active = false;
             this->discovery_database_->update_endpoint(info_reader);
         }
         else if (reason == fastdds::rtps::ReaderDiscoveryStatus::IGNORED_READER)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Reader " << info.guid << " ignored.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Reader " << info.guid << " ignored.");
 
             // Do not notify discovery database (design choice that might be changed in the future)
         }
@@ -173,20 +182,24 @@ void CommonParticipant::on_writer_discovery(
         }
         else if (reason == fastdds::rtps::WriterDiscoveryStatus::CHANGED_QOS_WRITER)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Writer " << info.guid << " changed TopicQoS.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Writer " << info.guid <<
+                    " changed TopicQoS.");
 
             this->discovery_database_->update_endpoint(info_writer);
         }
         else if (reason == fastdds::rtps::WriterDiscoveryStatus::REMOVED_WRITER)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Writer " << info.guid << " removed.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Writer " << info.guid << " removed.");
 
             info_writer.active = false;
             this->discovery_database_->update_endpoint(info_writer);
         }
         else if (reason == fastdds::rtps::WriterDiscoveryStatus::IGNORED_WRITER)
         {
-            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY, "Writer " << info.guid << " ignored.");
+            EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
+                    configuration_->id << " participant : " << "Writer " << info.guid << " ignored.");
 
             // Do not notify discovery database (design choice that might be changed in the future)
         }

--- a/ddspipe_yaml/include/ddspipe_yaml/YamlReader.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/YamlReader.hpp
@@ -51,14 +51,13 @@ enum YamlReaderVersion
      * @brief First version.
      *
      * @version 0.1.0
-     * @version 0.2.0
      */
     V_1_0,
 
     /**
      * @brief Version 2.0
      *
-     * @version 0.3.0
+     * @version 0.1.0
      *
      * - Adds builtin-topics tag.
      * - Adds participants list.
@@ -70,7 +69,7 @@ enum YamlReaderVersion
     /**
      * @brief Version 3.0
      *
-     * @version 0.4.0
+     * @version 0.1.0
      *
      * - Change wan to initial peers participant
      * - Add Specs
@@ -80,7 +79,7 @@ enum YamlReaderVersion
     /**
      * @brief Version 3.1.
      *
-     * @version 0.5.0
+     * @version 0.2.0
      *
      * - Add XML load by file or raw
      * - Add xml participant
@@ -88,9 +87,9 @@ enum YamlReaderVersion
     V_3_1,
 
     /**
-     * @brief Latest version.
+     * @brief Version 4.0.
      *
-     * @version 0.6.0
+     * @version 0.3.0
      *
      * - Forwarding Routes.
      * - Remove Unused Entities.
@@ -101,6 +100,16 @@ enum YamlReaderVersion
      * - Rename the `max-depth` under the `specs` tag to `history-depth`.
      */
     V_4_0,
+
+    /**
+     * @brief Latest version.
+     *
+     * @version 1.0.0
+     *
+     * - Make discovery server's guid prefix optional.
+     * - Remove server's guid prefix from discovery server clients' connection addresses.
+     */
+    V_5_0,
 
     /**
      * @brief  Main version.

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -28,6 +28,7 @@ constexpr const char* VERSION_TAG_V_2_0("v2.0");    //! Version v2.0
 constexpr const char* VERSION_TAG_V_3_0("v3.0");    //! Version v3.0
 constexpr const char* VERSION_TAG_V_3_1("v3.1");    //! Version v3.1
 constexpr const char* VERSION_TAG_V_4_0("v4.0");    //! Version v4.0
+constexpr const char* VERSION_TAG_V_5_0("v5.0");    //! Version v5.0
 
 // Topics related tags
 constexpr const char* ALLOWLIST_TAG("allowlist");     //! List of allowed topics

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -231,9 +231,21 @@ void YamlReader::fill(
                     YamlReader::get<GuidPrefix>(yml, version);
             break;
 
-        default:
+        case V_2_0:
+        case V_3_0:
+        case V_3_1:
+        case V_4_0:
             object.discovery_server_guid_prefix =
                     YamlReader::get<GuidPrefix>(yml, DISCOVERY_SERVER_GUID_PREFIX_TAG, version);
+            break;
+
+        case V_5_0:
+        default:
+            if (YamlReader::is_tag_present(yml, DISCOVERY_SERVER_GUID_PREFIX_TAG))
+            {
+                object.discovery_server_guid_prefix =
+                        YamlReader::get<GuidPrefix>(yml, DISCOVERY_SERVER_GUID_PREFIX_TAG, version);
+            }
             break;
     }
 }

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -165,24 +165,29 @@ GuidPrefix YamlReader::get<GuidPrefix>(
     }
 
     // ROS DS is optional.
-    bool ros_id;
+    bool ros_id = false;
     bool ros_id_set = is_tag_present(yml, DISCOVERY_SERVER_ID_ROS_TAG);
     if (ros_id_set)
     {
         ros_id = get_scalar<bool>(yml, DISCOVERY_SERVER_ID_ROS_TAG);
     }
 
-    // Id is mandatory if guid is not present
-    uint32_t id = get_scalar<uint32_t>(yml, DISCOVERY_SERVER_ID_TAG);
+    // Id is optional.
+    uint32_t id = 0;
+    bool id_set = is_tag_present(yml, DISCOVERY_SERVER_ID_TAG);
+    if (id_set)
+    {
+        id = get_scalar<uint32_t>(yml, DISCOVERY_SERVER_ID_TAG);
+    }
 
-    // Create GuidPrefix
-    if (ros_id_set)
+    if (ros_id_set || id_set)
     {
         return GuidPrefix(ros_id, id);
     }
     else
     {
-        return GuidPrefix(id);
+        // Return unknown prefix -> delegate assignment on Fast-DDS
+        return GuidPrefix();
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -98,6 +98,7 @@ YamlReaderVersion YamlReader::get<YamlReaderVersion>(
                     {VERSION_TAG_V_3_0, YamlReaderVersion::V_3_0},
                     {VERSION_TAG_V_3_1, YamlReaderVersion::V_3_1},
                     {VERSION_TAG_V_4_0, YamlReaderVersion::V_4_0},
+                    {VERSION_TAG_V_5_0, YamlReaderVersion::V_5_0},
                 });
 }
 
@@ -781,8 +782,12 @@ std::ostream& operator <<(
             break;
 
         case V_4_0:
-        case LATEST:
             os << VERSION_TAG_V_4_0;
+            break;
+
+        case V_5_0:
+        case LATEST:
+            os << VERSION_TAG_V_5_0;
             break;
 
         default:


### PR DESCRIPTION
This PR:
- Makes DiscoveryServer servers' guid prefix optional, as starting from Fast-DDS v3.0.0 release it is no longer required. Nonetheless, it's kept as an optional to allow for communication with clients using previous Fast-DDS versions (these clients need to point to a GUID, so it's necessary to fix one in the server side). Note that not setting a GUID solves a corner case when TCP localhost addresses are used: this is because Fast-DDS performs the transformation of (suitable) locators to localhost based on their associated GUID, which needs to convey certain rules. And so this mechanism only succeeds when the GUID is internally assigned by Fast-DDS instead of manually set by users. 
- Raises YAML reader version (given the previous change, and that `discovery-server-guid` is no longer present in `DiscoveryServerConnectionAddress`).