### PR TITLE
Add DLL Export to Protected Methods in CommonParticipant and SimpleParticipant Classes

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -210,6 +210,7 @@ protected:
      * @brief Virtual method that sets the common properties of std attributes for a Participant.
      *
      */
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual fastdds::rtps::RTPSParticipantAttributes add_participant_att_properties_(
             fastdds::rtps::RTPSParticipantAttributes& params) const;
 
@@ -217,6 +218,7 @@ protected:
      * @brief Virtual method that gives the std attributes for a Participant.
      *
      */
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual fastdds::rtps::RTPSParticipantAttributes reckon_participant_attributes_() const;
 
     /////

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/SimpleParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/SimpleParticipant.hpp
@@ -52,6 +52,7 @@ protected:
     /**
      * @brief Static method that gives the attributes for a Simple Participant.
      */
+    DDSPIPE_PARTICIPANTS_DllAPI
     fastdds::rtps::RTPSParticipantAttributes reckon_participant_attributes_() const override;
 };
 


### PR DESCRIPTION
This Pull Request introduces the addition of `DDSPIPE_PARTICIPANTS_DllAPI` to the protected methods in the `CommonParticipant` and `SimpleParticipant` classes. By exporting these methods, we ensure they are properly exposed when building shared libraries, allowing child classes of external modules to access these functionalities.