### PR TITLE
[21812 ] Add templated function to YamlWriter for supporting compact format

### DIFF
--- a/ddspipe_yaml/include/ddspipe_yaml/YamlWriter.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/YamlWriter.hpp
@@ -82,7 +82,7 @@ template <typename T>
 void set(
         Yaml& yml,
         const T& value,
-        const bool is_compact);
+        bool is_compact);
 
 //! Set the \c value in a new yaml in \c yml under \c tag .
 template <typename T>

--- a/ddspipe_yaml/include/ddspipe_yaml/YamlWriter.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/YamlWriter.hpp
@@ -65,9 +65,28 @@ void set(
         Yaml& yml,
         const T& value);
 
-//! Set the \c value in a new yaml in \c yml under \c tag .
+/**
+ * @brief Set a new value in \c yml .
+ *
+ * This function is intended to be specialized for different types, defining the method to serialize into YAML
+ * when two possible formats (compact and extended) are available.
+ * Depending on the \c is_compact flag, the serialization will be in either compact or extended format.
+ *
+ * @param[in,out] yaml base yaml where to write the value
+ * @param[in] value value to write
+ * @param[in] is_compact boolean value to set the format of the yaml
+ *
+ * @tparam T type of the value to set in the yaml.
+ */
 template <typename T>
 void set(
+        Yaml& yml,
+        const T& value,
+        const bool is_compact);
+
+//! Set the \c value in a new yaml in \c yml under \c tag .
+template <typename T>
+void set_in_tag(
         Yaml& yml,
         const TagType& tag,
         const T& value);

--- a/ddspipe_yaml/include/ddspipe_yaml/impl/YamlWriter.ipp
+++ b/ddspipe_yaml/include/ddspipe_yaml/impl/YamlWriter.ipp
@@ -48,6 +48,12 @@ void set_collection(
         Yaml& yml,
         const std::vector<T>& collection);
 
+template <typename T>
+void set_collection(
+        Yaml& yml,
+        const std::vector<T>& collection,
+        const bool is_compact);
+
 template <typename K, typename T>
 void set_map(
         Yaml& yml,
@@ -90,6 +96,15 @@ void set(
 template <typename T>
 void set(
         Yaml& yml,
+        const std::vector<T>& collection,
+        const bool is_compact)
+{
+    set_collection(yml, collection, is_compact);
+}
+
+template <typename T>
+void set(
+        Yaml& yml,
         const std::set<T>& collection)
 {
     set_collection(yml, std::vector<T>(collection.begin(), collection.end()));
@@ -108,7 +123,7 @@ void set(
 ////////////////////////////////////
 
 template <typename T>
-void set(
+void set_in_tag(
         Yaml& yml,
         const TagType& tag,
         const T& value)
@@ -126,6 +141,20 @@ void set_collection(
     {
         Yaml yml_value;
         set<T>(yml_value, v);
+        yml.push_back(yml_value);
+    }
+}
+
+template <typename T>
+void set_collection(
+        Yaml& yml,
+        const std::vector<T>& collection,
+        const bool is_compact)
+{
+    for (const auto& v : collection)
+    {
+        Yaml yml_value;
+        set<T>(yml_value, v, is_compact);
         yml.push_back(yml_value);
     }
 }

--- a/ddspipe_yaml/include/ddspipe_yaml/impl/YamlWriter.ipp
+++ b/ddspipe_yaml/include/ddspipe_yaml/impl/YamlWriter.ipp
@@ -52,7 +52,7 @@ template <typename T>
 void set_collection(
         Yaml& yml,
         const std::vector<T>& collection,
-        const bool is_compact);
+        bool is_compact);
 
 template <typename K, typename T>
 void set_map(
@@ -97,7 +97,7 @@ template <typename T>
 void set(
         Yaml& yml,
         const std::vector<T>& collection,
-        const bool is_compact)
+        bool is_compact)
 {
     set_collection(yml, collection, is_compact);
 }
@@ -149,7 +149,7 @@ template <typename T>
 void set_collection(
         Yaml& yml,
         const std::vector<T>& collection,
-        const bool is_compact)
+        bool is_compact)
 {
     for (const auto& v : collection)
     {

--- a/ddspipe_yaml/test/unittest/yaml_writer/YamlWriterTest.cpp
+++ b/ddspipe_yaml/test/unittest/yaml_writer/YamlWriterTest.cpp
@@ -91,8 +91,8 @@ void set(
         Yaml& yml,
         const test::A& a)
 {
-    set(yml, test::A_VALUE_TAG, a.value);
-    set(yml, test::A_NAME_TAG, a.name);
+    set_in_tag(yml, test::A_VALUE_TAG, a.value);
+    set_in_tag(yml, test::A_NAME_TAG, a.name);
 }
 
 //! Serialize an object B in a yaml
@@ -101,8 +101,8 @@ void set(
         Yaml& yml,
         const test::B& b)
 {
-    set(yml, test::B_ACTIVE_TAG, b.active);
-    set(yml, test::B_A_TAG, b.a);
+    set_in_tag(yml, test::B_ACTIVE_TAG, b.active);
+    set_in_tag(yml, test::B_A_TAG, b.a);
 }
 
 //! Deserialize an object A from a yaml
@@ -393,7 +393,7 @@ TEST(YamlWriterTest, set_specific_type)
 
     // Create yml
     Yaml yml;
-    set(yml, "b", b);
+    set_in_tag(yml, "b", b);
 
     // Check the b tag exists, and some inside
     ASSERT_TRUE(yml["b"]);
@@ -407,7 +407,7 @@ TEST(YamlWriterTest, set_specific_type)
     test::B b2;
     b.a.value = 3;
     Yaml yml2;
-    set(yml2, "b", b2);
+    set_in_tag(yml2, "b", b2);
 
     // Check that ymls are not equal
     ASSERT_NE(

--- a/ddspipe_yaml/test/unittest/yaml_writer/YamlWriter_collections_test.cpp
+++ b/ddspipe_yaml/test/unittest/yaml_writer/YamlWriter_collections_test.cpp
@@ -71,8 +71,8 @@ void set(
         Yaml& yml,
         const test::A& a)
 {
-    set(yml, test::A_VALUE_TAG, a.value);
-    set(yml, test::A_NAME_TAG, a.name);
+    set_in_tag(yml, test::A_VALUE_TAG, a.value);
+    set_in_tag(yml, test::A_NAME_TAG, a.name);
 }
 
 template <>
@@ -80,8 +80,8 @@ void set(
         Yaml& yml,
         const test::B& b)
 {
-    set(yml, test::B_ACTIVE_TAG, b.active);
-    set(yml, test::B_A_TAG, b.a);
+    set_in_tag(yml, test::B_ACTIVE_TAG, b.active);
+    set_in_tag(yml, test::B_A_TAG, b.a);
 }
 
 template <>


### PR DESCRIPTION
This PR adds support for two YAML serialization formats (compact and extended) and includes the following key changes:

- Addition of new templated function `set(Yaml& yml, const T& value, const bool is_compact)` is added to support writing values into YAML in either compact or extended format, based on the is_compact flag.

- The functionality has also been applied to `set_collection`, allowing collections vectors to be serialized in both compact and extended formats.

- Renaming of set with `TagType`: The function `set(Yaml& yml, const TagType& tag, const T& value)` has been renamed to `set_in_tag(Yaml& yml, const TagType& tag, const T& value)`.