### PR TITLE
Add auxiliar InternalWriter

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/InternalReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/auxiliar/InternalReader.hpp
@@ -26,6 +26,7 @@
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
 
+#include <ddspipe_participants/library/library_dll.h>
 #include <ddspipe_participants/reader/auxiliar/BaseReader.hpp>
 
 namespace eprosima {

--- a/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/InternalWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/auxiliar/InternalWriter.hpp
@@ -1,0 +1,48 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+
+#include <ddspipe_participants/library/library_dll.h>
+#include <ddspipe_participants/writer/auxiliar/BaseWriter.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace participants {
+
+/**
+ * Writer implementation that allow to register a callback to be executed with each data received.
+ */
+class InternalWriter : public BaseWriter
+{
+public:
+
+    DDSPIPE_PARTICIPANTS_DllAPI
+    InternalWriter(
+            const core::types::ParticipantId& participant_id,
+            const std::function<utils::ReturnCode(core::IRoutingData&)>& callback);
+
+protected:
+
+    virtual utils::ReturnCode write_nts_(
+            core::IRoutingData& data) noexcept override;
+
+    const std::function<utils::ReturnCode(core::IRoutingData&)> callback_;
+};
+
+} /* namespace participants */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_participants/src/cpp/writer/auxiliar/InternalWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/auxiliar/InternalWriter.cpp
@@ -1,0 +1,38 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ddspipe_participants/writer/auxiliar/InternalWriter.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace participants {
+
+InternalWriter::InternalWriter(
+        const core::types::ParticipantId& participant_id,
+        const std::function<utils::ReturnCode(core::IRoutingData&)>& callback)
+    : BaseWriter(participant_id)
+    , callback_(callback)
+{
+    // Do nothing
+}
+
+utils::ReturnCode InternalWriter::write_nts_(
+        core::IRoutingData& data) noexcept
+{
+    return callback_(data);
+}
+
+} /* namespace participants */
+} /* namespace ddspipe */
+} /* namespace eprosima */


### PR DESCRIPTION
Move already existing helper class from Fast-DDS-spy repo so that it can be reused in other tools.