### PR TITLE
[21670] Fix Data Races on DDS-Pipe

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -112,12 +112,12 @@ public:
     // LISTENER METHODS
     /////////////////////////
 
-    class DDSListener : public fastdds::dds::DomainParticipantListener
+    class DdsListener : public fastdds::dds::DomainParticipantListener
     {
     public:
 
         DDSPIPE_PARTICIPANTS_DllAPI
-        explicit DDSListener(
+        explicit DdsListener(
                 std::shared_ptr<SimpleParticipantConfiguration> conf,
                 std::shared_ptr<core::DiscoveryDatabase> ddb);
 

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -116,6 +116,7 @@ public:
     {
     public:
 
+        DDSPIPE_PARTICIPANTS_DllAPI
         explicit DDSListener(
                 std::shared_ptr<SimpleParticipantConfiguration> conf,
                 std::shared_ptr<core::DiscoveryDatabase> ddb);
@@ -125,6 +126,7 @@ public:
          *
          * This method is only used for debugging purposes.
          */
+        DDSPIPE_PARTICIPANTS_DllAPI
         void on_participant_discovery(
                 fastdds::dds::DomainParticipant* participant,
                 fastdds::rtps::ParticipantDiscoveryStatus reason,
@@ -136,6 +138,7 @@ public:
          *
          * This method adds to the database the discovered or modified endpoint.
          */
+        DDSPIPE_PARTICIPANTS_DllAPI
         void on_data_reader_discovery(
                 fastdds::dds::DomainParticipant* participant,
                 fastdds::rtps::ReaderDiscoveryStatus reason,
@@ -147,6 +150,7 @@ public:
          *
          * This method adds to the database the discovered or modified endpoint.
          */
+        DDSPIPE_PARTICIPANTS_DllAPI
         void on_data_writer_discovery(
                 fastdds::dds::DomainParticipant* participant,
                 fastdds::rtps::WriterDiscoveryStatus reason,
@@ -192,15 +196,18 @@ protected:
     // INTERNAL VIRTUAL METHODS
     /////////////////////////
 
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual
     fastdds::dds::DomainParticipantQos
     add_qos_properties_(
             fastdds::dds::DomainParticipantQos& qos) const;
 
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual
     fastdds::dds::DomainParticipantQos
     reckon_participant_qos_() const;
 
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual
     fastdds::dds::DomainParticipant*
     create_dds_participant_();

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -163,6 +163,7 @@ public:
         //! Setter for GUID of the participant
         void guid(
                 const fastdds::rtps::GUID_t& guid);
+
     private:
 
         //! GUID of the participant

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -153,17 +153,8 @@ public:
                 const fastdds::dds::PublicationBuiltinTopicData& info,
                 bool& /*should_be_ignored*/) override;
 
-        //! Getter for GUID of the participant
-        const fastdds::rtps::GUID_t& guid() const;
-
-        //! Setter for GUID of the participant
-        void guid(
-                const fastdds::rtps::GUID_t& guid);
-
     protected:
 
-        //! GUID of the participant
-        fastdds::rtps::GUID_t guid_;
         //! Shared pointer to the configuration of the participant
         const std::shared_ptr<SimpleParticipantConfiguration> configuration_;
         //! Shared pointer to the discovery database

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -118,11 +118,7 @@ public:
 
         explicit DDSListener(
                 std::shared_ptr<SimpleParticipantConfiguration> conf,
-                std::shared_ptr<core::DiscoveryDatabase> ddb)
-            : configuration_(conf)
-            , discovery_database_(ddb)
-        {
-        }
+                std::shared_ptr<core::DiscoveryDatabase> ddb);
 
         /**
          * @brief Override method from \c DomainParticipantListener
@@ -164,7 +160,7 @@ public:
         void guid(
                 const fastdds::rtps::GUID_t& guid);
 
-    private:
+    protected:
 
         //! GUID of the participant
         fastdds::rtps::GUID_t guid_;
@@ -191,6 +187,17 @@ protected:
             const std::shared_ptr<core::DiscoveryDatabase>& discovery_database);
 
     /////////////////////////
+    // VIRTUAL METHODS
+    /////////////////////////
+
+    /**
+     * @brief Virtual method that creates a listener for the internal DDS Participant.
+     *        It should be overridden if a different listener is needed.
+     */
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual std::unique_ptr<fastdds::dds::DomainParticipantListener> create_listener_();
+
+    /////////////////////////
     // INTERNAL VIRTUAL METHODS
     /////////////////////////
 
@@ -206,15 +213,6 @@ protected:
     virtual
     fastdds::dds::DomainParticipant*
     create_dds_participant_();
-
-    /**
-     * @brief Virtual method that creates a listener for the internal DDS Participant.
-     *        It should be overridden if a different listener is needed.
-     */
-    virtual std::unique_ptr<fastdds::dds::DomainParticipantListener> create_listener()
-    {
-        return std::make_unique<DDSListener>(configuration_, discovery_database_);
-    }
 
     /////////////////////////
     // INTERNAL METHODS

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
@@ -82,7 +82,7 @@ public:
         explicit DynTypesRtpsListener(
                 std::shared_ptr<ParticipantConfiguration> conf,
                 std::shared_ptr<core::DiscoveryDatabase> ddb,
-                core::types::ParticipantId id);
+                std::shared_ptr<InternalReader> internal_reader);
 
         DDSPIPE_PARTICIPANTS_DllAPI
         void on_reader_discovery(
@@ -106,7 +106,7 @@ public:
 
     protected:
 
-        //! Type Object Internal Reader
+        //! Copy of Type Object Internal Reader
         std::shared_ptr<InternalReader> type_object_reader_;
         //! Received types set
         std::set<std::string> received_types_;
@@ -121,6 +121,10 @@ protected:
 
     //! Override method from \c CommonParticipant to create the internal RTPS participant listener
     std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_() override;
+
+    //! Type Object Internal Reader
+    std::shared_ptr<InternalReader> type_object_reader_;
+
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
@@ -121,7 +121,8 @@ protected:
     //! Override method from \c CommonParticipant to create the internal RTPS participant listener
     std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener() override
     {
-        return std::make_unique<DynRTPSListener>(configuration_, discovery_database_, type_object_reader_, received_types_);
+        return std::make_unique<DynRTPSListener>(configuration_, discovery_database_, type_object_reader_,
+                       received_types_);
     }
 
     //! Type Object Internal Reader

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
@@ -74,20 +74,15 @@ public:
     std::shared_ptr<core::IReader> create_reader(
             const core::ITopic& topic) override;
 
-    class DynRTPSListener : public rtps::CommonParticipant::RTPSListener
+    class DynTypesRtpsListener : public rtps::CommonParticipant::RtpsListener
     {
     public:
 
-        explicit DynRTPSListener(
+        DDSPIPE_PARTICIPANTS_DllAPI
+        explicit DynTypesRtpsListener(
                 std::shared_ptr<ParticipantConfiguration> conf,
                 std::shared_ptr<core::DiscoveryDatabase> ddb,
-                std::shared_ptr<InternalReader> type_object_reader_,
-                std::set<std::string> received_types_)
-            : rtps::CommonParticipant::RTPSListener(conf, ddb)
-            , type_object_reader_(type_object_reader_)
-            , received_types_(received_types_)
-        {
-        }
+                core::types::ParticipantId id);
 
         DDSPIPE_PARTICIPANTS_DllAPI
         void on_reader_discovery(
@@ -103,7 +98,13 @@ public:
                 const fastdds::rtps::PublicationBuiltinTopicData& info,
                 bool& should_be_ignored) override;
 
-    private:
+        //! Type Object Reader getter
+        inline std::shared_ptr<InternalReader> type_object_reader() const
+        {
+            return type_object_reader_;
+        }
+
+    protected:
 
         //! Type Object Internal Reader
         std::shared_ptr<InternalReader> type_object_reader_;
@@ -119,17 +120,7 @@ public:
 protected:
 
     //! Override method from \c CommonParticipant to create the internal RTPS participant listener
-    std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener() override
-    {
-        return std::make_unique<DynRTPSListener>(configuration_, discovery_database_, type_object_reader_,
-                       received_types_);
-    }
-
-    //! Type Object Internal Reader
-    std::shared_ptr<InternalReader> type_object_reader_;
-
-    //! Received types set
-    std::set<std::string> received_types_;
+    std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_() override;
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -122,17 +122,14 @@ public:
     // RTPS LISTENER METHODS
     /////////////////////////
 
-    class RTPSListener : public fastdds::rtps::RTPSParticipantListener
+    class RtpsListener : public fastdds::rtps::RTPSParticipantListener
     {
     public:
 
-        explicit RTPSListener(
+        DDSPIPE_PARTICIPANTS_DllAPI
+        explicit RtpsListener(
                 std::shared_ptr<ParticipantConfiguration> conf,
-                std::shared_ptr<core::DiscoveryDatabase> ddb)
-            : configuration_(conf)
-            , discovery_database_(ddb)
-        {
-        }
+                std::shared_ptr<core::DiscoveryDatabase> ddb);
 
         /**
          * @brief Override method from \c RTPSParticipantListener .
@@ -250,10 +247,8 @@ protected:
      *        This method must be called after the RTPS Participant is created, otherwise no listener will be set.
      * @return A unique pointer to an RTPS Participant Listener.
      */
-    virtual std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener()
-    {
-        return std::make_unique<RTPSListener>(configuration_, discovery_database_);
-    }
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_();
 
     /////
     // VARIABLES

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
     }
 }
 
-CommonParticipant::DDSListener::DDSListener(
+CommonParticipant::DdsListener::DdsListener(
         std::shared_ptr<SimpleParticipantConfiguration> conf,
         std::shared_ptr<core::DiscoveryDatabase> ddb)
     : configuration_(conf)
@@ -220,7 +220,7 @@ CommonParticipant::DDSListener::DDSListener(
     EPROSIMA_LOG_INFO(DDSPIPE_DDS_PARTICIPANT, "Creating DDS Listener for Participant " << conf->id << ".");
 }
 
-void CommonParticipant::DDSListener::on_participant_discovery(
+void CommonParticipant::DdsListener::on_participant_discovery(
         fastdds::dds::DomainParticipant* participant,
         fastdds::rtps::ParticipantDiscoveryStatus reason,
         const fastdds::rtps::ParticipantBuiltinTopicData& info,
@@ -257,7 +257,7 @@ void CommonParticipant::DDSListener::on_participant_discovery(
     }
 }
 
-void CommonParticipant::DDSListener::on_data_reader_discovery(
+void CommonParticipant::DdsListener::on_data_reader_discovery(
         fastdds::dds::DomainParticipant* participant,
         fastdds::rtps::ReaderDiscoveryStatus reason,
         const fastdds::dds::SubscriptionBuiltinTopicData& info,
@@ -307,7 +307,7 @@ void CommonParticipant::DDSListener::on_data_reader_discovery(
     }
 }
 
-void CommonParticipant::DDSListener::on_data_writer_discovery(
+void CommonParticipant::DdsListener::on_data_writer_discovery(
         fastdds::dds::DomainParticipant* participant,
         fastdds::rtps::WriterDiscoveryStatus reason,
         const fastdds::dds::PublicationBuiltinTopicData& info,
@@ -371,7 +371,7 @@ CommonParticipant::CommonParticipant(
 std::unique_ptr<fastdds::dds::DomainParticipantListener> CommonParticipant::create_listener_()
 {
     EPROSIMA_LOG_INFO(DDSPIPE_DDS_PARTICIPANT, "Creating DDS Listener from CommonParticipant.");
-    return std::make_unique<DDSListener>(configuration_, discovery_database_);
+    return std::make_unique<DdsListener>(configuration_, discovery_database_);
 }
 
 fastdds::dds::DomainParticipantQos CommonParticipant::add_qos_properties_(

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -54,6 +54,11 @@ CommonParticipant::~CommonParticipant()
     }
 }
 
+std::unique_ptr<fastdds::dds::DomainParticipantListener> CommonParticipant::create_listener_()
+{
+    return std::make_unique<DDSListener>(configuration_, discovery_database_);
+}
+
 void CommonParticipant::init()
 {
     EPROSIMA_LOG_INFO(DDSPIPE_DDS_PARTICIPANT, "Initializing DDS Participant " << id() << ".");
@@ -212,6 +217,14 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
 
         return reader;
     }
+}
+
+CommonParticipant::DDSListener::DDSListener(
+        std::shared_ptr<SimpleParticipantConfiguration> conf,
+        std::shared_ptr<core::DiscoveryDatabase> ddb)
+    : configuration_(conf)
+    , discovery_database_(ddb)
+{
 }
 
 void CommonParticipant::DDSListener::on_participant_discovery(
@@ -414,7 +427,7 @@ fastdds::dds::DomainParticipant* CommonParticipant::create_dds_participant_()
     mask << fastdds::dds::StatusMask::subscription_matched();
 
     // Create the participant listener
-    dds_participant_listener_ = create_listener();
+    dds_participant_listener_ = create_listener_();
 
     return eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
         configuration_->domain,

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -54,11 +54,6 @@ CommonParticipant::~CommonParticipant()
     }
 }
 
-std::unique_ptr<fastdds::dds::DomainParticipantListener> CommonParticipant::create_listener_()
-{
-    return std::make_unique<DDSListener>(configuration_, discovery_database_);
-}
-
 void CommonParticipant::init()
 {
     EPROSIMA_LOG_INFO(DDSPIPE_DDS_PARTICIPANT, "Initializing DDS Participant " << id() << ".");
@@ -222,6 +217,7 @@ CommonParticipant::DDSListener::DDSListener(
     : configuration_(conf)
     , discovery_database_(ddb)
 {
+    EPROSIMA_LOG_INFO(DDSPIPE_DDS_PARTICIPANT, "Creating DDS Listener for Participant " << conf->id << ".");
 }
 
 void CommonParticipant::DDSListener::on_participant_discovery(
@@ -372,6 +368,12 @@ CommonParticipant::CommonParticipant(
     // Do nothing
 }
 
+std::unique_ptr<fastdds::dds::DomainParticipantListener> CommonParticipant::create_listener_()
+{
+    EPROSIMA_LOG_INFO(DDSPIPE_DDS_PARTICIPANT, "Creating DDS Listener from CommonParticipant.");
+    return std::make_unique<DDSListener>(configuration_, discovery_database_);
+}
+
 fastdds::dds::DomainParticipantQos CommonParticipant::add_qos_properties_(
         fastdds::dds::DomainParticipantQos& qos) const
 {
@@ -414,6 +416,10 @@ fastdds::dds::DomainParticipant* CommonParticipant::create_dds_participant_()
 
     // Create the participant listener
     dds_participant_listener_ = create_listener_();
+    if (!dds_participant_listener_)
+    {
+        EPROSIMA_LOG_WARNING(DDSPIPE_DDS_PARTICIPANT, "Error creating DDS Participant Listener.");
+    }
 
     return eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
         configuration_->domain,

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -96,9 +96,6 @@ void CommonParticipant::init()
     {
         throw utils::InitializationException(STR_ENTRY << "Error enabling DDS Participant " << id() << ".");
     }
-
-    // Set the GUID of the participant in the DDS Listener
-    static_cast<DDSListener*>(dds_participant_listener_.get())->guid(dds_participant_->guid());
 }
 
 core::types::ParticipantId CommonParticipant::id() const noexcept
@@ -265,13 +262,13 @@ void CommonParticipant::DDSListener::on_participant_discovery(
 }
 
 void CommonParticipant::DDSListener::on_data_reader_discovery(
-        fastdds::dds::DomainParticipant*,
+        fastdds::dds::DomainParticipant* participant,
         fastdds::rtps::ReaderDiscoveryStatus reason,
         const fastdds::dds::SubscriptionBuiltinTopicData& info,
         bool& /*should_be_ignored*/)
 {
     // If reader is from other participant, store it in discovery database
-    if (detail::come_from_same_participant_(info.guid, guid()))
+    if (detail::come_from_same_participant_(info.guid, participant->guid()))
     {
         // Come from this participant, do nothing
         return;
@@ -315,13 +312,13 @@ void CommonParticipant::DDSListener::on_data_reader_discovery(
 }
 
 void CommonParticipant::DDSListener::on_data_writer_discovery(
-        fastdds::dds::DomainParticipant*,
+        fastdds::dds::DomainParticipant* participant,
         fastdds::rtps::WriterDiscoveryStatus reason,
         const fastdds::dds::PublicationBuiltinTopicData& info,
         bool& /*should_be_ignored*/)
 {
     // If writer is from other participant, store it in discovery database
-    if (detail::come_from_same_participant_(info.guid, guid()))
+    if (detail::come_from_same_participant_(info.guid, participant->guid()))
     {
         // Come from this participant, do nothing
         return;
@@ -362,17 +359,6 @@ void CommonParticipant::DDSListener::on_data_writer_discovery(
 
         // Do not notify discovery database (design choice that might be changed in the future)
     }
-}
-
-const fastdds::rtps::GUID_t& CommonParticipant::DDSListener::guid() const
-{
-    return guid_;
-}
-
-void CommonParticipant::DDSListener::guid(
-        const fastdds::rtps::GUID_t& guid)
-{
-    guid_ = guid;
 }
 
 CommonParticipant::CommonParticipant(

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -362,7 +362,6 @@ void CommonParticipant::DDSListener::guid(
     guid_ = guid;
 }
 
-
 CommonParticipant::CommonParticipant(
         const std::shared_ptr<SimpleParticipantConfiguration>& participant_configuration,
         const std::shared_ptr<core::PayloadPool>& payload_pool,

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
@@ -50,6 +50,8 @@ DynTypesParticipant::DynTypesParticipant(
         participant_configuration,
         payload_pool,
         discovery_database)
+    , type_object_reader_(std::make_shared<InternalReader>(
+                this->id()))
 {
     // Do nothing
 }
@@ -78,11 +80,11 @@ std::shared_ptr<IReader> DynTypesParticipant::create_reader(
 DynTypesParticipant::DynTypesRtpsListener::DynTypesRtpsListener(
         std::shared_ptr<ParticipantConfiguration> conf,
         std::shared_ptr<core::DiscoveryDatabase> ddb,
-        core::types::ParticipantId id)
+        std::shared_ptr<InternalReader> internal_reader)
     : rtps::CommonParticipant::RtpsListener(
         conf,
         ddb)
-    , type_object_reader_(std::make_shared<InternalReader>(id))
+    , type_object_reader_(internal_reader)
 {
 }
 
@@ -178,7 +180,7 @@ void DynTypesParticipant::DynTypesRtpsListener::notify_type_discovered_(
 
 std::unique_ptr<fastdds::rtps::RTPSParticipantListener> DynTypesParticipant::create_listener_()
 {
-    return std::make_unique<DynTypesRtpsListener>(configuration_, discovery_database_, id());
+    return std::make_unique<DynTypesRtpsListener>(configuration_, discovery_database_, type_object_reader_);
 }
 
 } /* namespace participants */

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<IReader> DynTypesParticipant::create_reader(
     return rtps::SimpleParticipant::create_reader(topic);
 }
 
-void DynTypesParticipant::on_reader_discovery(
+void DynTypesParticipant::DynRTPSListener::on_reader_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::ReaderDiscoveryStatus reason,
         const fastdds::rtps::SubscriptionBuiltinTopicData& info,
@@ -88,13 +88,13 @@ void DynTypesParticipant::on_reader_discovery(
         const auto type_info = info.type_information.type_information;
         const auto type_name = info.type_name.to_string();
 
-        rtps::CommonParticipant::on_reader_discovery(participant, reason, info, should_be_ignored);
+        rtps::CommonParticipant::RTPSListener::on_reader_discovery(participant, reason, info, should_be_ignored);
 
         notify_type_discovered_(type_info, type_name);
     }
 }
 
-void DynTypesParticipant::on_writer_discovery(
+void DynTypesParticipant::DynRTPSListener::on_writer_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::WriterDiscoveryStatus reason,
         const fastdds::rtps::PublicationBuiltinTopicData& info,
@@ -106,13 +106,13 @@ void DynTypesParticipant::on_writer_discovery(
         const auto type_info = info.type_information.type_information;
         const auto type_name = info.type_name.to_string();
 
-        rtps::CommonParticipant::on_writer_discovery(participant, reason, info, should_be_ignored);
+        rtps::CommonParticipant::RTPSListener::on_writer_discovery(participant, reason, info, should_be_ignored);
 
         notify_type_discovered_(type_info, type_name);
     }
 }
 
-void DynTypesParticipant::notify_type_discovered_(
+void DynTypesParticipant::DynRTPSListener::notify_type_discovered_(
         const fastdds::dds::xtypes::TypeInformation& type_info,
         const std::string& type_name)
 {
@@ -150,7 +150,7 @@ void DynTypesParticipant::notify_type_discovered_(
     // Notify type_identifier
     // NOTE: We assume each type_name corresponds to only one type_identifier
     EPROSIMA_LOG_INFO(DDSPIPE_DYNTYPES_PARTICIPANT,
-            "Participant " << this->id() << " discovered type object " << dyn_type->get_name());
+            "Participant " << configuration_->id << " discovered type object " << dyn_type->get_name());
 
     monitor_type_discovered(type_name);
 

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -79,7 +79,7 @@ void CommonParticipant::init()
         participant_attributes_);
 }
 
-void CommonParticipant::on_participant_discovery(
+void CommonParticipant::RTPSListener::on_participant_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::ParticipantDiscoveryStatus reason,
         const fastdds::rtps::ParticipantBuiltinTopicData& info,
@@ -116,7 +116,7 @@ void CommonParticipant::on_participant_discovery(
     }
 }
 
-void CommonParticipant::on_reader_discovery(
+void CommonParticipant::RTPSListener::on_reader_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::ReaderDiscoveryStatus reason,
         const fastdds::rtps::SubscriptionBuiltinTopicData& info,
@@ -126,14 +126,14 @@ void CommonParticipant::on_reader_discovery(
     {
         core::types::Endpoint info_reader =
                 detail::create_endpoint_from_info_<fastdds::rtps::SubscriptionBuiltinTopicData>(
-            info, this->id());
+            info, configuration_->id);
 
         if (reason == fastdds::rtps::ReaderDiscoveryStatus::DISCOVERED_READER)
         {
             EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
                     "Found in Participant " << configuration_->id << " new Reader " << info.guid << ".");
 
-            this->discovery_database_->add_endpoint(info_reader);
+            discovery_database_->add_endpoint(info_reader);
         }
         else if (reason == fastdds::rtps::ReaderDiscoveryStatus::CHANGED_QOS_READER)
         {
@@ -141,7 +141,7 @@ void CommonParticipant::on_reader_discovery(
                     configuration_->id << " participant : " << "Reader " << info.guid <<
                     " changed TopicQoS.");
 
-            this->discovery_database_->update_endpoint(info_reader);
+            discovery_database_->update_endpoint(info_reader);
         }
         else if (reason == fastdds::rtps::ReaderDiscoveryStatus::REMOVED_READER)
         {
@@ -149,7 +149,7 @@ void CommonParticipant::on_reader_discovery(
                     configuration_->id << " participant : " << "Reader " << info.guid << " removed.");
 
             info_reader.active = false;
-            this->discovery_database_->update_endpoint(info_reader);
+            discovery_database_->update_endpoint(info_reader);
         }
         else if (reason == fastdds::rtps::ReaderDiscoveryStatus::IGNORED_READER)
         {
@@ -161,7 +161,7 @@ void CommonParticipant::on_reader_discovery(
     }
 }
 
-void CommonParticipant::on_writer_discovery(
+void CommonParticipant::RTPSListener::on_writer_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::WriterDiscoveryStatus reason,
         const fastdds::rtps::PublicationBuiltinTopicData& info,
@@ -171,14 +171,14 @@ void CommonParticipant::on_writer_discovery(
     {
         core::types::Endpoint info_writer =
                 detail::create_endpoint_from_info_<fastdds::rtps::PublicationBuiltinTopicData>(
-            info, this->id());
+            info, configuration_->id);
 
         if (reason == fastdds::rtps::WriterDiscoveryStatus::DISCOVERED_WRITER)
         {
             EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY,
                     "Found in Participant " << configuration_->id << " new Writer " << info.guid << ".");
 
-            this->discovery_database_->add_endpoint(info_writer);
+            discovery_database_->add_endpoint(info_writer);
         }
         else if (reason == fastdds::rtps::WriterDiscoveryStatus::CHANGED_QOS_WRITER)
         {
@@ -186,7 +186,7 @@ void CommonParticipant::on_writer_discovery(
                     configuration_->id << " participant : " << "Writer " << info.guid <<
                     " changed TopicQoS.");
 
-            this->discovery_database_->update_endpoint(info_writer);
+            discovery_database_->update_endpoint(info_writer);
         }
         else if (reason == fastdds::rtps::WriterDiscoveryStatus::REMOVED_WRITER)
         {
@@ -194,7 +194,7 @@ void CommonParticipant::on_writer_discovery(
                     configuration_->id << " participant : " << "Writer " << info.guid << " removed.");
 
             info_writer.active = false;
-            this->discovery_database_->update_endpoint(info_writer);
+            discovery_database_->update_endpoint(info_writer);
         }
         else if (reason == fastdds::rtps::WriterDiscoveryStatus::IGNORED_WRITER)
         {
@@ -326,12 +326,15 @@ void CommonParticipant::create_participant_(
     EPROSIMA_LOG_INFO(DDSPIPE_RTPS_PARTICIPANT,
             "Creating Participant in domain " << domain);
 
+    // Create the RTPS Participant Listener
+    rtps_participant_listener_ = create_listener();
+
     // Listener must be set in creation as no callbacks should be missed
     // It is safe to do so here as object is already created and callbacks do not require anything set in this method
     rtps_participant_ = fastdds::rtps::RTPSDomain::createParticipant(
         domain,
         participant_attributes,
-        this);
+        rtps_participant_listener_.get());
 
     if (!rtps_participant_)
     {

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -85,6 +85,7 @@ CommonParticipant::RtpsListener::RtpsListener(
     : configuration_(conf)
     , discovery_database_(ddb)
 {
+    EPROSIMA_LOG_INFO(DDSPIPE_RTPS_PARTICIPANT, "Creating RTPS Listener for Participant " << conf->id << ".");
 }
 
 void CommonParticipant::RtpsListener::on_participant_discovery(
@@ -336,6 +337,10 @@ void CommonParticipant::create_participant_(
 
     // Create the RTPS Participant Listener
     rtps_participant_listener_ = create_listener_();
+    if (!rtps_participant_listener_)
+    {
+        EPROSIMA_LOG_WARNING(DDSPIPE_RTPS_PARTICIPANT, "Error creating RTPS Participant Listener.");
+    }
 
     // Listener must be set in creation as no callbacks should be missed
     // It is safe to do so here as object is already created and callbacks do not require anything set in this method
@@ -514,6 +519,7 @@ CommonParticipant::reckon_participant_attributes_() const
 std::unique_ptr<fastdds::rtps::RTPSParticipantListener>
 CommonParticipant::create_listener_()
 {
+    EPROSIMA_LOG_INFO(DDSPIPE_RTPS_PARTICIPANT, "Creating RTPS Listener from CommonParticipant.");
     return std::make_unique<RtpsListener>(configuration_, discovery_database_);
 }
 

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -79,7 +79,15 @@ void CommonParticipant::init()
         participant_attributes_);
 }
 
-void CommonParticipant::RTPSListener::on_participant_discovery(
+CommonParticipant::RtpsListener::RtpsListener(
+        std::shared_ptr<ParticipantConfiguration> conf,
+        std::shared_ptr<core::DiscoveryDatabase> ddb)
+    : configuration_(conf)
+    , discovery_database_(ddb)
+{
+}
+
+void CommonParticipant::RtpsListener::on_participant_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::ParticipantDiscoveryStatus reason,
         const fastdds::rtps::ParticipantBuiltinTopicData& info,
@@ -116,7 +124,7 @@ void CommonParticipant::RTPSListener::on_participant_discovery(
     }
 }
 
-void CommonParticipant::RTPSListener::on_reader_discovery(
+void CommonParticipant::RtpsListener::on_reader_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::ReaderDiscoveryStatus reason,
         const fastdds::rtps::SubscriptionBuiltinTopicData& info,
@@ -161,7 +169,7 @@ void CommonParticipant::RTPSListener::on_reader_discovery(
     }
 }
 
-void CommonParticipant::RTPSListener::on_writer_discovery(
+void CommonParticipant::RtpsListener::on_writer_discovery(
         fastdds::rtps::RTPSParticipant* participant,
         fastdds::rtps::WriterDiscoveryStatus reason,
         const fastdds::rtps::PublicationBuiltinTopicData& info,
@@ -327,7 +335,7 @@ void CommonParticipant::create_participant_(
             "Creating Participant in domain " << domain);
 
     // Create the RTPS Participant Listener
-    rtps_participant_listener_ = create_listener();
+    rtps_participant_listener_ = create_listener_();
 
     // Listener must be set in creation as no callbacks should be missed
     // It is safe to do so here as object is already created and callbacks do not require anything set in this method
@@ -501,6 +509,12 @@ CommonParticipant::reckon_participant_attributes_() const
     add_participant_att_properties_(params);
 
     return params;
+}
+
+std::unique_ptr<fastdds::rtps::RTPSParticipantListener>
+CommonParticipant::create_listener_()
+{
+    return std::make_unique<RtpsListener>(configuration_, discovery_database_);
 }
 
 } /* namespace rtps */

--- a/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/auxiliar/BaseReader.cpp
@@ -165,7 +165,7 @@ bool BaseReader::should_accept_sample_() noexcept
 
 void BaseReader::on_data_available_() const noexcept
 {
-    if (on_data_available_lambda_set_)
+    if (on_data_available_lambda_set_ && enabled_.load())
     {
         on_data_available_lambda_();
     }

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -93,7 +93,7 @@ void CommonReader::init()
     if (fastdds::dds::RETCODE_OK != reader_->enable())
     {
         dds_subscriber_->delete_datareader(reader_);
-        dds_subscriber_ = nullptr;
+        reader_ = nullptr;
         throw utils::InitializationException(
                   utils::Formatter() << "Error enabling DataReader for Participant " <<
                       participant_id_ << " in topic " << topic_ << ".");

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -93,6 +93,7 @@ void CommonReader::init()
     if (fastdds::dds::RETCODE_OK != reader_->enable())
     {
         dds_subscriber_->delete_datareader(reader_);
+        dds_subscriber_ = nullptr;
         throw utils::InitializationException(
                   utils::Formatter() << "Error enabling DataReader for Participant " <<
                       participant_id_ << " in topic " << topic_ << ".");

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -187,7 +187,8 @@ utils::ReturnCode CommonReader::take_nts_(
             // There has been an error taking the data. Exit.
             return ret;
         }
-    } while (!should_accept_sample_(info));
+    }
+    while (!should_accept_sample_(info));
 
     EPROSIMA_LOG_INFO(DDSPIPE_DDS_READER, "Data taken in " << participant_id_ << " for topic " << topic_ << ".");
 

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -75,7 +75,7 @@ void CommonReader::init()
     reader_ = dds_subscriber_->create_datareader(
         dds_topic_,
         reckon_reader_qos_(),
-        nullptr,
+        this,
         eprosima::fastdds::dds::StatusMask::all(),
         payload_pool_);
 
@@ -85,10 +85,6 @@ void CommonReader::init()
                   utils::Formatter() << "Error creating DataReader for Participant " <<
                       participant_id_ << " in topic " << topic_ << ".");
     }
-
-    // Set listener after entity creation to avoid SEGFAULT (produced when callback using reader_ is
-    // invoked before the variable is fully set)
-    reader_->set_listener(this);
 
 }
 

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -121,10 +121,6 @@ void CommonReader::internal_entities_creation_(
                       participant_id_ << " in topic " << topic_ << ".");
     }
 
-    // Set listener after entity creation to avoid SEGFAULT (produced when callback using rtps_reader_ is
-    // invoked before the variable is fully set)
-    rtps_reader_->set_listener(this);
-
     // Register reader with topic
     if (!rtps_participant_->register_reader(rtps_reader_, topic_description, reader_qos))
     {

--- a/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/CommonReader.cpp
@@ -107,6 +107,7 @@ void CommonReader::internal_entities_creation_(
     // Create CommonReader
     // Listener must be set in creation as no callbacks should be missed
     // It is safe to do so here as object is already created and callbacks do not require anything set in this method
+    // Also, no data races can ocurr as no callback will be called until this reader is registered
     rtps_reader_ = fastdds::rtps::RTPSDomain::createRTPSReader(
         rtps_participant_,
         non_const_reader_attributes,


### PR DESCRIPTION
This PR is a follow up of https://github.com/eProsima/DDS-Router/pull/509 to fix tsan tests of the DDS Router. It fixes two data races:

- First, it uses the `enabled_` atomic boolean of the `BaseReader` to ensure that the `on_data_available_lambda_` is only called when the class has been properly enabled, that is, when the lambda has already been set. This change is not mandatory, but TSAN stops reporting a false positive related to a data race with the the mentioned lambda . 
- Then, it uses DDS/Rtps Listeners as attributes rather than inheriting from them. In this way, a data race between the `on_participant_discovery` callback and the destructor is avoided (data race on vptr (ctor/dtor vs virtual call)). This data rece occurs when a thread makes a call to a virtual method (`"dds.udp"` calls `listener_->on_participant_discovery`) while at the same time the destructor of the object that owns the virtual method is called (`~CommonParticipant`). Calling `set_listener(nullptr)` within the destructor does not prevent the data race, because the vtable is modified in the prologue of the destructor. 
- It also prevents several data races by avoiding calling `set_listener` after the Reader initialization.