### PR TITLE
Support repeater feature in DDS (XML) participants

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
@@ -131,9 +131,25 @@ protected:
     // INTERNAL METHODS
     /////////////////////////
 
+    /**
+     * @brief Get the specific Publisher QoS for the \c DdsTopic associated to this writer.
+     *
+     * This method is used to set the QoS of the Publisher that will be created for this writer.
+     * It takes into account the default publisher QoS and the specific \c DdsTopic QoS of this writer.
+     *
+     * @return The Publisher QoS to be used for this writer.
+     */
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual fastdds::dds::PublisherQos reckon_publisher_qos_() const noexcept;
 
+    /**
+     * @brief Get the specific DataWriter QoS for the \c DdsTopic associated to this writer.
+     *
+     * This method is used to set the QoS of the DataWriter that will be created for this writer.
+     * It takes into account the default data writer QoS and the specific \c DdsTopic QoS of this writer.
+     *
+     * @return The DataWriter QoS to be used for this writer.
+     */
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual fastdds::dds::DataWriterQos reckon_writer_qos_() const noexcept;
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
@@ -20,7 +20,9 @@
 #include <fastdds/dds/publisher/DataWriter.hpp>
 #include <fastdds/dds/publisher/Publisher.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
+#include <fastdds/dds/topic/IContentFilter.hpp>
 #include <fastdds/dds/topic/Topic.hpp>
+#include <fastdds/rtps/common/WriteParams.hpp>
 
 #include <ddspipe_core/efficiency/payload/PayloadPoolMediator.hpp>
 #include <ddspipe_core/types/participant/ParticipantId.hpp>
@@ -99,7 +101,8 @@ protected:
             const core::types::DdsTopic& topic,
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
-            fastdds::dds::Topic* topic_entity);
+            fastdds::dds::Topic* topic_entity,
+            const bool repeater);
 
     /////////////////////////
     // IWRITER METHODS
@@ -128,13 +131,22 @@ protected:
     // INTERNAL METHODS
     /////////////////////////
 
-    virtual
-    fastdds::dds::PublisherQos
-    reckon_publisher_qos_() const noexcept;
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual fastdds::dds::PublisherQos reckon_publisher_qos_() const noexcept;
 
-    virtual
-    fastdds::dds::DataWriterQos
-    reckon_writer_qos_() const noexcept;
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual fastdds::dds::DataWriterQos reckon_writer_qos_() const noexcept;
+
+    /**
+     * @brief Auxiliary method used in \c write to fill the sample to send and write params.
+     *
+     * @param [out] to_send_params write params to be filled and sent.
+     * @param [in] data data received that must be sent.
+     */
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual utils::ReturnCode fill_to_send_data_(
+            eprosima::fastdds::rtps::WriteParams& to_send_params,
+            const core::types::RtpsPayloadData& data) const noexcept;
 
     /////////////////////////
     // EXTERNAL VARIABLES
@@ -142,6 +154,7 @@ protected:
 
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
+    bool repeater_;
 
     /////////////////////////
     // INTERNAL VARIABLES
@@ -153,6 +166,7 @@ protected:
 
     fastdds::dds::Publisher* dds_publisher_;
     fastdds::dds::DataWriter* writer_;
+    std::shared_ptr<fastdds::dds::IContentFilter> data_filter_;
 };
 
 } /* namespace dds */

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
@@ -48,6 +48,7 @@ public:
      * @param payload_pool      Shared Payload Pool to received data and take it.
      * @param participant       DDS Participant pointer.
      * @param topic_entity      DDS Topic pointer.
+     * @param repeater          If this MultiWriter is a repeater or not.
      *
      * @throw \c InitializationException in case any creation has failed
      */
@@ -57,7 +58,8 @@ public:
             const core::types::DdsTopic& topic,
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
-            fastdds::dds::Topic* topic_entity);
+            fastdds::dds::Topic* topic_entity,
+            const bool repeater = false);
 
     /**
      * @brief Destroy the MultiWriter object
@@ -99,6 +101,7 @@ protected:
 
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
+    bool repeater_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
@@ -39,8 +39,10 @@ public:
      * @param participant_id    Router Id of the Participant that has created this QoSSpecificWriter.
      * @param topic             Topic that this QoSSpecificWriter subscribes to.
      * @param payload_pool      Shared Payload Pool to received data and take it.
+     * @param specific_qos      Specific QoS of the Endpoint.
      * @param participant       DDS Participant pointer.
      * @param topic_entity      DDS Topic pointer.
+     * @param repeater          If this QoSSpecificWriter is a repeater or not.
      *
      * @throw \c InitializationException in case any creation has failed
      */
@@ -51,7 +53,8 @@ public:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             const core::types::SpecificEndpointQoS& specific_qos,
             fastdds::dds::DomainParticipant* participant,
-            fastdds::dds::Topic* topic_entity);
+            fastdds::dds::Topic* topic_entity,
+            const bool repeater = false);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
@@ -43,6 +43,7 @@ public:
      * @param payload_pool      Shared Payload Pool to received data and take it.
      * @param participant       DDS Participant pointer.
      * @param topic_entity      DDS Topic pointer.
+     * @param repeater          If this SimpleWriter is a repeater or not.
      *
      * @throw \c InitializationException in case any creation has failed
      */
@@ -52,7 +53,8 @@ public:
             const core::types::DdsTopic& topic,
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
-            fastdds::dds::Topic* topic_entity);
+            fastdds::dds::Topic* topic_entity,
+            const bool repeater = false);
 
 };
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp
@@ -1,0 +1,53 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/WriteParams.hpp>
+
+#include <ddspipe_participants/library/library_dll.h>
+#include <ddspipe_participants/writer/dds/filter/SelfDataFilter.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace participants {
+namespace dds {
+
+struct RepeaterWriteData : public fastdds::rtps::WriteParams::UserWriteData
+{
+    fastdds::rtps::GuidPrefix_t last_writer_guid_prefix;  ///< GUID of the writer that sent this change.
+};
+
+/**
+ * This filter allows to not send messages from this Writer to the Readers belonging to the source Participant.
+ * It is used in "repeater" participants in order to propagate information to external participants
+ * (participants not belonging to the same DDS-Router instance),
+ * leaving out the participant from which this information was received.
+ */
+class RepeaterDataFilter : public SelfDataFilter
+{
+public:
+
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool evaluate(
+            const fastdds::rtps::SerializedPayload_t& payload,
+            const fastdds::dds::IContentFilter::FilterSampleInfo& sample_info,
+            const fastdds::rtps::GUID_t& reader_guid) const override;
+};
+
+} /* namespace dds */
+} /* namespace participants */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file RepeaterDataFilter.hpp
+ */
+
 #pragma once
 
 #include <fastdds/rtps/common/Guid.hpp>
@@ -26,24 +30,41 @@ namespace participants {
 namespace dds {
 
 /**
- * Struct containing all relevant information for the RepeaterDataFilter.
+ * @brief Struct containing all relevant information for the \c RepeaterDataFilter.
+ *
+ * This structure extends the \c UserWriteData to include the GUID prefix of the last writer
+ * that sent a change. It is used to track the origin of a message in repeater scenarios.
  */
 struct RepeaterWriteData : public fastdds::rtps::WriteParams::UserWriteData
 {
-    // GUID of the writer that sent this change.
+    /// GUID of the writer that sent this change.
     fastdds::rtps::GuidPrefix_t last_writer_guid_prefix;
 };
 
 /**
- * This filter allows to not send messages from this Writer to the Readers belonging to the source Participant.
- * It is used in "repeater" participants in order to propagate information to external participants
- * (participants not belonging to the same DDS-Router instance),
- * leaving out the participant from which this information was received.
+ * @brief Data filter to prevent sending messages back to their source participant.
+ *
+ * This filter is used by "repeater" participants to propagate information only to external participants,
+ * i.e., participants not belonging to the same DDS-Router instance. It ensures that messages are not
+ * sent to readers that belong to the participant from which the information was originally received.
  */
 class RepeaterDataFilter : public SelfDataFilter
 {
 public:
 
+    /**
+     * @brief Evaluates whether a message should be sent to a given reader.
+     *
+     * This method checks whether the reader belongs to the same participant from which the message originated.
+     * I also checks whether the reader belongs to the same participant as the writer.
+     *
+     * @param payload The serialized payload of the message.
+     * @param sample_info Information about the sample for content filtering.
+     * @param reader_guid The GUID of the reader to which the message may be sent.
+     * @return true if the reader does not belong to the participant that sent the message
+     * and also does not belong to the same participant as the writer.
+     * @return false otherwise.
+     */
     DDSPIPE_PARTICIPANTS_DllAPI
     bool evaluate(
             const fastdds::rtps::SerializedPayload_t& payload,

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp
@@ -25,9 +25,13 @@ namespace ddspipe {
 namespace participants {
 namespace dds {
 
+/**
+ * Struct containing all relevant information for the RepeaterDataFilter.
+ */
 struct RepeaterWriteData : public fastdds::rtps::WriteParams::UserWriteData
 {
-    fastdds::rtps::GuidPrefix_t last_writer_guid_prefix;  ///< GUID of the writer that sent this change.
+    // GUID of the writer that sent this change.
+    fastdds::rtps::GuidPrefix_t last_writer_guid_prefix;
 };
 
 /**

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/SelfDataFilter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/SelfDataFilter.hpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * @file SelfDataFilter.hpp
+ */
+
 #pragma once
 
 #include <fastdds/dds/topic/IContentFilter.hpp>
@@ -27,16 +31,24 @@ namespace participants {
 namespace dds {
 
 /**
- * This filter allows to not send messages from this Writer to the Readers in the same Participant.
+ * @brief Filter to prevent sending messages from this writer to readers in the same participant.
+ *
+ * This filter ensures that messages originating from this writer are not delivered
+ * to readers that belong to the same participant, avoiding self-data delivery.
  */
 class SelfDataFilter : public fastdds::dds::IContentFilter
 {
 public:
 
     /**
-     * @brief Whether incoming sample is relevant for this reader.
+     * @brief Evaluates whether a message should be sent to a given reader.
      *
-     * @return true if the reader does not belong to same Participant.
+     * This method checks whether the reader belongs to the same participant as the writer.
+     *
+     * @param payload The serialized payload of the message.
+     * @param sample_info Information about the sample for content filtering.
+     * @param reader_guid The GUID of the reader to which the message may be sent.
+     * @return true if the reader does not belong to the same participant.
      * @return false otherwise.
      */
     DDSPIPE_PARTICIPANTS_DllAPI

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/SelfDataFilter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/filter/SelfDataFilter.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fastdds/dds/topic/IContentFilter.hpp>
+
+#include <fastdds/rtps/common/Guid.hpp>
+#include <fastdds/rtps/common/SerializedPayload.hpp>
+
+#include <ddspipe_participants/library/library_dll.h>
+
+namespace eprosima {
+namespace ddspipe {
+namespace participants {
+namespace dds {
+
+/**
+ * This filter allows to not send messages from this Writer to the Readers in the same Participant.
+ */
+class SelfDataFilter : public fastdds::dds::IContentFilter
+{
+public:
+
+    /**
+     * @brief Whether incoming sample is relevant for this reader.
+     *
+     * @return true if the reader does not belong to same Participant.
+     * @return false otherwise.
+     */
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool evaluate(
+            const fastdds::rtps::SerializedPayload_t& payload,
+            const fastdds::dds::IContentFilter::FilterSampleInfo& sample_info,
+            const fastdds::rtps::GUID_t& reader_guid) const override;
+};
+
+} /* namespace dds */
+} /* namespace participants */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
@@ -193,7 +193,7 @@ protected:
             core::IRoutingData& data) noexcept override;
 
     /**
-     * @brief Auxiliary method used in \c write to fill the cache change to send.
+     * @brief Auxiliary method used in \c write to fill the cache change to send and write params.
      *
      * @param [out] to_send_change_to_fill cache change to be filled and sent.
      * @param [out] to_send_params write params to be filled and sent.

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -105,7 +105,7 @@ bool CommonParticipant::is_rtps_kind() const noexcept
 
 bool CommonParticipant::is_repeater() const noexcept
 {
-    return false;
+    return configuration_->is_repeater;
 }
 
 core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
@@ -143,7 +143,8 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             dds_topic,
             this->payload_pool_,
             dds_participant_,
-            fastdds_topic);
+            fastdds_topic,
+            configuration_->is_repeater);
     }
     else
     {
@@ -152,7 +153,8 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             dds_topic,
             this->payload_pool_,
             dds_participant_,
-            fastdds_topic);
+            fastdds_topic,
+            configuration_->is_repeater);
         writer->init();
 
         return writer;

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -13,17 +13,20 @@
 // limitations under the License.
 
 
-#include <fastdds/rtps/RTPSDomain.hpp>
-#include <fastdds/rtps/participant/RTPSParticipant.hpp>
 #include <fastdds/rtps/common/CacheChange.hpp>
+#include <fastdds/rtps/common/WriteParams.hpp>
+#include <fastdds/rtps/participant/RTPSParticipant.hpp>
+#include <fastdds/rtps/RTPSDomain.hpp>
 
 #include <cpp_utils/exception/InitializationException.hpp>
 #include <cpp_utils/Log.hpp>
 #include <cpp_utils/time/time_utils.hpp>
 
 #include <ddspipe_participants/efficiency/cache_change/CacheChangePool.hpp>
-#include <ddspipe_participants/writer/dds/CommonWriter.hpp>
 #include <ddspipe_participants/types/dds/RouterCacheChange.hpp>
+#include <ddspipe_participants/writer/dds/CommonWriter.hpp>
+#include <ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp>
+#include <ddspipe_participants/writer/dds/filter/SelfDataFilter.hpp>
 
 namespace eprosima {
 namespace ddspipe {
@@ -83,6 +86,24 @@ void CommonWriter::init()
                   utils::Formatter() << "Error creating DataWriter for Participant " <<
                       participant_id_ << " in topic " << topic_ << ".");
     }
+
+    if (repeater_)
+    {
+        // Use filter writer of origin
+        data_filter_ = std::make_shared<RepeaterDataFilter>();
+    }
+    else
+    {
+        // Use default filter
+        data_filter_ = std::make_shared<SelfDataFilter>();
+    }
+
+    if (fastdds::dds::RETCODE_OK != writer_->set_sample_prefilter(data_filter_))
+    {
+        throw utils::InitializationException(
+                  utils::Formatter() << "Error setting DataWriter prefilter for Participant " <<
+                      participant_id_ << " in topic " << topic_ << ".");
+    }
 }
 
 CommonWriter::CommonWriter(
@@ -90,12 +111,14 @@ CommonWriter::CommonWriter(
         const DdsTopic& topic,
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
-        fastdds::dds::Topic* topic_entity)
+        fastdds::dds::Topic* topic_entity,
+        const bool repeater)
     : BaseWriter(participant_id, topic.topic_qos.max_tx_rate)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(new core::PayloadPoolMediator(payload_pool))
     , topic_(topic)
+    , repeater_(repeater)
     , dds_publisher_(nullptr)
     , writer_(nullptr)
 {
@@ -110,15 +133,23 @@ utils::ReturnCode CommonWriter::write_nts_(
 
     auto& rtps_data = dynamic_cast<core::types::RtpsPayloadData&>(data);
 
-    if (topic_.topic_qos.keyed)
+    fastdds::rtps::WriteParams wparams;
+
+    if (fill_to_send_data_(wparams, rtps_data) != utils::ReturnCode::RETCODE_OK)
     {
-        // TODO check if in case of dispose it must be done something differently
-        return payload_pool_->write(writer_, &rtps_data, rtps_data.instanceHandle);
+        EPROSIMA_LOG_ERROR(DDSPIPE_DDS_WRITER, "Error setting data to send.");
+        return utils::ReturnCode::RETCODE_ERROR;
     }
-    else
-    {
-        return payload_pool_->write(writer_, &rtps_data);
-    }
+
+    // WARNING: At the time of this writing, there is no DataWriter API to write both with parameters and instance handle.
+    // However, the current implementation of write without instance handle always computes its value via type support
+    // (if it corresponds to a keyed topic), so it is equivalent to write with instance handle (and can hence use the
+    // write with params overload to cover all cases). Future developers should be aware of this and might need to
+    // update this method if the DataWriter implementation changes at some point.
+    return payload_pool_->write(writer_, &rtps_data, wparams);
+
+    // TODO: handle dipose case -> DataWriter::write will always send ALIVE changes, so this case must be handled
+    // with additional logic (e.g. by using unregister_instance instead of write).
 }
 
 fastdds::dds::PublisherQos CommonWriter::reckon_publisher_qos_() const noexcept
@@ -170,6 +201,23 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
     qos.deadline().period = eprosima::fastdds::dds::Duration_t(0);
 
     return qos;
+}
+
+utils::ReturnCode CommonWriter::fill_to_send_data_(
+        fastdds::rtps::WriteParams& to_send_params,
+        const RtpsPayloadData& data) const noexcept
+{
+    if (repeater_)
+    {
+        auto write_data = std::make_shared<RepeaterWriteData>();
+        write_data->last_writer_guid_prefix = data.source_guid.guidPrefix;
+        to_send_params.user_write_data(write_data);
+    }
+
+    // Set source time stamp to be the original one
+    to_send_params.source_timestamp(data.source_timestamp);
+
+    return utils::ReturnCode::RETCODE_OK;
 }
 
 } /* namespace dds */

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -170,8 +170,6 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
 {
     fastdds::dds::DataWriterQos qos = dds_publisher_->get_default_datawriter_qos();
 
-    dds_publisher_->get_default_datawriter_qos();
-
     qos.durability().kind =
             (topic_.topic_qos.is_transient_local())
             ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS

--- a/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
@@ -38,12 +38,14 @@ MultiWriter::MultiWriter(
         const DdsTopic& topic,
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
-        fastdds::dds::Topic* topic_entity)
+        fastdds::dds::Topic* topic_entity,
+        const bool repeater /* = false */)
     : BaseWriter(participant_id)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(payload_pool)
     , topic_(topic)
+    , repeater_(repeater)
 {
     // Do nothing
 }
@@ -137,7 +139,8 @@ QoSSpecificWriter* MultiWriter::create_writer_nts_(
         this->payload_pool_,
         data_qos,
         this->dds_participant_,
-        this->dds_topic_);
+        this->dds_topic_,
+        repeater_);
     writer->init();
 
     return writer;

--- a/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
@@ -28,9 +28,10 @@ QoSSpecificWriter::QoSSpecificWriter(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         const core::types::SpecificEndpointQoS& specific_qos,
         fastdds::dds::DomainParticipant* participant,
-        fastdds::dds::Topic* topic_entity)
+        fastdds::dds::Topic* topic_entity,
+        const bool repeater /* = false */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater)
     , specific_qos_(specific_qos)
 {
 }

--- a/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
@@ -34,9 +34,10 @@ SimpleWriter::SimpleWriter(
         const core::types::DdsTopic& topic,
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
-        fastdds::dds::Topic* topic_entity)
+        fastdds::dds::Topic* topic_entity,
+        const bool repeater /* = false */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater)
 {
     // Do nothing
 }

--- a/ddspipe_participants/src/cpp/writer/dds/filter/RepeaterDataFilter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/filter/RepeaterDataFilter.cpp
@@ -1,0 +1,54 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cpp_utils/Log.hpp>
+
+#include <ddspipe_participants/writer/dds/filter/RepeaterDataFilter.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace participants {
+namespace dds {
+
+bool RepeaterDataFilter::evaluate(
+        const fastdds::rtps::SerializedPayload_t& payload,
+        const fastdds::dds::IContentFilter::FilterSampleInfo& sample_info,
+        const fastdds::rtps::GUID_t& reader_guid) const
+{
+    if (!SelfDataFilter::evaluate(payload, sample_info, reader_guid))
+    {
+        logDebug(
+            REPEATER_DATA_FILTER,
+            "Ignoring message by SelfDataFilter evaluate result.");
+
+        // Discard sample if it comes from the same participant
+        return false;
+    }
+
+    auto write_data = std::static_pointer_cast<RepeaterWriteData>(sample_info.user_write_data);
+
+    bool is_relevant = write_data->last_writer_guid_prefix != reader_guid.guidPrefix;
+
+    logDebug(
+        REPEATER_DATA_FILTER,
+        "Evaluating whether sample with origin writer GUID prefix " << write_data->last_writer_guid_prefix  <<
+            " is relevant for reader GUID " << reader_guid << "? " << (is_relevant ? "TRUE" : "FALSE"));
+
+    return is_relevant;
+}
+
+} /* namespace dds */
+} /* namespace participants */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_participants/src/cpp/writer/dds/filter/SelfDataFilter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/filter/SelfDataFilter.cpp
@@ -1,0 +1,34 @@
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ddspipe_participants/writer/dds/filter/SelfDataFilter.hpp>
+
+namespace eprosima {
+namespace ddspipe {
+namespace participants {
+namespace dds {
+
+bool SelfDataFilter::evaluate(
+        const fastdds::rtps::SerializedPayload_t&,
+        const fastdds::dds::IContentFilter::FilterSampleInfo& sample_info,
+        const fastdds::rtps::GUID_t& reader_guid) const
+{
+    // It is relevant only if the reader does not belong to same participant as writer
+    return sample_info.sample_identity.writer_guid().guidPrefix != reader_guid.guidPrefix;
+}
+
+} /* namespace dds */
+} /* namespace participants */
+} /* namespace ddspipe */
+} /* namespace eprosima */

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -340,6 +340,12 @@ void YamlReader::fill(
 
     // Mandatory participant profile
     object.participant_profile = YamlReader::get<std::string>(yml, XML_PARTICIPANT_PROFILE_TAG, version);
+
+    // Optional Repeater
+    if (YamlReader::is_tag_present(yml, IS_REPEATER_TAG))
+    {
+        object.is_repeater = YamlReader::get<bool>(yml, IS_REPEATER_TAG, version);
+    }
 }
 
 template <>


### PR DESCRIPTION
This PR adds the possibility to configure DDS (XML) participants so they support the [repeater feature](https://eprosima-dds-router.readthedocs.io/en/latest/rst/use_cases/repeater.html), which up to now has been available only for RTPS participants. The implementation relies on the new feature introduced in https://github.com/eProsima/Fast-DDS/pull/5861.