### PR TITLE
Add export to 'create_listener'

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
@@ -98,12 +98,6 @@ public:
                 const fastdds::rtps::PublicationBuiltinTopicData& info,
                 bool& should_be_ignored) override;
 
-        //! Type Object Reader getter
-        inline std::shared_ptr<InternalReader> type_object_reader() const
-        {
-            return type_object_reader_;
-        }
-
     protected:
 
         //! Copy of Type Object Internal Reader
@@ -120,6 +114,7 @@ public:
 protected:
 
     //! Override method from \c CommonParticipant to create the internal RTPS participant listener
+    DDSPIPE_PARTICIPANTS_DllAPI
     std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_() override;
 
     //! Type Object Internal Reader

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
@@ -69,8 +69,7 @@ std::shared_ptr<IReader> DynTypesParticipant::create_reader(
     // If type object topic, return the internal reader for type objects
     if (core::types::is_type_object_topic(topic))
     {
-        return static_cast<DynTypesParticipant::DynTypesRtpsListener*>(rtps_participant_listener_.get())->
-                       type_object_reader();
+        return type_object_reader_;
     }
 
     // If not type object, use the parent method


### PR DESCRIPTION
This PR adds a missing export to the create_listener method to fix compilation on Windows in products inheriting from `DynTypesParticipant`.