### PR TITLE
Split RTPS and DDS Listeners in DynTypesParticipant

### DIFF
--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
@@ -71,16 +71,36 @@ public:
     std::shared_ptr<core::IReader> create_reader(
             const core::ITopic& topic) override;
 
-    class DynTypesRtpsListener : public rtps::CommonParticipant::RtpsListener,
-        public eprosima::fastdds::dds::DomainParticipantListener
+    // DynTypesParticipant makes use of both RTPS and DDS listeners
+
+    /**
+     * @brief This class is the RTPS Listener for DynTypesParticipant. It inherits from
+     * \c rtps::CommonParticipant::RtpsListener .
+     */
+    class DynTypesRtpsListener : public rtps::CommonParticipant::RtpsListener
     {
     public:
 
         DDSPIPE_PARTICIPANTS_DllAPI
         explicit DynTypesRtpsListener(
                 std::shared_ptr<ParticipantConfiguration> conf,
-                std::shared_ptr<core::DiscoveryDatabase> ddb,
-                std::shared_ptr<InternalReader> internal_reader);
+                std::shared_ptr<core::DiscoveryDatabase> ddb);
+
+    };
+
+    /**
+     * @brief This class is the DDS Listener for DynTypesParticipant. It inherits directly from
+     * \c fastdds::dds::DomainParticipantListener and implements the methods needed to process type objects and
+     * type lookup services.
+     */
+    class DynTypesDdsListener : public eprosima::fastdds::dds::DomainParticipantListener
+    {
+    public:
+
+        DDSPIPE_PARTICIPANTS_DllAPI
+        explicit DynTypesDdsListener(
+                std::shared_ptr<InternalReader> type_object_reader,
+                core::types::ParticipantId participant_id);
 
         DDSPIPE_PARTICIPANTS_DllAPI
         void on_type_discovery(
@@ -106,6 +126,9 @@ public:
         //! Copy of Type Object Internal Reader
         std::shared_ptr<InternalReader> type_object_reader_;
 
+        //! Participant ID for informative purposes. It is stored in the CommonParticipant (RTPS)
+        core::types::ParticipantId participant_id_;
+
     };
 
 protected:
@@ -114,12 +137,18 @@ protected:
 
     eprosima::fastdds::dds::DomainParticipant* dds_participant_;
 
+    std::unique_ptr<eprosima::fastdds::dds::DomainParticipantListener> dds_participant_listener_;
+
     //! Type Object Internal Reader
     std::shared_ptr<InternalReader> type_object_reader_;
 
     //! Override method from \c CommonParticipant to create the internal RTPS participant listener
     DDSPIPE_PARTICIPANTS_DllAPI
     std::unique_ptr<fastrtps::rtps::RTPSParticipantListener> create_listener_() override;
+
+    //! Method to create the internal DDS participant listener
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual std::unique_ptr<fastdds::dds::DomainParticipantListener> create_dds_listener_();
 
 };
 

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
@@ -71,23 +71,6 @@ public:
     std::shared_ptr<core::IReader> create_reader(
             const core::ITopic& topic) override;
 
-    // DynTypesParticipant makes use of both RTPS and DDS listeners
-
-    /**
-     * @brief This class is the RTPS Listener for DynTypesParticipant. It inherits from
-     * \c rtps::CommonParticipant::RtpsListener .
-     */
-    class DynTypesRtpsListener : public rtps::CommonParticipant::RtpsListener
-    {
-    public:
-
-        DDSPIPE_PARTICIPANTS_DllAPI
-        explicit DynTypesRtpsListener(
-                std::shared_ptr<ParticipantConfiguration> conf,
-                std::shared_ptr<core::DiscoveryDatabase> ddb);
-
-    };
-
     /**
      * @brief This class is the DDS Listener for DynTypesParticipant. It inherits directly from
      * \c fastdds::dds::DomainParticipantListener and implements the methods needed to process type objects and
@@ -141,10 +124,6 @@ protected:
 
     //! Type Object Internal Reader
     std::shared_ptr<InternalReader> type_object_reader_;
-
-    //! Override method from \c CommonParticipant to create the internal RTPS participant listener
-    DDSPIPE_PARTICIPANTS_DllAPI
-    std::unique_ptr<fastrtps::rtps::RTPSParticipantListener> create_listener_() override;
 
     //! Method to create the internal DDS participant listener
     DDSPIPE_PARTICIPANTS_DllAPI

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
@@ -94,15 +94,6 @@ std::shared_ptr<IReader> DynTypesParticipant::create_reader(
     return rtps::SimpleParticipant::create_reader(topic);
 }
 
-DynTypesParticipant::DynTypesRtpsListener::DynTypesRtpsListener(
-        std::shared_ptr<ParticipantConfiguration> conf,
-        std::shared_ptr<core::DiscoveryDatabase> ddb)
-    : rtps::CommonParticipant::RtpsListener(
-        conf,
-        ddb)
-{
-}
-
 DynTypesParticipant::DynTypesDdsListener::DynTypesDdsListener(
         std::shared_ptr<InternalReader> type_object_reader,
         core::types::ParticipantId participant_id)
@@ -317,11 +308,6 @@ void DynTypesParticipant::initialize_internal_dds_participant_()
     {
         throw utils::InitializationException("Error creating DDS Participant.");
     }
-}
-
-std::unique_ptr<fastrtps::rtps::RTPSParticipantListener> DynTypesParticipant::create_listener_()
-{
-    return std::make_unique<DynTypesRtpsListener>(configuration_, discovery_database_);
 }
 
 std::unique_ptr<fastdds::dds::DomainParticipantListener> DynTypesParticipant::create_dds_listener_()


### PR DESCRIPTION
This PR splits the Listener of DynTypesParticipant into two separated listeners: RTPS and DDS.

In this way, the logic of each listener is isolated from the other. 

Also, it allows the SpyDdsParticipant to store in the DDS listener the GUID of the RTPS listener as it will already be created during the DDS participant construction. This allows to properly filter out any discovery message received from the RTPS listener. 

This PR is necessary to implement:

- https://github.com/eProsima/Fast-DDS-spy/pull/125