### PR TITLE
[#23594] Support "partitions" in DDS Recorder & Replayer

### DIFF
--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -60,6 +60,10 @@ public:
     DDSPIPE_CORE_DllAPI
     virtual types::TopicQoS topic_qos() const noexcept = 0;
 
+    //! The Participant's Topic Partitions.
+    DDSPIPE_CORE_DllAPI
+    virtual std::vector<std::string> topic_partitions() const noexcept = 0;
+
     /**
      * @brief Return a new Writer
      *

--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -62,7 +62,7 @@ public:
 
     //! The Participant's Topic Partitions.
     DDSPIPE_CORE_DllAPI
-    virtual std::map<std::string, std::set<std::string>> topic_partitions() const noexcept = 0;
+    virtual std::map<std::string, std::map<std::string, std::string>> topic_partitions() const noexcept = 0;
 
     /**
      * @brief Return a new Writer
@@ -105,7 +105,7 @@ public:
      */
     DDSPIPE_CORE_DllAPI
     virtual bool add_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) = 0;
 
     /**
@@ -117,7 +117,7 @@ public:
      */
     DDSPIPE_CORE_DllAPI
     virtual bool delete_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) = 0;
 
     /**

--- a/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IParticipant.hpp
@@ -62,7 +62,7 @@ public:
 
     //! The Participant's Topic Partitions.
     DDSPIPE_CORE_DllAPI
-    virtual std::vector<std::string> topic_partitions() const noexcept = 0;
+    virtual std::map<std::string, std::set<std::string>> topic_partitions() const noexcept = 0;
 
     /**
      * @brief Return a new Writer
@@ -95,6 +95,38 @@ public:
     DDSPIPE_CORE_DllAPI
     virtual std::shared_ptr<IReader> create_reader(
             const ITopic& topic) = 0;
+
+    /**
+     * Add a Partition in the Participant.
+     *
+     * @param [in] partition : Partition name that will be added.
+     *
+     * @return bool if the function adds the partition.
+     */
+    DDSPIPE_CORE_DllAPI
+    virtual bool add_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) = 0;
+
+    /**
+     * Remove a Partition of the Participant.
+     *
+     * @param [in] partition : Partition name that will be added.
+     *
+     * @return bool if the function adds the partition.
+     */
+    DDSPIPE_CORE_DllAPI
+    virtual bool delete_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) = 0;
+
+    /**
+     * Clear the Partitions of the Participant.
+     *
+     * @param [in] partition : Partition name that will be added.
+     */
+    DDSPIPE_CORE_DllAPI
+    virtual void clear_topic_partitions() = 0;
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
@@ -58,6 +58,10 @@ struct Endpoint
     DDSPIPE_CORE_DllAPI
     TopicQoS topic_qos() const noexcept;
 
+    //! Partition of the topic
+    DDSPIPE_CORE_DllAPI
+    std::vector<std::string> topic_partitions() const noexcept;
+
     //! Whether the endpoint is a writer
     DDSPIPE_CORE_DllAPI
     bool is_writer() const noexcept;
@@ -86,6 +90,9 @@ struct Endpoint
 
     //! Specific QoS of the entity
     SpecificEndpointQoS specific_qos {};
+
+    //! Specific Partitions of the entity
+    std::vector<std::string> specific_partitions;
 
     //! Whether the endpoint is currently active
     bool active {true};

--- a/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
@@ -60,7 +60,7 @@ struct Endpoint
 
     //! Partition of the topic
     DDSPIPE_CORE_DllAPI
-    std::vector<std::string> topic_partitions() const noexcept;
+    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept;
 
     //! Whether the endpoint is a writer
     DDSPIPE_CORE_DllAPI
@@ -92,7 +92,7 @@ struct Endpoint
     SpecificEndpointQoS specific_qos {};
 
     //! Specific Partitions of the entity
-    std::vector<std::string> specific_partitions;
+    std::map<std::string, std::set<std::string>> specific_partitions;
 
     //! Whether the endpoint is currently active
     bool active {true};

--- a/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/Endpoint.hpp
@@ -60,7 +60,7 @@ struct Endpoint
 
     //! Partition of the topic
     DDSPIPE_CORE_DllAPI
-    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept;
+    std::map<std::string, std::map<std::string, std::string>> topic_partitions() const noexcept;
 
     //! Whether the endpoint is a writer
     DDSPIPE_CORE_DllAPI
@@ -92,7 +92,7 @@ struct Endpoint
     SpecificEndpointQoS specific_qos {};
 
     //! Specific Partitions of the entity
-    std::map<std::string, std::set<std::string>> specific_partitions;
+    std::map<std::string, std::map<std::string, std::string>> specific_partitions;
 
     //! Whether the endpoint is currently active
     bool active {true};

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -144,7 +144,7 @@ struct Topic : public ITopic, public IConfiguration
      *
      * e.g.: In ShapeDemos there are the following partitions ("", "A", "B", "C", "D", "*")
      */
-    std::set<std::string> partition_name{};
+    std::map<std::string, std::string> partition_name{};
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -75,6 +75,10 @@ struct Topic : public ITopic, public IConfiguration
     DDSPIPE_CORE_DllAPI
     virtual std::string topic_name() const noexcept override;
 
+    /*//! ITopic partition
+    DDSPIPE_CORE_DllAPI
+    virtual std::string topic_partition() const noexcept override;*/
+
     DDSPIPE_CORE_DllAPI
     virtual TopicInternalTypeDiscriminator internal_type_discriminator() const noexcept override;
 
@@ -134,6 +138,13 @@ struct Topic : public ITopic, public IConfiguration
      * If the Topic has manually configured Topic QoS, the Topic QoS that are manually configured get overriden.
      */
     types::TopicQoS topic_qos{};
+
+    /**
+     * @brief The Name of the topic Partition.
+     *
+     * e.g.: In ShapeDemos there are the following partitions ("", "A", "B", "C", "D", "*")
+     */
+    std::vector<std::string> partition_name{};
 };
 
 /**

--- a/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/Topic.hpp
@@ -144,7 +144,7 @@ struct Topic : public ITopic, public IConfiguration
      *
      * e.g.: In ShapeDemos there are the following partitions ("", "A", "B", "C", "D", "*")
      */
-    std::vector<std::string> partition_name{};
+    std::set<std::string> partition_name{};
 };
 
 /**

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -321,7 +321,11 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
     topic->topic_qos.set_qos(participant->topic_qos(), utils::FuzzyLevelValues::fuzzy_level_hard);
 
     // 3. Topic Partition
-    topic->partition_name = participant->topic_partitions()[topic->m_topic_name];
+    // TODO. check if is ddsrecorder or ddsreplayer
+    if(topic->partition_name.size() == 0)
+    {
+        topic->partition_name = participant->topic_partitions()[topic->m_topic_name];
+    }
 
     return topic;
 }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -133,6 +133,20 @@ void DdsBridge::create_all_tracks_()
         }
     }
 
+    std::set<std::string> curr_partition_map;
+
+    // get partitions
+    for (const auto& id : writers_to_create)
+    {
+        std::shared_ptr<IParticipant> participant = participants_->get_participant(id);
+        const auto topic = create_topic_for_participant_nts_(participant);
+
+        for(std::string curr_partition_name: topic->partition_name)
+        {
+            curr_partition_map.insert(curr_partition_name);
+        }
+    }
+
     // Create the writers.
     std::map<ParticipantId, std::shared_ptr<IWriter>> writers;
 
@@ -140,6 +154,7 @@ void DdsBridge::create_all_tracks_()
     {
         std::shared_ptr<IParticipant> participant = participants_->get_participant(id);
         const auto topic = create_topic_for_participant_nts_(participant);
+        topic->partition_name = curr_partition_map;
         writers[id] = participant->create_writer(*topic);
     }
 
@@ -306,7 +321,7 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
     topic->topic_qos.set_qos(participant->topic_qos(), utils::FuzzyLevelValues::fuzzy_level_hard);
 
     // 3. Topic Partition
-    topic->partition_name = participant->topic_partitions();
+    topic->partition_name = participant->topic_partitions()[topic->m_topic_name];
 
     return topic;
 }

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -305,6 +305,9 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
     // 2. Participant Topic QoS.
     topic->topic_qos.set_qos(participant->topic_qos(), utils::FuzzyLevelValues::fuzzy_level_hard);
 
+    // 3. Topic Partition
+    topic->partition_name = participant->topic_partitions();
+
     return topic;
 }
 

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -133,17 +133,16 @@ void DdsBridge::create_all_tracks_()
         }
     }
 
-    std::set<std::string> curr_partition_map;
+    std::map<std::string, std::string> curr_partition_map;
 
     // get partitions
     for (const auto& id : writers_to_create)
     {
         std::shared_ptr<IParticipant> participant = participants_->get_participant(id);
         const auto topic = create_topic_for_participant_nts_(participant);
-
-        for(std::string curr_partition_name: topic->partition_name)
+        for (const auto& pair : topic->partition_name)
         {
-            curr_partition_map.insert(curr_partition_name);
+            curr_partition_map[pair.first] = pair.second;
         }
     }
 
@@ -320,8 +319,6 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
     // 2. Participant Topic QoS.
     topic->topic_qos.set_qos(participant->topic_qos(), utils::FuzzyLevelValues::fuzzy_level_hard);
 
-    // 3. Topic Partition
-    // TODO. check if is ddsrecorder or ddsreplayer
     if(topic->partition_name.size() == 0)
     {
         topic->partition_name = participant->topic_partitions()[topic->m_topic_name];

--- a/ddspipe_core/src/cpp/types/dds/Endpoint.cpp
+++ b/ddspipe_core/src/cpp/types/dds/Endpoint.cpp
@@ -25,7 +25,7 @@ TopicQoS Endpoint::topic_qos() const noexcept
     return topic.topic_qos;
 }
 
-std::map<std::string, std::set<std::string>> Endpoint::topic_partitions() const noexcept
+std::map<std::string, std::map<std::string, std::string>> Endpoint::topic_partitions() const noexcept
 {
     return specific_partitions;
 }

--- a/ddspipe_core/src/cpp/types/dds/Endpoint.cpp
+++ b/ddspipe_core/src/cpp/types/dds/Endpoint.cpp
@@ -25,6 +25,11 @@ TopicQoS Endpoint::topic_qos() const noexcept
     return topic.topic_qos;
 }
 
+std::vector<std::string> Endpoint::topic_partitions() const noexcept
+{
+    return specific_partitions;//topic.topic_partitions;
+}
+
 bool Endpoint::is_writer() const noexcept
 {
     return kind == EndpointKind::writer;

--- a/ddspipe_core/src/cpp/types/dds/Endpoint.cpp
+++ b/ddspipe_core/src/cpp/types/dds/Endpoint.cpp
@@ -25,9 +25,9 @@ TopicQoS Endpoint::topic_qos() const noexcept
     return topic.topic_qos;
 }
 
-std::vector<std::string> Endpoint::topic_partitions() const noexcept
+std::map<std::string, std::set<std::string>> Endpoint::topic_partitions() const noexcept
 {
-    return specific_partitions;//topic.topic_partitions;
+    return specific_partitions;
 }
 
 bool Endpoint::is_writer() const noexcept

--- a/ddspipe_core/src/cpp/types/topic/Topic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/Topic.cpp
@@ -49,6 +49,11 @@ std::string Topic::topic_name() const noexcept
     return m_topic_name;
 }
 
+/*std::string Topic::topic_partition() const noexcept
+{
+    return partition_name;
+}*/
+
 std::string Topic::serialize() const noexcept
 {
     std::stringstream ss;
@@ -123,6 +128,7 @@ Topic& Topic::operator = (
     this->m_internal_type_discriminator = other.m_internal_type_discriminator;
     this->m_topic_discoverer = other.m_topic_discoverer;
     this->topic_qos = other.topic_qos;
+    this->partition_name = other.partition_name;
 
     return *this;
 }

--- a/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
@@ -57,7 +57,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
+    std::map<std::string, std::map<std::string, std::string>> topic_partitions() const noexcept override;
 
     //! Override create_writer() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
@@ -72,13 +72,13 @@ public:
     //! Override add_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool add_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override delete_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool delete_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override clear_topic_partitions() IParticipant method
@@ -90,7 +90,8 @@ protected:
     //! Participant Id
     const core::types::ParticipantId id_;
 
-    std::map<std::string, std::set<std::string>> partition_names;
+    //std::map<std::string, std::set<std::string>> partition_names;
+    std::map<std::string, std::map<std::string, std::string>> partition_names;
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
@@ -55,6 +55,10 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::TopicQoS topic_qos() const noexcept override;
 
+    //! Override topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    std::vector<std::string> topic_partitions() const noexcept override;
+
     //! Override create_writer() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     std::shared_ptr<core::IWriter> create_writer(

--- a/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/auxiliar/BlankParticipant.hpp
@@ -57,7 +57,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::vector<std::string> topic_partitions() const noexcept override;
+    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
 
     //! Override create_writer() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
@@ -69,10 +69,28 @@ public:
     std::shared_ptr<core::IReader> create_reader(
             const core::ITopic& topic) override;
 
+    //! Override add_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool add_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override delete_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool delete_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override clear_topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    void clear_topic_partitions() override;
+
 protected:
 
     //! Participant Id
     const core::types::ParticipantId id_;
+
+    std::map<std::string, std::set<std::string>> partition_names;
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -92,7 +92,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::vector<std::string> topic_partitions() const noexcept override;
+    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
 
     /**
      * @brief Create a writer object
@@ -111,6 +111,22 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     std::shared_ptr<core::IReader> create_reader(
             const core::ITopic& topic) override;
+
+    //! Override add_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool add_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override delete_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool delete_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override clear_topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    void clear_topic_partitions() override;
 
     /////////////////////////
     // LISTENER METHODS
@@ -194,7 +210,7 @@ protected:
      *        It should be overridden if a different listener is needed.
      */
     DDSPIPE_PARTICIPANTS_DllAPI
-    virtual std::unique_ptr<fastdds::dds::DomainParticipantListener> create_listener_();
+    virtual std::unique_ptr<fastdds::dds::DomainParticipantListener> create_listener_(CommonParticipant& parent_class);
 
     /////////////////////////
     // INTERNAL VIRTUAL METHODS
@@ -251,6 +267,8 @@ protected:
 
     //! DDS Router shared Discovery Database
     const std::shared_ptr<core::DiscoveryDatabase> discovery_database_;
+
+    std::map<std::string, std::set<std::string>> partition_names;
 };
 
 } /* namespace dds */

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -90,6 +90,10 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::TopicQoS topic_qos() const noexcept override;
 
+    //! Override topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    std::vector<std::string> topic_partitions() const noexcept override;
+
     /**
      * @brief Create a writer object
      *

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -92,7 +92,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
+    std::map<std::string, std::map<std::string, std::string>> topic_partitions() const noexcept override;
 
     /**
      * @brief Create a writer object
@@ -115,13 +115,13 @@ public:
     //! Override add_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool add_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override delete_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool delete_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override clear_topic_partitions() IParticipant method
@@ -268,7 +268,8 @@ protected:
     //! DDS Router shared Discovery Database
     const std::shared_ptr<core::DiscoveryDatabase> discovery_database_;
 
-    std::map<std::string, std::set<std::string>> partition_names;
+    //std::map<std::string, std::set<std::string>> partition_names;
+    std::map<std::string, std::map<std::string, std::string>> partition_names;
 };
 
 } /* namespace dds */

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/DynTypesParticipant.hpp
@@ -82,6 +82,13 @@ public:
         explicit DynTypesRtpsListener(
                 std::shared_ptr<ParticipantConfiguration> conf,
                 std::shared_ptr<core::DiscoveryDatabase> ddb,
+                std::shared_ptr<InternalReader> internal_reader,
+                CommonParticipant& parent_class);
+
+        DDSPIPE_PARTICIPANTS_DllAPI
+        explicit DynTypesRtpsListener(
+                std::shared_ptr<ParticipantConfiguration> conf,
+                std::shared_ptr<core::DiscoveryDatabase> ddb,
                 std::shared_ptr<InternalReader> internal_reader);
 
         DDSPIPE_PARTICIPANTS_DllAPI
@@ -115,7 +122,7 @@ protected:
 
     //! Override method from \c CommonParticipant to create the internal RTPS participant listener
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_() override;
+    std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_(CommonParticipant& parent_class) override;
 
     //! Type Object Internal Reader
     std::shared_ptr<InternalReader> type_object_reader_;

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
@@ -58,7 +58,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
+    std::map<std::string, std::map<std::string, std::string>> topic_partitions() const noexcept override;
 
     //! Override create_writer_() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
@@ -73,13 +73,13 @@ public:
     //! Override add_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool add_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override delete_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool delete_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override clear_topic_partitions() IParticipant method
@@ -102,7 +102,8 @@ protected:
 
     std::shared_ptr<ISchemaHandler> schema_handler_;
 
-    std::map<std::string, std::set<std::string>> partition_names;
+    //std::map<std::string, std::set<std::string>> partition_names;
+    std::map<std::string, std::map<std::string, std::string>> partition_names;
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
@@ -58,7 +58,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::vector<std::string> topic_partitions() const noexcept override;
+    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
 
     //! Override create_writer_() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
@@ -69,6 +69,22 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     std::shared_ptr<core::IReader> create_reader(
             const core::ITopic& topic) override;
+
+    //! Override add_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool add_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override delete_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool delete_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override clear_topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    void clear_topic_partitions() override;
 
 protected:
 
@@ -85,6 +101,8 @@ protected:
     std::shared_ptr<core::DiscoveryDatabase> discovery_database_;
 
     std::shared_ptr<ISchemaHandler> schema_handler_;
+
+    std::map<std::string, std::set<std::string>> partition_names;
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
@@ -56,6 +56,10 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::TopicQoS topic_qos() const noexcept override;
 
+    //! Override topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    std::vector<std::string> topic_partitions() const noexcept override;
+
     //! Override create_writer_() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     std::shared_ptr<core::IWriter> create_writer(

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -102,7 +102,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::vector<std::string> topic_partitions() const noexcept override;
+    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
 
     /**
      * @brief Create a writer object
@@ -122,6 +122,22 @@ public:
     std::shared_ptr<core::IReader> create_reader(
             const core::ITopic& topic) override;
 
+    //! Override add_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool add_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override delete_topic_partition() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool delete_topic_partition(
+            const std::string& topic_name,
+            const std::string& partition) override;
+
+    //! Override clear_topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    void clear_topic_partitions() override;
+
     /////////////////////////
     // RTPS LISTENER METHODS
     /////////////////////////
@@ -134,6 +150,12 @@ public:
         explicit RtpsListener(
                 std::shared_ptr<ParticipantConfiguration> conf,
                 std::shared_ptr<core::DiscoveryDatabase> ddb);
+
+        DDSPIPE_PARTICIPANTS_DllAPI
+        explicit RtpsListener(
+                std::shared_ptr<ParticipantConfiguration> conf,
+                std::shared_ptr<core::DiscoveryDatabase> ddb,
+                CommonParticipant& parent_class);
 
         /**
          * @brief Override method from \c RTPSParticipantListener .
@@ -177,6 +199,8 @@ public:
         const std::shared_ptr<ParticipantConfiguration> configuration_;
         //! Shared pointer to the discovery database
         const std::shared_ptr<core::DiscoveryDatabase> discovery_database_;
+
+        CommonParticipant* parent_class_{nullptr};
 
     };
 
@@ -252,7 +276,7 @@ protected:
      * @return A unique pointer to an RTPS Participant Listener.
      */
     DDSPIPE_PARTICIPANTS_DllAPI
-    virtual std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_();
+    virtual std::unique_ptr<fastdds::rtps::RTPSParticipantListener> create_listener_(CommonParticipant& parent_class);
 
     /////
     // VARIABLES
@@ -274,6 +298,8 @@ protected:
 
     //! Participant attributes to create the internal RTPS Participant.
     fastdds::rtps::RTPSParticipantAttributes participant_attributes_;
+
+    std::map<std::string, std::set<std::string>> partition_names;
 };
 
 } /* namespace rtps */

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -100,6 +100,10 @@ public:
     DDSPIPE_PARTICIPANTS_DllAPI
     core::types::TopicQoS topic_qos() const noexcept override;
 
+    //! Override topic_partitions() IParticipant method
+    DDSPIPE_PARTICIPANTS_DllAPI
+    std::vector<std::string> topic_partitions() const noexcept override;
+
     /**
      * @brief Create a writer object
      *

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -102,7 +102,7 @@ public:
 
     //! Override topic_partitions() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
-    std::map<std::string, std::set<std::string>> topic_partitions() const noexcept override;
+    std::map<std::string, std::map<std::string, std::string>> topic_partitions() const noexcept override;
 
     /**
      * @brief Create a writer object
@@ -125,13 +125,13 @@ public:
     //! Override add_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool add_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override delete_topic_partition() IParticipant method
     DDSPIPE_PARTICIPANTS_DllAPI
     bool delete_topic_partition(
-            const std::string& topic_name,
+            const std::string& topic_name, const std::string& writer_name,
             const std::string& partition) override;
 
     //! Override clear_topic_partitions() IParticipant method
@@ -299,7 +299,8 @@ protected:
     //! Participant attributes to create the internal RTPS Participant.
     fastdds::rtps::RTPSParticipantAttributes participant_attributes_;
 
-    std::map<std::string, std::set<std::string>> partition_names;
+    //std::map<std::string, std::set<std::string>> partition_names;
+    std::map<std::string, std::map<std::string, std::string>> partition_names;
 };
 
 } /* namespace rtps */

--- a/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
@@ -48,6 +48,12 @@ core::types::TopicQoS BlankParticipant::topic_qos() const noexcept
     return m_topic_qos;
 }
 
+std::vector<std::string> BlankParticipant::topic_partitions() const noexcept
+{
+    // TODO. danip
+    return {};
+}
+
 std::shared_ptr<core::IWriter> BlankParticipant::create_writer(
         const core::ITopic& topic)
 {

--- a/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
@@ -48,9 +48,8 @@ core::types::TopicQoS BlankParticipant::topic_qos() const noexcept
     return m_topic_qos;
 }
 
-std::map<std::string, std::set<std::string>> BlankParticipant::topic_partitions() const noexcept
+std::map<std::string, std::map<std::string, std::string>> BlankParticipant::topic_partitions() const noexcept
 {
-    // TODO. danip
     return partition_names;
 }
 
@@ -67,43 +66,48 @@ std::shared_ptr<core::IReader> BlankParticipant::create_reader(
 }
 
 bool BlankParticipant::add_topic_partition(
-        const std::string& topic_name,
+        const std::string& topic_name, const std::string& writer_name,
         const std::string& partition)
 {
-    if (partition_names.find(topic_name) != partition_names.end())
+    if(partition_names.find(topic_name) != partition_names.end())
     {
-        if (partition_names[topic_name].find(partition) != partition_names[topic_name].end())
+        // the topic exists
+        if(partition_names[topic_name].find(writer_name) != partition_names[topic_name].end())
         {
-            // the partition is already in the set
+            // the writer is already added in the topic
             return false;
         }
     }
     else
     {
-        partition_names[topic_name] = std::set<std::string>();
+        // there is no topic in the dictionary
+        partition_names[topic_name] = std::map<std::string, std::string>();
     }
 
-    partition_names[topic_name].insert(partition);
+    // adds [writer, partition] in the topic
+    partition_names[topic_name][writer_name] = partition;
 
     return true;
 }
 
 bool BlankParticipant::delete_topic_partition(
-        const std::string& topic_name,
+        const std::string& topic_name, const std::string& writer_name,
         const std::string& partition)
 {
-    if (partition_names.find(topic_name) == partition_names.end())
+    if(partition_names.find(topic_name) == partition_names.end())
     {
-        // the topic is not in the dictionary
+        // the topic dont exists
         return false;
     }
-    if (partition_names[topic_name].find(partition) == partition_names[topic_name].end())
+    if(partition_names[topic_name].find(writer_name) != partition_names[topic_name].end())
     {
-        // the partition is not in the set
+        // the writer dont exist in the topic
         return false;
     }
 
-    partition_names.erase(partition);
+    // delete [writer, partition] in the topic
+    partition_names.erase(writer_name);
+
     return true;
 }
 

--- a/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/auxiliar/BlankParticipant.cpp
@@ -48,10 +48,10 @@ core::types::TopicQoS BlankParticipant::topic_qos() const noexcept
     return m_topic_qos;
 }
 
-std::vector<std::string> BlankParticipant::topic_partitions() const noexcept
+std::map<std::string, std::set<std::string>> BlankParticipant::topic_partitions() const noexcept
 {
     // TODO. danip
-    return {};
+    return partition_names;
 }
 
 std::shared_ptr<core::IWriter> BlankParticipant::create_writer(
@@ -64,6 +64,52 @@ std::shared_ptr<core::IReader> BlankParticipant::create_reader(
         const core::ITopic& topic)
 {
     return std::make_shared<BlankReader>();
+}
+
+bool BlankParticipant::add_topic_partition(
+        const std::string& topic_name,
+        const std::string& partition)
+{
+    if (partition_names.find(topic_name) != partition_names.end())
+    {
+        if (partition_names[topic_name].find(partition) != partition_names[topic_name].end())
+        {
+            // the partition is already in the set
+            return false;
+        }
+    }
+    else
+    {
+        partition_names[topic_name] = std::set<std::string>();
+    }
+
+    partition_names[topic_name].insert(partition);
+
+    return true;
+}
+
+bool BlankParticipant::delete_topic_partition(
+        const std::string& topic_name,
+        const std::string& partition)
+{
+    if (partition_names.find(topic_name) == partition_names.end())
+    {
+        // the topic is not in the dictionary
+        return false;
+    }
+    if (partition_names[topic_name].find(partition) == partition_names[topic_name].end())
+    {
+        // the partition is not in the set
+        return false;
+    }
+
+    partition_names.erase(partition);
+    return true;
+}
+
+void BlankParticipant::clear_topic_partitions()
+{
+    partition_names.clear();
 }
 
 } /* namespace participants */

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -113,6 +113,12 @@ core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
     return configuration_->topic_qos;
 }
 
+std::vector<std::string> CommonParticipant::topic_partitions() const noexcept
+{
+    // TODO. danip
+    return {};
+}
+
 std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
         const core::ITopic& topic)
 {

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -113,11 +113,9 @@ core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
     return configuration_->topic_qos;
 }
 
-std::map<std::string, std::set<std::string>> CommonParticipant::topic_partitions() const noexcept
+std::map<std::string, std::map<std::string, std::string>> CommonParticipant::topic_partitions() const noexcept
 {
-    // TODO. danip
     return partition_names;
-    //return std::set<std::string>{"2.2"};
 }
 
 std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
@@ -495,43 +493,48 @@ fastdds::dds::Topic* CommonParticipant::topic_related_(
 }
 
 bool CommonParticipant::add_topic_partition(
-        const std::string& topic_name,
+        const std::string& topic_name, const std::string& writer_name,
         const std::string& partition)
 {
-    if (partition_names.find(topic_name) != partition_names.end())
+    if(partition_names.find(topic_name) != partition_names.end())
     {
-        if (partition_names[topic_name].find(partition) != partition_names[topic_name].end())
+        // the topic exists
+        if(partition_names[topic_name].find(writer_name) != partition_names[topic_name].end())
         {
-            // the partition is already in the set
+            // the writer is already added in the topic
             return false;
         }
     }
     else
     {
-        partition_names[topic_name] = std::set<std::string>();
+        // there is no topic in the dictionary
+        partition_names[topic_name] = std::map<std::string, std::string>();
     }
 
-    partition_names[topic_name].insert(partition);
+    // adds [writer, partition] in the topic
+    partition_names[topic_name][writer_name] = partition;
 
     return true;
 }
 
 bool CommonParticipant::delete_topic_partition(
-        const std::string& topic_name,
+        const std::string& topic_name, const std::string& writer_name,
         const std::string& partition)
 {
-    if (partition_names.find(topic_name) == partition_names.end())
+    if(partition_names.find(topic_name) == partition_names.end())
     {
-        // the topic is not in the dictionary
+        // the topic dont exists
         return false;
     }
-    if (partition_names[topic_name].find(partition) == partition_names[topic_name].end())
+    if(partition_names[topic_name].find(writer_name) != partition_names[topic_name].end())
     {
-        // the partition is not in the set
+        // the writer dont exist in the topic
         return false;
     }
 
-    partition_names.erase(partition);
+    // delete [writer, partition] in the topic
+    partition_names.erase(writer_name);
+
     return true;
 }
 

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/DynTypesParticipant.cpp
@@ -79,6 +79,19 @@ std::shared_ptr<IReader> DynTypesParticipant::create_reader(
 DynTypesParticipant::DynTypesRtpsListener::DynTypesRtpsListener(
         std::shared_ptr<ParticipantConfiguration> conf,
         std::shared_ptr<core::DiscoveryDatabase> ddb,
+        std::shared_ptr<InternalReader> internal_reader,
+        CommonParticipant& parent_class)
+    : rtps::CommonParticipant::RtpsListener(
+        conf,
+        ddb,
+        parent_class)
+    , type_object_reader_(internal_reader)
+{
+}
+
+DynTypesParticipant::DynTypesRtpsListener::DynTypesRtpsListener(
+        std::shared_ptr<ParticipantConfiguration> conf,
+        std::shared_ptr<core::DiscoveryDatabase> ddb,
         std::shared_ptr<InternalReader> internal_reader)
     : rtps::CommonParticipant::RtpsListener(
         conf,
@@ -177,9 +190,9 @@ void DynTypesParticipant::DynTypesRtpsListener::notify_type_discovered_(
     type_object_reader_->simulate_data_reception(std::move(data));
 }
 
-std::unique_ptr<fastdds::rtps::RTPSParticipantListener> DynTypesParticipant::create_listener_()
+std::unique_ptr<fastdds::rtps::RTPSParticipantListener> DynTypesParticipant::create_listener_(CommonParticipant& parent_class)
 {
-    return std::make_unique<DynTypesRtpsListener>(configuration_, discovery_database_, type_object_reader_);
+    return std::make_unique<DynTypesRtpsListener>(configuration_, discovery_database_, type_object_reader_, parent_class);
 }
 
 } /* namespace participants */

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
@@ -69,6 +69,12 @@ core::types::TopicQoS SchemaParticipant::topic_qos() const noexcept
     return configuration_->topic_qos;
 }
 
+std::vector<std::string> SchemaParticipant::topic_partitions() const noexcept
+{
+    // TODO. danip
+    return {};
+}
+
 std::shared_ptr<IWriter> SchemaParticipant::create_writer(
         const ITopic& topic)
 {

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
@@ -69,11 +69,9 @@ core::types::TopicQoS SchemaParticipant::topic_qos() const noexcept
     return configuration_->topic_qos;
 }
 
-std::map<std::string, std::set<std::string>> SchemaParticipant::topic_partitions() const noexcept
+std::map<std::string, std::map<std::string, std::string>> SchemaParticipant::topic_partitions() const noexcept
 {
-    // TODO. danip
     return partition_names;
-    //return std::set<std::string>{"1"};
 }
 
 std::shared_ptr<IWriter> SchemaParticipant::create_writer(
@@ -102,43 +100,48 @@ std::shared_ptr<IReader> SchemaParticipant::create_reader(
 }
 
 bool SchemaParticipant::add_topic_partition(
-        const std::string& topic_name,
+        const std::string& topic_name, const std::string& writer_name,
         const std::string& partition)
 {
-    if (partition_names.find(topic_name) != partition_names.end())
+    if(partition_names.find(topic_name) != partition_names.end())
     {
-        if (partition_names[topic_name].find(partition) != partition_names[topic_name].end())
+        // the topic exists
+        if(partition_names[topic_name].find(writer_name) != partition_names[topic_name].end())
         {
-            // the partition is already in the set
+            // the writer is already added in the topic
             return false;
         }
     }
     else
     {
-        partition_names[topic_name] = std::set<std::string>();
+        // there is no topic in the dictionary
+        partition_names[topic_name] = std::map<std::string, std::string>();
     }
 
-    partition_names[topic_name].insert(partition);
+    // adds [writer, partition] in the topic
+    partition_names[topic_name][writer_name] = partition;
 
     return true;
 }
 
 bool SchemaParticipant::delete_topic_partition(
-        const std::string& topic_name,
+        const std::string& topic_name, const std::string& writer_name,
         const std::string& partition)
 {
-    if (partition_names.find(topic_name) == partition_names.end())
+    if(partition_names.find(topic_name) == partition_names.end())
     {
-        // the topic is not in the dictionary
+        // the topic dont exists
         return false;
     }
-    if (partition_names[topic_name].find(partition) == partition_names[topic_name].end())
+    if(partition_names[topic_name].find(writer_name) != partition_names[topic_name].end())
     {
-        // the partition is not in the set
+        // the writer dont exist in the topic
         return false;
     }
 
-    partition_names.erase(partition);
+    // delete [writer, partition] in the topic
+    partition_names.erase(writer_name);
+
     return true;
 }
 

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
@@ -69,10 +69,11 @@ core::types::TopicQoS SchemaParticipant::topic_qos() const noexcept
     return configuration_->topic_qos;
 }
 
-std::vector<std::string> SchemaParticipant::topic_partitions() const noexcept
+std::map<std::string, std::set<std::string>> SchemaParticipant::topic_partitions() const noexcept
 {
     // TODO. danip
-    return {};
+    return partition_names;
+    //return std::set<std::string>{"1"};
 }
 
 std::shared_ptr<IWriter> SchemaParticipant::create_writer(
@@ -98,6 +99,52 @@ std::shared_ptr<IReader> SchemaParticipant::create_reader(
         const ITopic& /* topic */)
 {
     return std::make_shared<BlankReader>();
+}
+
+bool SchemaParticipant::add_topic_partition(
+        const std::string& topic_name,
+        const std::string& partition)
+{
+    if (partition_names.find(topic_name) != partition_names.end())
+    {
+        if (partition_names[topic_name].find(partition) != partition_names[topic_name].end())
+        {
+            // the partition is already in the set
+            return false;
+        }
+    }
+    else
+    {
+        partition_names[topic_name] = std::set<std::string>();
+    }
+
+    partition_names[topic_name].insert(partition);
+
+    return true;
+}
+
+bool SchemaParticipant::delete_topic_partition(
+        const std::string& topic_name,
+        const std::string& partition)
+{
+    if (partition_names.find(topic_name) == partition_names.end())
+    {
+        // the topic is not in the dictionary
+        return false;
+    }
+    if (partition_names[topic_name].find(partition) == partition_names[topic_name].end())
+    {
+        // the partition is not in the set
+        return false;
+    }
+
+    partition_names.erase(partition);
+    return true;
+}
+
+void SchemaParticipant::clear_topic_partitions()
+{
+    partition_names.clear();
 }
 
 } /* namespace participants */

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -326,6 +326,12 @@ core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
     return configuration_->topic_qos;
 }
 
+std::vector<std::string> CommonParticipant::topic_partitions() const noexcept
+{
+    // TODO. danip
+    return {};
+}
+
 void CommonParticipant::create_participant_(
         const core::types::DomainId& domain,
         const fastdds::rtps::RTPSParticipantAttributes& participant_attributes)

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -422,7 +422,17 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
     }
     else if (topic.internal_type_discriminator() == core::types::INTERNAL_TOPIC_TYPE_RTPS)
     {
-        if (dds_topic.topic_qos.has_partitions() || dds_topic.topic_qos.has_ownership())
+        if (dds_topic.partition_name.size() > 0)
+        {
+            // Notice that MultiWriter does not require an init call
+            return std::make_shared<MultiWriter>(
+                this->id(),
+                dds_topic,
+                this->payload_pool_,
+                rtps_participant_,
+                this->configuration_->is_repeater);
+        }
+        else if (dds_topic.topic_qos.has_partitions() || dds_topic.topic_qos.has_ownership())
         {
             // Notice that MultiWriter does not require an init call
             return std::make_shared<MultiWriter>(

--- a/ddspipe_participants/src/cpp/utils/utils.cpp
+++ b/ddspipe_participants/src/cpp/utils/utils.cpp
@@ -59,12 +59,17 @@ core::types::Endpoint create_common_endpoint_from_info_(
     }
     // Set Topic with Partitions
     endpoint.topic.topic_qos.use_partitions.set_value(!info.partition.empty());
-    
-    
-    //std::cout << "Enters\t" << info.partition <<"\n";
-    std::vector<std::string> partition_names = info.partition.getNames();
-    for(int i=0;i<partition_names.size();i++){
-        std::cout << partition_names[i] << " - ";
+
+    // Topic partitions
+    //std::set<std::string> partition_names;
+    std::map<std::string, std::set<std::string>> partition_names;
+    std::vector<std::string> partition_names_vector = info.partition.getNames();
+
+    for(int i = 0; i < partition_names_vector.size(); i++)
+    {
+        //partition_names.insert(partition_names_vector[i]);
+        partition_names[std::string(info.topic_name)].insert(partition_names_vector[i]);
+        std::cout << partition_names_vector[i] << " - ";
     }
     std::cout << "\n";
     endpoint.specific_partitions = partition_names;

--- a/ddspipe_participants/src/cpp/utils/utils.cpp
+++ b/ddspipe_participants/src/cpp/utils/utils.cpp
@@ -59,6 +59,16 @@ core::types::Endpoint create_common_endpoint_from_info_(
     }
     // Set Topic with Partitions
     endpoint.topic.topic_qos.use_partitions.set_value(!info.partition.empty());
+    
+    
+    //std::cout << "Enters\t" << info.partition <<"\n";
+    std::vector<std::string> partition_names = info.partition.getNames();
+    for(int i=0;i<partition_names.size();i++){
+        std::cout << partition_names[i] << " - ";
+    }
+    std::cout << "\n";
+    endpoint.specific_partitions = partition_names;
+
     // Set Topic with ownership
     endpoint.topic.topic_qos.ownership_qos.set_value(info.ownership.kind);
     // Set Topic key

--- a/ddspipe_participants/src/cpp/utils/utils.cpp
+++ b/ddspipe_participants/src/cpp/utils/utils.cpp
@@ -39,6 +39,9 @@ core::types::Endpoint create_common_endpoint_from_info_(
     // Parse GUID
     endpoint.guid = info.guid;
 
+    std::ostringstream guid_ss;
+    guid_ss << endpoint.guid;
+
     // Parse TopicQoS
     // Durability
     endpoint.topic.topic_qos.durability_qos.set_value(info.durability.durabilityKind());
@@ -65,14 +68,33 @@ core::types::Endpoint create_common_endpoint_from_info_(
     std::map<std::string, std::set<std::string>> partition_names;
     std::vector<std::string> partition_names_vector = info.partition.getNames();
 
-    for(int i = 0; i < partition_names_vector.size(); i++)
+    /*for(int i = 0; i < partition_names_vector.size(); i++)
     {
         //partition_names.insert(partition_names_vector[i]);
         partition_names[std::string(info.topic_name)].insert(partition_names_vector[i]);
-        std::cout << partition_names_vector[i] << " - ";
+        std::cout << partition_names_vector[i] << " | ";
     }
-    std::cout << "\n";
-    endpoint.specific_partitions = partition_names;
+    std::cout << "\n";*/
+
+    std::string partitions_set = "";
+    int partitions_n = partition_names_vector.size();
+    if(partitions_n > 0)
+    {
+        partitions_set = partition_names_vector[0];
+
+        for(int i = 1; i < partitions_n; i++)
+        {
+            partitions_set += "|" + partition_names_vector[i];
+            std::cout << partition_names_vector[i] << " | ";
+        }
+        std::cout << "\n";
+        partition_names[std::string(info.topic_name)].insert(partitions_set);
+    }
+
+
+
+    //endpoint.specific_partitions = partition_names;
+    endpoint.specific_partitions[std::string(info.topic_name)][guid_ss.str()] = partitions_set;
 
     // Set Topic with ownership
     endpoint.topic.topic_qos.ownership_qos.set_value(info.ownership.kind);

--- a/ddspipe_participants/src/cpp/writer/rtps/MultiWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/MultiWriter.cpp
@@ -139,7 +139,7 @@ QoSSpecificWriter* MultiWriter::create_writer_nts_(
 }
 
 // Specific enable/disable do not need to be implemented
-utils::ReturnCode MultiWriter::write_nts_(
+utils::ReturnCode MultiWriter::write_nts_( // TODO. HERE
         core::IRoutingData& data) noexcept
 {
     auto& rtps_data = dynamic_cast<core::types::RtpsPayloadData&>(data);
@@ -148,6 +148,11 @@ utils::ReturnCode MultiWriter::write_nts_(
         DDSPIPE_MULTIWRITER,
         "Writing in Partitions Writer " << *this << " a data with qos " << rtps_data.writer_qos << " from " <<
             rtps_data.source_guid);
+
+    for(std::string partition_name: topic_.partition_name)
+    {
+        rtps_data.writer_qos.partitions.push_back(partition_name.c_str());
+    }
 
     // Take Writer
     auto this_qos_writer = get_writer_or_create_(rtps_data.writer_qos);

--- a/ddspipe_participants/src/cpp/writer/rtps/MultiWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/MultiWriter.cpp
@@ -139,7 +139,7 @@ QoSSpecificWriter* MultiWriter::create_writer_nts_(
 }
 
 // Specific enable/disable do not need to be implemented
-utils::ReturnCode MultiWriter::write_nts_( // TODO. HERE
+utils::ReturnCode MultiWriter::write_nts_(
         core::IRoutingData& data) noexcept
 {
     auto& rtps_data = dynamic_cast<core::types::RtpsPayloadData&>(data);
@@ -148,11 +148,6 @@ utils::ReturnCode MultiWriter::write_nts_( // TODO. HERE
         DDSPIPE_MULTIWRITER,
         "Writing in Partitions Writer " << *this << " a data with qos " << rtps_data.writer_qos << " from " <<
             rtps_data.source_guid);
-
-    for(std::string partition_name: topic_.partition_name)
-    {
-        rtps_data.writer_qos.partitions.push_back(partition_name.c_str());
-    }
 
     // Take Writer
     auto this_qos_writer = get_writer_or_create_(rtps_data.writer_qos);

--- a/ddspipe_participants/src/cpp/writer/rtps/QoSSpecificWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/QoSSpecificWriter.cpp
@@ -48,7 +48,7 @@ fastdds::dds::WriterQos QoSSpecificWriter::reckon_writer_qos_(
     fastdds::dds::WriterQos qos = CommonWriter::reckon_writer_qos_(topic);
 
     // Set Partitions
-    if (topic.topic_qos.has_partitions())
+    if (topic.topic_qos.has_partitions() || specific_qos.partitions.names().size() > 0)
     {
         qos.m_partition = specific_qos.partitions;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the following features feature in **DDS-Record-Replay**:
- Store the partitions information in the two formats (.sqlSQL and MCAP).
- Replay the 


<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [ ] Code snippets related to the added documentation have been provided.
- [ ] Documentation tests pass locally.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
