### PR TITLE
Avoid forwarding NOT_ALIVE_NO_W... as DISPOSE in keyless topics

### DIFF
--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -333,11 +333,10 @@ bool CommonReader::should_accept_sample_(
     // remote readers. However, those remote readers will still receive a NOT_ALIVE_NO_WRITERS_INSTANCE_STATE
     // sample when their associated writers' leaseDurationPeriod expires. Thus, we opt to reject samples
     // whose instance state is NOT_ALIVE_NO_WRITERS when they are emitted from a keyless topic.
-    // The same reasoning applied to NOT_ALIVE_DISPOSED_INSTANCE_STATE, because there is no way to forward
-    // that status change at the moment.
+    // The same reasoning applied to any NOT_ALIVE_INSTANCE_STATE, because there is no way to forward
+    // that changes at the moment.
     if (!topic_.topic_qos.keyed &&
-            (info.instance_state == fastdds::dds::InstanceStateKind::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE ||
-            info.instance_state == fastdds::dds::InstanceStateKind::NOT_ALIVE_DISPOSED_INSTANCE_STATE))
+            (info.instance_state & fastdds::dds::NOT_ALIVE_INSTANCE_STATE))
     {
         return false;
     }

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -223,10 +223,8 @@ utils::ReturnCode CommonReader::take_nts_(
 
     EPROSIMA_LOG_INFO(DDSPIPE_DDS_READER, "Taking data in " << participant_id_ << " for topic " << topic_ << ".");
 
-
     std::unique_ptr<RtpsPayloadData> rtps_data;
     fastdds::dds::SampleInfo info;
-
     do
     {
         rtps_data.reset(new RtpsPayloadData());
@@ -325,6 +323,17 @@ bool CommonReader::should_accept_sample_(
     if (detail::come_from_same_participant_(
                 detail::guid_from_instance_handle(info.publication_handle),
                 this->dds_participant_->guid()))
+    {
+        return false;
+    }
+
+    // At the time of this writing, the DDS API does not allow to send DISPOSE or UNREGISTER messages
+    // in keyless topics, and there is no way to request a state transition on the instances in the
+    // remote readers. However, those remote readers will still receive a NOT_ALIVE_NO_WRITERS_INSTANCE_STATE
+    // sample when their associated writers' leaseDurationPeriod expires. Thus, we opt to reject samples
+    // whose instance state is NOT_ALIVE_NO_WRITERS when they are emitted from a keyless topic.
+    if (!topic_.topic_qos.keyed &&
+        info.instance_state == fastdds::dds::InstanceStateKind::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
     {
         return false;
     }

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -225,6 +225,7 @@ utils::ReturnCode CommonReader::take_nts_(
 
     std::unique_ptr<RtpsPayloadData> rtps_data;
     fastdds::dds::SampleInfo info;
+
     do
     {
         rtps_data.reset(new RtpsPayloadData());
@@ -328,12 +329,15 @@ bool CommonReader::should_accept_sample_(
     }
 
     // At the time of this writing, the DDS API does not allow to send DISPOSE or UNREGISTER messages
-    // in keyless topics, and there is no way to request a state transition on the instances in the
+    // in keyless topics, and there is no way to request a state transition on the instances living in the
     // remote readers. However, those remote readers will still receive a NOT_ALIVE_NO_WRITERS_INSTANCE_STATE
     // sample when their associated writers' leaseDurationPeriod expires. Thus, we opt to reject samples
     // whose instance state is NOT_ALIVE_NO_WRITERS when they are emitted from a keyless topic.
+    // The same reasoning applied to NOT_ALIVE_DISPOSED_INSTANCE_STATE, because there is no way to forward
+    // that status change at the moment.
     if (!topic_.topic_qos.keyed &&
-        info.instance_state == fastdds::dds::InstanceStateKind::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE)
+            (info.instance_state == fastdds::dds::InstanceStateKind::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE ||
+            info.instance_state == fastdds::dds::InstanceStateKind::NOT_ALIVE_DISPOSED_INSTANCE_STATE))
     {
         return false;
     }


### PR DESCRIPTION
This pull request ensures that samples with a NOT_ALIVE_NO_WRITERS instance state are rejected for keyless topics, aligning the behavior with DDS API limitations and preventing unintended state transitions. 