### PR TITLE
[24451] Add Topic-Name Profile Lookup for Endpoint Creation

### DIFF
--- a/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/dds/TopicQoS.hpp
@@ -144,6 +144,9 @@ TopicQoS
     //! Downsampling factor: keep 1 out of every *downsampling* samples received (downsampling=1 <=> no downsampling)
     utils::Fuzzy<unsigned int> downsampling;
 
+    //! XML profile name to use for endpoint QoS lookup
+    utils::Fuzzy<std::string> endpoint_profile_name;
+
     /////////////////////////
     // GLOBAL VARIABLES
     /////////////////////////

--- a/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
+++ b/ddspipe_core/include/ddspipe_core/types/topic/dds/DdsTopic.hpp
@@ -90,6 +90,9 @@ struct DdsTopic : public DistributedTopic
 
     //! Type Identifiers: first one is complete and second one minimal
     fastdds::dds::xtypes::TypeIdentifierPair type_identifiers;
+
+    //! The Topic QoS explicitly configured by the user
+    types::TopicQoS user_configured_qos{};
 };
 
 } /* namespace types */

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -16,6 +16,7 @@
 #include <cpp_utils/Log.hpp>
 
 #include <ddspipe_core/communication/dds/DdsBridge.hpp>
+#include <ddspipe_core/types/topic/dds/DdsTopic.hpp>
 
 #include <cpp_utils/utils.hpp>
 
@@ -316,6 +317,10 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
     // A Topic QoS set with fuzzy_level_hard (the highest FuzzyLevel) cannot be overwritten.
     // Thus, the order matters. In this case, manual_topics[0] > manual_topics[1] > participant.
 
+    // If this is a DDS Topic, also track the QoS that come exclusively from user configuration,
+    // as opposed to topic_qos which also absorbs QoS observed via RTPS discovery of remote endpoints.
+    bool is_dds_topic = topic.can_cast<types::DdsTopic>();
+
     // 1. Manually Configured Topic QoS.
     for (const auto& manual_topic : manual_topics_)
     {
@@ -324,11 +329,23 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
         if (participant_ids.empty() || participant_ids.count(participant->id()))
         {
             topic->topic_qos.set_qos(manual_topic.first->topic_qos, utils::FuzzyLevelValues::fuzzy_level_hard);
+
+            if (is_dds_topic)
+            {
+                topic.dyn_cast<types::DdsTopic>().user_configured_qos.set_qos(
+                    manual_topic.first->topic_qos, utils::FuzzyLevelValues::fuzzy_level_hard);
+            }
         }
     }
 
     // 2. Participant Topic QoS.
     topic->topic_qos.set_qos(participant->topic_qos(), utils::FuzzyLevelValues::fuzzy_level_hard);
+
+    if (is_dds_topic)
+    {
+        topic.dyn_cast<types::DdsTopic>().user_configured_qos.set_qos(
+            participant->topic_qos(), utils::FuzzyLevelValues::fuzzy_level_hard);
+    }
 
     // 3. Partitions Topic
     if (topic->partition_name.size() == 0)

--- a/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/dds/DdsBridge.cpp
@@ -317,7 +317,7 @@ utils::Heritable<DistributedTopic> DdsBridge::create_topic_for_participant_nts_(
     // A Topic QoS set with fuzzy_level_hard (the highest FuzzyLevel) cannot be overwritten.
     // Thus, the order matters. In this case, manual_topics[0] > manual_topics[1] > participant.
 
-    // If this is a DDS Topic, also track the QoS that come exclusively from user configuration,
+    // If this is a DDS Topic, also track the QoS that comes exclusively from user configuration,
     // as opposed to topic_qos which also absorbs QoS observed via RTPS discovery of remote endpoints.
     bool is_dds_topic = topic.can_cast<types::DdsTopic>();
 

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -265,6 +265,8 @@ std::ostream& operator <<(
        << ";max_tx_rate(" << qos.max_tx_rate << ")"
        << ";max_rx_rate(" << qos.max_rx_rate << ")"
        << ";downsampling(" << qos.downsampling << ")"
+       << (qos.endpoint_profile_name.is_set() ? ";endpoint_profile_name(" + qos.endpoint_profile_name.get_value() +
+    ")" : "")
        << "}";
 
     return os;

--- a/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
+++ b/ddspipe_core/src/cpp/types/dds/TopicQoS.cpp
@@ -61,7 +61,8 @@ bool TopicQoS::operator ==(
         this->keyed == other.keyed &&
         this->max_tx_rate == other.max_tx_rate &&
         this->max_rx_rate == other.max_rx_rate &&
-        this->downsampling == other.downsampling;
+        this->downsampling == other.downsampling &&
+        this->endpoint_profile_name == other.endpoint_profile_name;
 }
 
 bool TopicQoS::is_reliable() const noexcept
@@ -131,6 +132,11 @@ void TopicQoS::set_qos(
     if (downsampling.get_level() < fuzzy_level && qos.downsampling.is_set())
     {
         downsampling.set_value(qos.downsampling.get_value(), fuzzy_level);
+    }
+
+    if (endpoint_profile_name.get_level() < fuzzy_level && qos.endpoint_profile_name.is_set())
+    {
+        endpoint_profile_name.set_value(qos.endpoint_profile_name.get_value(), fuzzy_level);
     }
 }
 

--- a/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
+++ b/ddspipe_core/src/cpp/types/topic/dds/DdsTopic.cpp
@@ -56,8 +56,8 @@ std::string DdsTopic::topic_unique_name() const noexcept
 std::string DdsTopic::serialize() const noexcept
 {
     std::stringstream ss;
-    ss << "Topic{" << m_topic_name << ";" << type_name << ";" << topic_qos << "(" << m_internal_type_discriminator <<
-        ")}";
+    ss << "Topic{" << m_topic_name << ";" << type_name << ";" << topic_qos << "(" << m_internal_type_discriminator
+       << ")}";
     return ss.str();
 }
 
@@ -122,6 +122,7 @@ DdsTopic& DdsTopic::operator = (
 
     this->type_name = other.type_name;
     this->type_identifiers = other.type_identifiers;
+    this->user_configured_qos = other.user_configured_qos;
 
     return *this;
 }

--- a/ddspipe_participants/include/ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp
@@ -63,6 +63,9 @@ public:
     types::IpType easy_mode_ip {};
 
     core::types::IgnoreParticipantFlags ignore_participant_flags {core::types::IgnoreParticipantFlags::no_filter};
+
+    // XML override
+    bool xml_override {false};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp
@@ -63,9 +63,6 @@ public:
     types::IpType easy_mode_ip {};
 
     core::types::IgnoreParticipantFlags ignore_participant_flags {core::types::IgnoreParticipantFlags::no_filter};
-
-    // XML override
-    bool xml_override {false};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/configuration/XmlParticipantConfiguration.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/configuration/XmlParticipantConfiguration.hpp
@@ -23,6 +23,12 @@ namespace eprosima {
 namespace ddspipe {
 namespace participants {
 
+enum class EndpointQoSMode
+{
+    XML_STANDALONE,    //! XML profile is selected
+    XML_OVERRIDABLE,   //! YAML QoS overrides XML
+};
+
 /**
  * This data struct represents a configuration for a Participant loaded from an XML profile.
  */
@@ -49,6 +55,8 @@ public:
     /////////////////////////
 
     utils::Fuzzy<std::string> participant_profile {};
+
+    EndpointQoSMode endpoint_qos_mode {EndpointQoSMode::XML_OVERRIDABLE};
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -251,6 +251,12 @@ protected:
     /////////////////////////
 
     DDSPIPE_PARTICIPANTS_DllAPI
+    virtual bool endpoint_qos_mode_() const noexcept
+    {
+        return false;
+    }
+
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual
     fastdds::dds::DomainParticipantQos
     reckon_participant_qos_() const;

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -256,6 +256,13 @@ protected:
         return false;
     }
 
+    //! Whether XML endpoint profile lookup is enabled. Disabled by default for plain (non-XML) participants.
+    DDSPIPE_PARTICIPANTS_DllAPI
+    virtual bool xml_lookup_enabled_() const noexcept
+    {
+        return false;
+    }
+
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual
     fastdds::dds::DomainParticipantQos

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -250,6 +250,7 @@ protected:
     // INTERNAL VIRTUAL METHODS
     /////////////////////////
 
+    //! Whether the user's (YAML) QoS overrides the QoS from a matching XML endpoint profile
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual bool endpoint_qos_mode_() const noexcept
     {

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/XmlParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/XmlParticipant.hpp
@@ -64,6 +64,9 @@ protected:
     virtual bool endpoint_qos_mode_() const noexcept override;
 
     DDSPIPE_PARTICIPANTS_DllAPI
+    virtual bool xml_lookup_enabled_() const noexcept override;
+
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual
     fastdds::dds::DomainParticipantQos
     reckon_participant_qos_() const override;

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/XmlParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/XmlParticipant.hpp
@@ -60,6 +60,7 @@ protected:
     // INTERNAL METHODS
     /////////////////////////
 
+    //! Whether the user's (YAML) QoS overrides the QoS from a matching XML endpoint profile
     DDSPIPE_PARTICIPANTS_DllAPI
     virtual bool endpoint_qos_mode_() const noexcept override;
 

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/XmlParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/XmlParticipant.hpp
@@ -61,6 +61,9 @@ protected:
     /////////////////////////
 
     DDSPIPE_PARTICIPANTS_DllAPI
+    virtual bool endpoint_qos_mode_() const noexcept override;
+
+    DDSPIPE_PARTICIPANTS_DllAPI
     virtual
     fastdds::dds::DomainParticipantQos
     reckon_participant_qos_() const override;

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -121,7 +121,7 @@ protected:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool xml_override = false);
+            const bool yaml_qos_override = true);
 
     // Specific enable/disable do not need to be implemented
 
@@ -162,7 +162,7 @@ protected:
     virtual
     fastdds::dds::DataReaderQos
     reckon_reader_qos_(
-            const std::string& topic_name) const;
+            const std::string& profile_name) const;
 
     //! Whether a sample received should be processed
     virtual bool should_accept_sample_(
@@ -179,7 +179,7 @@ protected:
 
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
-    bool xml_override_;
+    bool yaml_qos_override_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -160,7 +160,8 @@ protected:
 
     virtual
     fastdds::dds::DataReaderQos
-    reckon_reader_qos_() const;
+    reckon_reader_qos_(
+            const std::string& topic_name) const;
 
     //! Whether a sample received should be processed
     virtual bool should_accept_sample_(

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -121,7 +121,8 @@ protected:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool yaml_qos_override = true);
+            const bool yaml_qos_override = true,
+            const bool xml_lookup_enabled = false);
 
     // Specific enable/disable do not need to be implemented
 
@@ -179,6 +180,7 @@ protected:
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
     bool yaml_qos_override_;
+    bool xml_lookup_enabled_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -120,7 +120,8 @@ protected:
             const core::types::DdsTopic& topic,
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
-            fastdds::dds::Topic* topic_entity);
+            fastdds::dds::Topic* topic_entity,
+            const bool xml_override = false);
 
     // Specific enable/disable do not need to be implemented
 
@@ -178,6 +179,7 @@ protected:
 
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
+    bool xml_override_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/CommonReader.hpp
@@ -161,8 +161,7 @@ protected:
 
     virtual
     fastdds::dds::DataReaderQos
-    reckon_reader_qos_(
-            const std::string& profile_name) const;
+    reckon_reader_qos_() const;
 
     //! Whether a sample received should be processed
     virtual bool should_accept_sample_(

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/SimpleReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/SimpleReader.hpp
@@ -49,7 +49,7 @@ public:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool xml_override = false);
+            const bool yaml_qos_override = true);
 };
 
 } /* namespace dds */

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/SimpleReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/SimpleReader.hpp
@@ -49,7 +49,8 @@ public:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool yaml_qos_override = true);
+            const bool yaml_qos_override = true,
+            const bool xml_lookup_enabled = false);
 };
 
 } /* namespace dds */

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/SimpleReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/SimpleReader.hpp
@@ -48,7 +48,8 @@ public:
             const core::types::DdsTopic& topic,
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
-            fastdds::dds::Topic* topic_entity);
+            fastdds::dds::Topic* topic_entity,
+            const bool xml_override = false);
 };
 
 } /* namespace dds */

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/SpecificQoSReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/SpecificQoSReader.hpp
@@ -55,7 +55,8 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const std::shared_ptr<core::DiscoveryDatabase>& discovery_database,
-            const bool yaml_qos_override = true);
+            const bool yaml_qos_override = true,
+            const bool xml_lookup_enabled = false);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/SpecificQoSReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/SpecificQoSReader.hpp
@@ -54,7 +54,8 @@ public:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const std::shared_ptr<core::DiscoveryDatabase>& discovery_database);
+            const std::shared_ptr<core::DiscoveryDatabase>& discovery_database,
+            const bool xml_override = false);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/reader/dds/SpecificQoSReader.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/reader/dds/SpecificQoSReader.hpp
@@ -55,7 +55,7 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const std::shared_ptr<core::DiscoveryDatabase>& discovery_database,
-            const bool xml_override = false);
+            const bool yaml_qos_override = true);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
@@ -104,7 +104,8 @@ protected:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater,
-            const bool yaml_qos_override = true);
+            const bool yaml_qos_override = true,
+            const bool xml_lookup_enabled = false);
 
     /////////////////////////
     // IWRITER METHODS
@@ -184,6 +185,7 @@ protected:
     fastdds::dds::Topic* dds_topic_;
     bool repeater_;
     bool yaml_qos_override_;
+    bool xml_lookup_enabled_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
@@ -152,7 +152,8 @@ protected:
      * @return The DataWriter QoS to be used for this writer.
      */
     DDSPIPE_PARTICIPANTS_DllAPI
-    virtual fastdds::dds::DataWriterQos reckon_writer_qos_() const noexcept;
+    virtual fastdds::dds::DataWriterQos reckon_writer_qos_(
+            const std::string& topic_name) const noexcept;
 
     /**
      * @brief Auxiliary method used in \c write to fill the sample to send and write params.

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
@@ -104,7 +104,7 @@ protected:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater,
-            const bool xml_override = false);
+            const bool yaml_qos_override = true);
 
     /////////////////////////
     // IWRITER METHODS
@@ -184,7 +184,7 @@ protected:
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
     bool repeater_;
-    bool xml_override_;
+    bool yaml_qos_override_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
@@ -153,8 +153,7 @@ protected:
      * @return The DataWriter QoS to be used for this writer.
      */
     DDSPIPE_PARTICIPANTS_DllAPI
-    virtual fastdds::dds::DataWriterQos reckon_writer_qos_(
-            const std::string& topic_name) const noexcept;
+    virtual fastdds::dds::DataWriterQos reckon_writer_qos_() const noexcept;
 
     /**
      * @brief Auxiliary method used in \c write to fill the sample to send and write params.

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/CommonWriter.hpp
@@ -103,7 +103,8 @@ protected:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool repeater);
+            const bool repeater,
+            const bool xml_override = false);
 
     /////////////////////////
     // IWRITER METHODS
@@ -183,6 +184,7 @@ protected:
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
     bool repeater_;
+    bool xml_override_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
@@ -59,7 +59,8 @@ public:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool repeater = false);
+            const bool repeater = false,
+            const bool xml_override = false);
 
     /**
      * @brief Destroy the MultiWriter object
@@ -110,6 +111,7 @@ protected:
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
     bool repeater_;
+    bool xml_override_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
@@ -60,7 +60,7 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater = false,
-            const bool xml_override = false);
+            const bool yaml_qos_override = true);
 
     /**
      * @brief Destroy the MultiWriter object
@@ -111,7 +111,7 @@ protected:
     fastdds::dds::DomainParticipant* dds_participant_;
     fastdds::dds::Topic* dds_topic_;
     bool repeater_;
-    bool xml_override_;
+    bool yaml_qos_override_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/MultiWriter.hpp
@@ -60,7 +60,8 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater = false,
-            const bool yaml_qos_override = true);
+            const bool yaml_qos_override = true,
+            const bool xml_lookup_enabled = false);
 
     /**
      * @brief Destroy the MultiWriter object
@@ -112,6 +113,7 @@ protected:
     fastdds::dds::Topic* dds_topic_;
     bool repeater_;
     bool yaml_qos_override_;
+    bool xml_lookup_enabled_;
 
     /////////////////////////
     // INTERNAL VARIABLES

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
@@ -55,7 +55,7 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater = false,
-            const bool xml_override = false);
+            const bool yaml_qos_override = true);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
@@ -54,7 +54,8 @@ public:
             const core::types::SpecificEndpointQoS& specific_qos,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool repeater = false);
+            const bool repeater = false,
+            const bool xml_override = false);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
@@ -55,7 +55,8 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater = false,
-            const bool yaml_qos_override = true);
+            const bool yaml_qos_override = true,
+            const bool xml_lookup_enabled = false);
 
 protected:
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
@@ -65,7 +65,8 @@ protected:
     //! Specific writer QoS to override (more or less) the CommonWriter qos
     virtual
     fastdds::dds::DataWriterQos
-    reckon_writer_qos_() const noexcept override;
+    reckon_writer_qos_(
+            const std::string& topic_name) const noexcept override;
 
     //! Specific QoS of the Endpoint
     core::types::SpecificEndpointQoS specific_qos_;

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/QoSSpecificWriter.hpp
@@ -66,8 +66,7 @@ protected:
     //! Specific writer QoS to override (more or less) the CommonWriter qos
     virtual
     fastdds::dds::DataWriterQos
-    reckon_writer_qos_(
-            const std::string& topic_name) const noexcept override;
+    reckon_writer_qos_() const noexcept override;
 
     //! Specific QoS of the Endpoint
     core::types::SpecificEndpointQoS specific_qos_;

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
@@ -55,7 +55,7 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater = false,
-            const bool xml_override = false);
+            const bool yaml_qos_override = true);
 
 };
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
@@ -55,7 +55,8 @@ public:
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
             const bool repeater = false,
-            const bool yaml_qos_override = true);
+            const bool yaml_qos_override = true,
+            const bool xml_lookup_enabled = false);
 
 };
 

--- a/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/dds/SimpleWriter.hpp
@@ -54,7 +54,8 @@ public:
             const std::shared_ptr<core::PayloadPool>& payload_pool,
             fastdds::dds::DomainParticipant* participant,
             fastdds::dds::Topic* topic_entity,
-            const bool repeater = false);
+            const bool repeater = false,
+            const bool xml_override = false);
 
 };
 

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -160,7 +160,8 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             this->payload_pool_,
             dds_participant_,
             fastdds_topic,
-            configuration_->is_repeater);
+            configuration_->is_repeater,
+            configuration_->xml_override);
     }
     else
     {
@@ -170,7 +171,8 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             this->payload_pool_,
             dds_participant_,
             fastdds_topic,
-            configuration_->is_repeater);
+            configuration_->is_repeater,
+            configuration_->xml_override);
         writer->init(partition_filter_set_);
 
         return writer;
@@ -217,7 +219,8 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
             this->payload_pool_,
             dds_participant_,
             fastdds_topic,
-            discovery_database_);
+            discovery_database_,
+            configuration_->xml_override);
         // Add the filters data structures
         // if these filters are empty, the filters are not applied.
         reader->init(partition_filter_set_, content_topic_filter_expr);
@@ -231,7 +234,8 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
             dds_topic,
             this->payload_pool_,
             dds_participant_,
-            fastdds_topic);
+            fastdds_topic,
+            configuration_->xml_override);
         // Add the filters data structures
         // if these filters are empty, the filters are not applied.
         reader->init(partition_filter_set_, content_topic_filter_expr);

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -161,7 +161,7 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             dds_participant_,
             fastdds_topic,
             configuration_->is_repeater,
-            configuration_->xml_override);
+            endpoint_qos_mode_());
     }
     else
     {
@@ -172,7 +172,7 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             dds_participant_,
             fastdds_topic,
             configuration_->is_repeater,
-            configuration_->xml_override);
+            endpoint_qos_mode_());
         writer->init(partition_filter_set_);
 
         return writer;
@@ -220,7 +220,7 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
             dds_participant_,
             fastdds_topic,
             discovery_database_,
-            configuration_->xml_override);
+            endpoint_qos_mode_());
         // Add the filters data structures
         // if these filters are empty, the filters are not applied.
         reader->init(partition_filter_set_, content_topic_filter_expr);
@@ -235,7 +235,7 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
             this->payload_pool_,
             dds_participant_,
             fastdds_topic,
-            configuration_->xml_override);
+            endpoint_qos_mode_());
         // Add the filters data structures
         // if these filters are empty, the filters are not applied.
         reader->init(partition_filter_set_, content_topic_filter_expr);

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -161,7 +161,8 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             dds_participant_,
             fastdds_topic,
             configuration_->is_repeater,
-            endpoint_qos_mode_());
+            endpoint_qos_mode_(),
+            xml_lookup_enabled_());
     }
     else
     {
@@ -172,7 +173,8 @@ std::shared_ptr<core::IWriter> CommonParticipant::create_writer(
             dds_participant_,
             fastdds_topic,
             configuration_->is_repeater,
-            endpoint_qos_mode_());
+            endpoint_qos_mode_(),
+            xml_lookup_enabled_());
         writer->init(partition_filter_set_);
 
         return writer;
@@ -220,7 +222,8 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
             dds_participant_,
             fastdds_topic,
             discovery_database_,
-            endpoint_qos_mode_());
+            endpoint_qos_mode_(),
+            xml_lookup_enabled_());
         // Add the filters data structures
         // if these filters are empty, the filters are not applied.
         reader->init(partition_filter_set_, content_topic_filter_expr);
@@ -235,7 +238,8 @@ std::shared_ptr<core::IReader> CommonParticipant::create_reader(
             this->payload_pool_,
             dds_participant_,
             fastdds_topic,
-            endpoint_qos_mode_());
+            endpoint_qos_mode_(),
+            xml_lookup_enabled_());
         // Add the filters data structures
         // if these filters are empty, the filters are not applied.
         reader->init(partition_filter_set_, content_topic_filter_expr);

--- a/ddspipe_participants/src/cpp/participant/dds/XmlParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/XmlParticipant.cpp
@@ -87,6 +87,11 @@ std::shared_ptr<core::IReader> XmlParticipant::create_reader(
     }
 }
 
+bool XmlParticipant::endpoint_qos_mode_() const noexcept
+{
+    return xml_specific_configuration_.endpoint_qos_mode == EndpointQoSMode::XML_OVERRIDABLE;
+}
+
 fastdds::dds::DomainParticipantQos XmlParticipant::reckon_participant_qos_() const
 {
     fastdds::dds::DomainParticipantQos qos = CommonParticipant::reckon_participant_qos_();

--- a/ddspipe_participants/src/cpp/participant/dds/XmlParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/XmlParticipant.cpp
@@ -92,6 +92,11 @@ bool XmlParticipant::endpoint_qos_mode_() const noexcept
     return xml_specific_configuration_.endpoint_qos_mode == EndpointQoSMode::XML_OVERRIDABLE;
 }
 
+bool XmlParticipant::xml_lookup_enabled_() const noexcept
+{
+    return true;
+}
+
 fastdds::dds::DomainParticipantQos XmlParticipant::reckon_participant_qos_() const
 {
     fastdds::dds::DomainParticipantQos qos = CommonParticipant::reckon_participant_qos_();

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -320,40 +320,43 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
     }
     else if (yaml_qos_override_)
     {
-        if (topic_.topic_qos.durability_qos.is_set())
+        // Only override the XML profile with fields explicitly set by the user (YAML)
+        const auto& user_qos = topic_.user_configured_qos;
+
+        if (user_qos.durability_qos.is_set())
         {
             qos.durability().kind =
-                    (topic_.topic_qos.is_transient_local())
+                    (user_qos.is_transient_local())
                     ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
                     : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
         }
 
-        if (topic_.topic_qos.reliability_qos.is_set())
+        if (user_qos.reliability_qos.is_set())
         {
             qos.reliability().kind =
-                    (topic_.topic_qos.is_reliable())
+                    (user_qos.is_reliable())
                     ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
                     : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
         }
 
-        if (topic_.topic_qos.ownership_qos.is_set())
+        if (user_qos.ownership_qos.is_set())
         {
             qos.ownership().kind =
-                    (topic_.topic_qos.has_ownership())
+                    (user_qos.has_ownership())
                     ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
                     : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
         }
 
-        if (topic_.topic_qos.history_depth.is_set())
+        if (user_qos.history_depth.is_set())
         {
-            if (topic_.topic_qos.history_depth == 0U)
+            if (user_qos.history_depth == 0U)
             {
                 qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
             }
             else
             {
                 qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
-                qos.history().depth = topic_.topic_qos.history_depth;
+                qos.history().depth = user_qos.history_depth;
             }
         }
     }

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -121,7 +121,7 @@ void CommonReader::init(
     // It is safe to do so here as object is already created and callbacks do not require anything set in this method
     reader_ = dds_subscriber_->create_datareader(
         filtered_topic_, // Using new filtered topic
-        reckon_reader_qos_(),
+        reckon_reader_qos_(topic_.topic_name()),
         this,
         eprosima::fastdds::dds::StatusMask::all(),
         payload_pool_);
@@ -274,9 +274,16 @@ fastdds::dds::SubscriberQos CommonReader::reckon_subscriber_qos_() const
     return qos;
 }
 
-fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
+fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_(
+        const std::string& topic_name) const
 {
-    fastdds::dds::DataReaderQos qos = dds_subscriber_->get_default_datareader_qos();
+    fastdds::dds::DataReaderQos qos;
+    fastdds::dds::ReturnCode_t ret_xml_qos = dds_subscriber_->get_datareader_qos_from_profile(topic_name, qos);
+
+    if (ret_xml_qos != fastdds::dds::RETCODE_OK)
+    {
+        qos = dds_subscriber_->get_default_datareader_qos();
+    }
 
     // IMPORTANT
     // As we do not have access to TypeSupport, we do not know the size of the key

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -278,11 +278,36 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_(
         const std::string& topic_name) const
 {
     fastdds::dds::DataReaderQos qos;
-    fastdds::dds::ReturnCode_t ret_xml_qos = dds_subscriber_->get_datareader_qos_from_profile(topic_name, qos);
 
-    if (ret_xml_qos != fastdds::dds::RETCODE_OK)
+    // Don't override XML with YAML Qos
+    if (fastdds::dds::RETCODE_OK != dds_subscriber_->get_datareader_qos_from_profile(topic_name, qos))
     {
         qos = dds_subscriber_->get_default_datareader_qos();
+
+        qos.durability().kind =
+                (topic_.topic_qos.is_transient_local())
+                ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
+                : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
+
+        qos.reliability().kind =
+                (topic_.topic_qos.is_reliable())
+                ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
+                : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
+
+        qos.ownership().kind =
+                (topic_.topic_qos.has_ownership())
+                ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
+                : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+
+        if (topic_.topic_qos.history_depth == 0U)
+        {
+            qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
+        }
+        else
+        {
+            qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
+            qos.history().depth = topic_.topic_qos.history_depth;
+        }
     }
 
     // IMPORTANT
@@ -294,31 +319,6 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_(
     if (topic_.topic_qos.keyed)
     {
         qos.expects_inline_qos(true);
-    }
-
-    qos.durability().kind =
-            (topic_.topic_qos.is_transient_local())
-            ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
-            : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
-
-    qos.reliability().kind =
-            (topic_.topic_qos.is_reliable())
-            ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
-            : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
-
-    qos.ownership().kind =
-            (topic_.topic_qos.has_ownership())
-            ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
-            : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
-
-    if (topic_.topic_qos.history_depth == 0U)
-    {
-        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
-    }
-    else
-    {
-        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
-        qos.history().depth = topic_.topic_qos.history_depth;
     }
 
     return qos;

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -204,11 +204,13 @@ CommonReader::CommonReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool yaml_qos_override /* = true */)
+        const bool yaml_qos_override /* = true */,
+        const bool xml_lookup_enabled /* = false */)
     : BaseReader(participant_id, topic.topic_qos.max_rx_rate, topic.topic_qos.downsampling)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , yaml_qos_override_(yaml_qos_override)
+    , xml_lookup_enabled_(xml_lookup_enabled)
     , payload_pool_(payload_pool)
     , topic_(topic)
     , dds_subscriber_(nullptr)
@@ -284,7 +286,7 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
             ? topic_.topic_qos.endpoint_profile_name.get_value()
             : topic_.topic_name();
 
-    bool xml_profile_found =
+    bool xml_profile_found = xml_lookup_enabled_ &&
             (fastdds::dds::RETCODE_OK == dds_subscriber_->get_datareader_qos_from_profile(profile_key, qos));
 
     if (!xml_profile_found)

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -203,10 +203,12 @@ CommonReader::CommonReader(
         const DdsTopic& topic,
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
-        fastdds::dds::Topic* topic_entity)
+        fastdds::dds::Topic* topic_entity,
+        const bool xml_override /* = false */)
     : BaseReader(participant_id, topic.topic_qos.max_rx_rate, topic.topic_qos.downsampling)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
+    , xml_override_(xml_override)
     , payload_pool_(payload_pool)
     , topic_(topic)
     , dds_subscriber_(nullptr)
@@ -279,10 +281,15 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_(
 {
     fastdds::dds::DataReaderQos qos;
 
-    // Don't override XML with YAML Qos
-    if (fastdds::dds::RETCODE_OK != dds_subscriber_->get_datareader_qos_from_profile(topic_name, qos))
+    bool xml_profile_found =
+            (fastdds::dds::RETCODE_OK == dds_subscriber_->get_datareader_qos_from_profile(topic_name, qos));
+
+    if (!xml_profile_found || xml_override_)
     {
-        qos = dds_subscriber_->get_default_datareader_qos();
+        if (!xml_profile_found)
+        {
+            qos = dds_subscriber_->get_default_datareader_qos();
+        }
 
         qos.durability().kind =
                 (topic_.topic_qos.is_transient_local())

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -204,11 +204,11 @@ CommonReader::CommonReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool xml_override /* = false */)
+        const bool yaml_qos_override /* = true */)
     : BaseReader(participant_id, topic.topic_qos.max_rx_rate, topic.topic_qos.downsampling)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
-    , xml_override_(xml_override)
+    , yaml_qos_override_(yaml_qos_override)
     , payload_pool_(payload_pool)
     , topic_(topic)
     , dds_subscriber_(nullptr)
@@ -284,7 +284,7 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_(
     bool xml_profile_found =
             (fastdds::dds::RETCODE_OK == dds_subscriber_->get_datareader_qos_from_profile(topic_name, qos));
 
-    if (!xml_profile_found || xml_override_)
+    if (!xml_profile_found || yaml_qos_override_)
     {
         if (!xml_profile_found)
         {

--- a/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/CommonReader.cpp
@@ -121,7 +121,7 @@ void CommonReader::init(
     // It is safe to do so here as object is already created and callbacks do not require anything set in this method
     reader_ = dds_subscriber_->create_datareader(
         filtered_topic_, // Using new filtered topic
-        reckon_reader_qos_(topic_.topic_name()),
+        reckon_reader_qos_(),
         this,
         eprosima::fastdds::dds::StatusMask::all(),
         payload_pool_);
@@ -276,20 +276,20 @@ fastdds::dds::SubscriberQos CommonReader::reckon_subscriber_qos_() const
     return qos;
 }
 
-fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_(
-        const std::string& topic_name) const
+fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_() const
 {
     fastdds::dds::DataReaderQos qos;
 
-    bool xml_profile_found =
-            (fastdds::dds::RETCODE_OK == dds_subscriber_->get_datareader_qos_from_profile(topic_name, qos));
+    const std::string& profile_key = topic_.topic_qos.endpoint_profile_name.is_set()
+            ? topic_.topic_qos.endpoint_profile_name.get_value()
+            : topic_.topic_name();
 
-    if (!xml_profile_found || yaml_qos_override_)
+    bool xml_profile_found =
+            (fastdds::dds::RETCODE_OK == dds_subscriber_->get_datareader_qos_from_profile(profile_key, qos));
+
+    if (!xml_profile_found)
     {
-        if (!xml_profile_found)
-        {
-            qos = dds_subscriber_->get_default_datareader_qos();
-        }
+        qos = dds_subscriber_->get_default_datareader_qos();
 
         qos.durability().kind =
                 (topic_.topic_qos.is_transient_local())
@@ -314,6 +314,45 @@ fastdds::dds::DataReaderQos CommonReader::reckon_reader_qos_(
         {
             qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
             qos.history().depth = topic_.topic_qos.history_depth;
+        }
+    }
+    else if (yaml_qos_override_)
+    {
+        if (topic_.topic_qos.durability_qos.is_set())
+        {
+            qos.durability().kind =
+                    (topic_.topic_qos.is_transient_local())
+                    ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
+                    : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
+        }
+
+        if (topic_.topic_qos.reliability_qos.is_set())
+        {
+            qos.reliability().kind =
+                    (topic_.topic_qos.is_reliable())
+                    ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
+                    : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
+        }
+
+        if (topic_.topic_qos.ownership_qos.is_set())
+        {
+            qos.ownership().kind =
+                    (topic_.topic_qos.has_ownership())
+                    ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
+                    : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+        }
+
+        if (topic_.topic_qos.history_depth.is_set())
+        {
+            if (topic_.topic_qos.history_depth == 0U)
+            {
+                qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
+            }
+            else
+            {
+                qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
+                qos.history().depth = topic_.topic_qos.history_depth;
+            }
         }
     }
 

--- a/ddspipe_participants/src/cpp/reader/dds/SimpleReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/SimpleReader.cpp
@@ -30,9 +30,9 @@ SimpleReader::SimpleReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool xml_override /* = false */)
+        const bool yaml_qos_override /* = true */)
     : CommonReader(
-        participant_id, topic, payload_pool, participant, topic_entity, xml_override)
+        participant_id, topic, payload_pool, participant, topic_entity, yaml_qos_override)
 {
     // Do nothing
 }

--- a/ddspipe_participants/src/cpp/reader/dds/SimpleReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/SimpleReader.cpp
@@ -30,9 +30,10 @@ SimpleReader::SimpleReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool yaml_qos_override /* = true */)
+        const bool yaml_qos_override /* = true */,
+        const bool xml_lookup_enabled /* = false */)
     : CommonReader(
-        participant_id, topic, payload_pool, participant, topic_entity, yaml_qos_override)
+        participant_id, topic, payload_pool, participant, topic_entity, yaml_qos_override, xml_lookup_enabled)
 {
     // Do nothing
 }

--- a/ddspipe_participants/src/cpp/reader/dds/SimpleReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/SimpleReader.cpp
@@ -29,9 +29,10 @@ SimpleReader::SimpleReader(
         const core::types::DdsTopic& topic,
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
-        fastdds::dds::Topic* topic_entity)
+        fastdds::dds::Topic* topic_entity,
+        const bool xml_override /* = false */)
     : CommonReader(
-        participant_id, topic, payload_pool, participant, topic_entity)
+        participant_id, topic, payload_pool, participant, topic_entity, xml_override)
 {
     // Do nothing
 }

--- a/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
@@ -34,9 +34,9 @@ SpecificQoSReader::SpecificQoSReader(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const std::shared_ptr<core::DiscoveryDatabase>& discovery_database,
-        const bool xml_override /* = false */)
+        const bool yaml_qos_override /* = true */)
     : CommonReader(
-        participant_id, topic, payload_pool, participant, topic_entity, xml_override)
+        participant_id, topic, payload_pool, participant, topic_entity, yaml_qos_override)
     , discovery_database_(discovery_database)
 {
 }

--- a/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
@@ -33,9 +33,10 @@ SpecificQoSReader::SpecificQoSReader(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const std::shared_ptr<core::DiscoveryDatabase>& discovery_database)
+        const std::shared_ptr<core::DiscoveryDatabase>& discovery_database,
+        const bool xml_override /* = false */)
     : CommonReader(
-        participant_id, topic, payload_pool, participant, topic_entity)
+        participant_id, topic, payload_pool, participant, topic_entity, xml_override)
     , discovery_database_(discovery_database)
 {
 }

--- a/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
@@ -34,9 +34,10 @@ SpecificQoSReader::SpecificQoSReader(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const std::shared_ptr<core::DiscoveryDatabase>& discovery_database,
-        const bool yaml_qos_override /* = true */)
+        const bool yaml_qos_override /* = true */,
+        const bool xml_lookup_enabled /* = false */)
     : CommonReader(
-        participant_id, topic, payload_pool, participant, topic_entity, yaml_qos_override)
+        participant_id, topic, payload_pool, participant, topic_entity, yaml_qos_override, xml_lookup_enabled)
     , discovery_database_(discovery_database)
 {
 }

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -133,13 +133,15 @@ CommonWriter::CommonWriter(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool repeater)
+        const bool repeater,
+        const bool xml_override /* = false */)
     : BaseWriter(participant_id, topic.topic_qos.max_tx_rate)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(new core::PayloadPoolMediator(payload_pool))
     , topic_(topic)
     , repeater_(repeater)
+    , xml_override_(xml_override)
     , dds_publisher_(nullptr)
     , writer_(nullptr)
 {
@@ -231,9 +233,15 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_(
 {
     fastdds::dds::DataWriterQos qos;
 
-    if (fastdds::dds::RETCODE_OK != dds_publisher_->get_datawriter_qos_from_profile(topic_name, qos))
+    bool xml_profile_found =
+            (fastdds::dds::RETCODE_OK == dds_publisher_->get_datawriter_qos_from_profile(topic_name, qos));
+
+    if (!xml_profile_found || xml_override_)
     {
-        qos = dds_publisher_->get_default_datawriter_qos();
+        if (!xml_profile_found)
+        {
+            qos = dds_publisher_->get_default_datawriter_qos();
+        }
 
         qos.durability().kind =
                 (topic_.topic_qos.is_transient_local())

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -134,7 +134,8 @@ CommonWriter::CommonWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater,
-        const bool yaml_qos_override /* = true */)
+        const bool yaml_qos_override /* = true */,
+        const bool xml_lookup_enabled /* = false */)
     : BaseWriter(participant_id, topic.topic_qos.max_tx_rate)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
@@ -142,6 +143,7 @@ CommonWriter::CommonWriter(
     , topic_(topic)
     , repeater_(repeater)
     , yaml_qos_override_(yaml_qos_override)
+    , xml_lookup_enabled_(xml_lookup_enabled)
     , dds_publisher_(nullptr)
     , writer_(nullptr)
 {
@@ -236,7 +238,7 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
             ? topic_.topic_qos.endpoint_profile_name.get_value()
             : topic_.topic_name();
 
-    bool xml_profile_found =
+    bool xml_profile_found = xml_lookup_enabled_ &&
             (fastdds::dds::RETCODE_OK == dds_publisher_->get_datawriter_qos_from_profile(profile_key, qos));
 
     if (!xml_profile_found)

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -96,7 +96,7 @@ void CommonWriter::init(
 
     writer_ = dds_publisher_->create_datawriter(
         dds_topic_,
-        reckon_writer_qos_(),
+        reckon_writer_qos_(topic_.topic_name()),
         nullptr,
         eprosima::fastdds::dds::StatusMask::all(),
         payload_pool_);
@@ -226,9 +226,16 @@ fastdds::dds::PublisherQos CommonWriter::reckon_publisher_qos_() const noexcept
     return qos;
 }
 
-fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
+fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_(
+        const std::string& topic_name) const noexcept
 {
-    fastdds::dds::DataWriterQos qos = dds_publisher_->get_default_datawriter_qos();
+    fastdds::dds::DataWriterQos qos;
+    fastdds::dds::ReturnCode_t ret_xml_qos = dds_publisher_->get_datawriter_qos_from_profile(topic_name, qos);
+
+    if (ret_xml_qos != fastdds::dds::RETCODE_OK)
+    {
+        qos = dds_publisher_->get_default_datawriter_qos();
+    }
 
     qos.durability().kind =
             (topic_.topic_qos.is_transient_local())

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -134,14 +134,14 @@ CommonWriter::CommonWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater,
-        const bool xml_override /* = false */)
+        const bool yaml_qos_override /* = true */)
     : BaseWriter(participant_id, topic.topic_qos.max_tx_rate)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(new core::PayloadPoolMediator(payload_pool))
     , topic_(topic)
     , repeater_(repeater)
-    , xml_override_(xml_override)
+    , yaml_qos_override_(yaml_qos_override)
     , dds_publisher_(nullptr)
     , writer_(nullptr)
 {
@@ -236,7 +236,7 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_(
     bool xml_profile_found =
             (fastdds::dds::RETCODE_OK == dds_publisher_->get_datawriter_qos_from_profile(topic_name, qos));
 
-    if (!xml_profile_found || xml_override_)
+    if (!xml_profile_found || yaml_qos_override_)
     {
         if (!xml_profile_found)
         {

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -96,7 +96,7 @@ void CommonWriter::init(
 
     writer_ = dds_publisher_->create_datawriter(
         dds_topic_,
-        reckon_writer_qos_(topic_.topic_name()),
+        reckon_writer_qos_(),
         nullptr,
         eprosima::fastdds::dds::StatusMask::all(),
         payload_pool_);
@@ -228,20 +228,20 @@ fastdds::dds::PublisherQos CommonWriter::reckon_publisher_qos_() const noexcept
     return qos;
 }
 
-fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_(
-        const std::string& topic_name) const noexcept
+fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
 {
     fastdds::dds::DataWriterQos qos;
 
-    bool xml_profile_found =
-            (fastdds::dds::RETCODE_OK == dds_publisher_->get_datawriter_qos_from_profile(topic_name, qos));
+    const std::string& profile_key = topic_.topic_qos.endpoint_profile_name.is_set()
+            ? topic_.topic_qos.endpoint_profile_name.get_value()
+            : topic_.topic_name();
 
-    if (!xml_profile_found || yaml_qos_override_)
+    bool xml_profile_found =
+            (fastdds::dds::RETCODE_OK == dds_publisher_->get_datawriter_qos_from_profile(profile_key, qos));
+
+    if (!xml_profile_found)
     {
-        if (!xml_profile_found)
-        {
-            qos = dds_publisher_->get_default_datawriter_qos();
-        }
+        qos = dds_publisher_->get_default_datawriter_qos();
 
         qos.durability().kind =
                 (topic_.topic_qos.is_transient_local())
@@ -266,6 +266,45 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_(
         {
             qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
             qos.history().depth = topic_.topic_qos.history_depth;
+        }
+    }
+    else if (yaml_qos_override_)
+    {
+        if (topic_.topic_qos.durability_qos.is_set())
+        {
+            qos.durability().kind =
+                    (topic_.topic_qos.is_transient_local())
+                    ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
+                    : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
+        }
+
+        if (topic_.topic_qos.reliability_qos.is_set())
+        {
+            qos.reliability().kind =
+                    (topic_.topic_qos.is_reliable())
+                    ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
+                    : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
+        }
+
+        if (topic_.topic_qos.ownership_qos.is_set())
+        {
+            qos.ownership().kind =
+                    (topic_.topic_qos.has_ownership())
+                    ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
+                    : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+        }
+
+        if (topic_.topic_qos.history_depth.is_set())
+        {
+            if (topic_.topic_qos.history_depth == 0U)
+            {
+                qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
+            }
+            else
+            {
+                qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
+                qos.history().depth = topic_.topic_qos.history_depth;
+            }
         }
     }
 

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -230,36 +230,35 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_(
         const std::string& topic_name) const noexcept
 {
     fastdds::dds::DataWriterQos qos;
-    fastdds::dds::ReturnCode_t ret_xml_qos = dds_publisher_->get_datawriter_qos_from_profile(topic_name, qos);
 
-    if (ret_xml_qos != fastdds::dds::RETCODE_OK)
+    if (fastdds::dds::RETCODE_OK != dds_publisher_->get_datawriter_qos_from_profile(topic_name, qos))
     {
         qos = dds_publisher_->get_default_datawriter_qos();
-    }
 
-    qos.durability().kind =
-            (topic_.topic_qos.is_transient_local())
-            ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
-            : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
+        qos.durability().kind =
+                (topic_.topic_qos.is_transient_local())
+                ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
+                : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
 
-    qos.reliability().kind =
-            (topic_.topic_qos.is_reliable())
-            ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
-            : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
+        qos.reliability().kind =
+                (topic_.topic_qos.is_reliable())
+                ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
+                : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
 
-    qos.ownership().kind =
-            (topic_.topic_qos.has_ownership())
-            ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
-            : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
+        qos.ownership().kind =
+                (topic_.topic_qos.has_ownership())
+                ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
+                : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
 
-    if (topic_.topic_qos.history_depth == 0U)
-    {
-        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
-    }
-    else
-    {
-        qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
-        qos.history().depth = topic_.topic_qos.history_depth;
+        if (topic_.topic_qos.history_depth == 0U)
+        {
+            qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
+        }
+        else
+        {
+            qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
+            qos.history().depth = topic_.topic_qos.history_depth;
+        }
     }
 
     // Set minimum deadline so it matches with everything

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -272,33 +272,36 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
     }
     else if (yaml_qos_override_)
     {
-        if (topic_.topic_qos.durability_qos.is_set())
+        // Only override the XML profile with fields explicitly set by the user (YAML)
+        const auto& user_qos = topic_.user_configured_qos;
+
+        if (user_qos.durability_qos.is_set())
         {
             qos.durability().kind =
-                    (topic_.topic_qos.is_transient_local())
+                    (user_qos.is_transient_local())
                     ? fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS
                     : fastdds::dds::DurabilityQosPolicyKind::VOLATILE_DURABILITY_QOS;
         }
 
-        if (topic_.topic_qos.reliability_qos.is_set())
+        if (user_qos.reliability_qos.is_set())
         {
             qos.reliability().kind =
-                    (topic_.topic_qos.is_reliable())
+                    (user_qos.is_reliable())
                     ? fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS
                     : fastdds::dds::ReliabilityQosPolicyKind::BEST_EFFORT_RELIABILITY_QOS;
         }
 
-        if (topic_.topic_qos.ownership_qos.is_set())
+        if (user_qos.ownership_qos.is_set())
         {
             qos.ownership().kind =
-                    (topic_.topic_qos.has_ownership())
+                    (user_qos.has_ownership())
                     ? fastdds::dds::OwnershipQosPolicyKind::EXCLUSIVE_OWNERSHIP_QOS
                     : fastdds::dds::OwnershipQosPolicyKind::SHARED_OWNERSHIP_QOS;
         }
 
-        if (topic_.topic_qos.history_depth.is_set())
+        if (user_qos.history_depth.is_set())
         {
-            if (topic_.topic_qos.history_depth == 0U)
+            if (user_qos.history_depth == 0U)
             {
                 qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_ALL_HISTORY_QOS;
             }

--- a/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/CommonWriter.cpp
@@ -308,7 +308,7 @@ fastdds::dds::DataWriterQos CommonWriter::reckon_writer_qos_() const noexcept
             else
             {
                 qos.history().kind = eprosima::fastdds::dds::HistoryQosPolicyKind::KEEP_LAST_HISTORY_QOS;
-                qos.history().depth = topic_.topic_qos.history_depth;
+                qos.history().depth = user_qos.history_depth;
             }
         }
     }

--- a/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
@@ -40,14 +40,14 @@ MultiWriter::MultiWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater /* = false */,
-        const bool xml_override /* = false */)
+        const bool yaml_qos_override /* = true */)
     : BaseWriter(participant_id)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(payload_pool)
     , topic_(topic)
     , repeater_(repeater)
-    , xml_override_(xml_override)
+    , yaml_qos_override_(yaml_qos_override)
 {
     // Do nothing
 }
@@ -149,7 +149,7 @@ QoSSpecificWriter* MultiWriter::create_writer_nts_(
         this->dds_participant_,
         this->dds_topic_,
         repeater_,
-        xml_override_);
+        yaml_qos_override_);
     // No filters
     writer->init(std::set<std::string>());
 

--- a/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
@@ -39,13 +39,15 @@ MultiWriter::MultiWriter(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool repeater /* = false */)
+        const bool repeater /* = false */,
+        const bool xml_override /* = false */)
     : BaseWriter(participant_id)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
     , payload_pool_(payload_pool)
     , topic_(topic)
     , repeater_(repeater)
+    , xml_override_(xml_override)
 {
     // Do nothing
 }
@@ -146,7 +148,8 @@ QoSSpecificWriter* MultiWriter::create_writer_nts_(
         data_qos,
         this->dds_participant_,
         this->dds_topic_,
-        repeater_);
+        repeater_,
+        xml_override_);
     // No filters
     writer->init(std::set<std::string>());
 

--- a/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/MultiWriter.cpp
@@ -40,7 +40,8 @@ MultiWriter::MultiWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater /* = false */,
-        const bool yaml_qos_override /* = true */)
+        const bool yaml_qos_override /* = true */,
+        const bool xml_lookup_enabled /* = false */)
     : BaseWriter(participant_id)
     , dds_participant_(participant)
     , dds_topic_(topic_entity)
@@ -48,6 +49,7 @@ MultiWriter::MultiWriter(
     , topic_(topic)
     , repeater_(repeater)
     , yaml_qos_override_(yaml_qos_override)
+    , xml_lookup_enabled_(xml_lookup_enabled)
 {
     // Do nothing
 }
@@ -149,7 +151,8 @@ QoSSpecificWriter* MultiWriter::create_writer_nts_(
         this->dds_participant_,
         this->dds_topic_,
         repeater_,
-        yaml_qos_override_);
+        yaml_qos_override_,
+        xml_lookup_enabled_);
     // No filters
     writer->init(std::set<std::string>());
 

--- a/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
@@ -30,9 +30,11 @@ QoSSpecificWriter::QoSSpecificWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater /* = false */,
-        const bool yaml_qos_override /* = true */)
+        const bool yaml_qos_override /* = true */,
+        const bool xml_lookup_enabled /* = false */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity, repeater, yaml_qos_override)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater, yaml_qos_override,
+        xml_lookup_enabled)
     , specific_qos_(specific_qos)
 {
 }

--- a/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
@@ -30,9 +30,9 @@ QoSSpecificWriter::QoSSpecificWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater /* = false */,
-        const bool xml_override /* = false */)
+        const bool yaml_qos_override /* = true */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity, repeater, xml_override)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater, yaml_qos_override)
     , specific_qos_(specific_qos)
 {
 }

--- a/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
@@ -48,10 +48,11 @@ fastdds::dds::PublisherQos QoSSpecificWriter::reckon_publisher_qos_() const noex
     return qos;
 }
 
-fastdds::dds::DataWriterQos QoSSpecificWriter::reckon_writer_qos_() const noexcept
+fastdds::dds::DataWriterQos QoSSpecificWriter::reckon_writer_qos_(
+        const std::string& topic_name) const noexcept
 {
     // Get QoS from parent class
-    fastdds::dds::DataWriterQos qos = CommonWriter::reckon_writer_qos_();
+    fastdds::dds::DataWriterQos qos = CommonWriter::reckon_writer_qos_(topic_.topic_name());
 
     // Set Ownership
     if (topic_.topic_qos.has_ownership())

--- a/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
@@ -49,11 +49,10 @@ fastdds::dds::PublisherQos QoSSpecificWriter::reckon_publisher_qos_() const noex
     return qos;
 }
 
-fastdds::dds::DataWriterQos QoSSpecificWriter::reckon_writer_qos_(
-        const std::string& topic_name) const noexcept
+fastdds::dds::DataWriterQos QoSSpecificWriter::reckon_writer_qos_() const noexcept
 {
     // Get QoS from parent class
-    fastdds::dds::DataWriterQos qos = CommonWriter::reckon_writer_qos_(topic_.topic_name());
+    fastdds::dds::DataWriterQos qos = CommonWriter::reckon_writer_qos_();
 
     // Set Ownership
     if (topic_.topic_qos.has_ownership())

--- a/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/QoSSpecificWriter.cpp
@@ -29,9 +29,10 @@ QoSSpecificWriter::QoSSpecificWriter(
         const core::types::SpecificEndpointQoS& specific_qos,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool repeater /* = false */)
+        const bool repeater /* = false */,
+        const bool xml_override /* = false */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity, repeater)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater, xml_override)
     , specific_qos_(specific_qos)
 {
 }

--- a/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
@@ -36,9 +36,11 @@ SimpleWriter::SimpleWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater /* = false */,
-        const bool yaml_qos_override /* = true */)
+        const bool yaml_qos_override /* = true */,
+        const bool xml_lookup_enabled /* = false */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity, repeater, yaml_qos_override)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater, yaml_qos_override,
+        xml_lookup_enabled)
 {
     // Do nothing
 }

--- a/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
@@ -35,9 +35,10 @@ SimpleWriter::SimpleWriter(
         const std::shared_ptr<core::PayloadPool>& payload_pool,
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
-        const bool repeater /* = false */)
+        const bool repeater /* = false */,
+        const bool xml_override /* = false */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity, repeater)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater, xml_override)
 {
     // Do nothing
 }

--- a/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/dds/SimpleWriter.cpp
@@ -36,9 +36,9 @@ SimpleWriter::SimpleWriter(
         fastdds::dds::DomainParticipant* participant,
         fastdds::dds::Topic* topic_entity,
         const bool repeater /* = false */,
-        const bool xml_override /* = false */)
+        const bool yaml_qos_override /* = true */)
     : CommonWriter(
-        participant_id, topic, payload_pool, participant, topic_entity, repeater, xml_override)
+        participant_id, topic, payload_pool, participant, topic_entity, repeater, yaml_qos_override)
 {
     // Do nothing
 }

--- a/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
+++ b/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
@@ -22,6 +22,8 @@ set(TEST_LIST
         default_configuration
         creation_trivial
         ddspipe_all_creation_builtin_topic
+        writer_topic_profile_lookup
+        reader_topic_profile_lookup
     )
 
 set(TEST_NEEDED_SOURCES

--- a/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
+++ b/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
@@ -26,6 +26,8 @@ set(TEST_LIST
         reader_topic_profile_lookup
         writer_xml_override
         reader_xml_override
+        writer_xml_qos_not_overridden_when_yaml_unset
+        writer_endpoint_profile_name_override
     )
 
 set(TEST_NEEDED_SOURCES

--- a/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
+++ b/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
@@ -28,6 +28,8 @@ set(TEST_LIST
         reader_xml_override
         writer_xml_qos_not_overridden_when_yaml_unset
         writer_endpoint_profile_name_override
+        writer_topic_profile_lookup_not_enabled_by_default
+        reader_topic_profile_lookup_not_enabled_by_default
     )
 
 set(TEST_NEEDED_SOURCES

--- a/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
+++ b/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
@@ -24,6 +24,8 @@ set(TEST_LIST
         ddspipe_all_creation_builtin_topic
         writer_topic_profile_lookup
         reader_topic_profile_lookup
+        writer_xml_override
+        reader_xml_override
     )
 
 set(TEST_NEEDED_SOURCES

--- a/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
+++ b/ddspipe_participants/test/blackbox/participants_creation/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_LIST
         writer_xml_override
         reader_xml_override
         writer_xml_qos_not_overridden_when_yaml_unset
+        writer_xml_qos_not_overridden_by_discovered_topic_qos
         writer_endpoint_profile_name_override
         writer_topic_profile_lookup_not_enabled_by_default
         reader_topic_profile_lookup_not_enabled_by_default

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -644,6 +644,165 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
     fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
 }
 
+/**
+ * Test that XML profile QoS is preserved when YAML topic_qos fields are not explicitly set,
+ * even under the default xml-overridable mode.
+ */
+TEST(ParticipantsCreationgTest, writer_xml_qos_not_overridden_when_yaml_unset)
+{
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_writer profile_name="writer_yaml_unset_topic">
+                    <topic>
+                        <historyQos>
+                            <kind>KEEP_ALL</kind>
+                        </historyQos>
+                    </topic>
+                    <qos>
+                        <reliability>
+                            <kind>RELIABLE</kind>
+                        </reliability>
+                        <durability>
+                            <kind>TRANSIENT_LOCAL</kind>
+                        </durability>
+                    </qos>
+                </data_writer>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
+
+    core::types::ParticipantId part_id("WriterYamlUnsetTestPart");
+
+    fastdds::dds::TypeSupport type_support(
+        new participants::dds::TopicDataType(
+            payload_pool,
+            "WriterYamlUnsetType",
+            fastdds::dds::xtypes::TypeIdentifierPair(),
+            false));
+    dds_participant->register_type(type_support);
+    auto dds_topic = dds_participant->create_topic(
+        "writer_yaml_unset_topic",
+        "WriterYamlUnsetType",
+        dds_participant->get_default_topic_qos());
+    ASSERT_NE(nullptr, dds_topic);
+
+    core::types::DdsTopic topic;
+    topic.m_topic_name = "writer_yaml_unset_topic";
+    topic.type_name = "WriterYamlUnsetType";
+    // Intentionally leave all topic_qos fields unset
+
+    test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+            false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */);
+    writer.init({});
+
+    fastdds::dds::DataWriterQos qos;
+    writer.get_dds_writer()->get_qos(qos);
+
+    EXPECT_EQ(fastdds::dds::RELIABLE_RELIABILITY_QOS, qos.reliability().kind);
+    EXPECT_EQ(fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS, qos.durability().kind);
+    EXPECT_EQ(fastdds::dds::KEEP_ALL_HISTORY_QOS, qos.history().kind);
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
+}
+
+/**
+ * Test that two writers with the same topic name but different endpoint_profile_name
+ * each load their own XML profile independently.
+ */
+TEST(ParticipantsCreationgTest, writer_endpoint_profile_name_override)
+{
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_writer profile_name="profile_chatter_reliable">
+                    <qos>
+                        <reliability>
+                            <kind>RELIABLE</kind>
+                        </reliability>
+                    </qos>
+                </data_writer>
+                <data_writer profile_name="profile_chatter_besteffort">
+                    <qos>
+                        <reliability>
+                            <kind>BEST_EFFORT</kind>
+                        </reliability>
+                    </qos>
+                </data_writer>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
+
+    core::types::ParticipantId part_id("WriterEndpointProfileTestPart");
+
+    fastdds::dds::TypeSupport type_support(
+        new participants::dds::TopicDataType(
+            payload_pool,
+            "ChatterType",
+            fastdds::dds::xtypes::TypeIdentifierPair(),
+            false));
+    dds_participant->register_type(type_support);
+    auto dds_topic = dds_participant->create_topic(
+        "chatter",
+        "ChatterType",
+        dds_participant->get_default_topic_qos());
+    ASSERT_NE(nullptr, dds_topic);
+
+    // First writer
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = "chatter";
+        topic.type_name = "ChatterType";
+        topic.topic_qos.endpoint_profile_name.set_value("profile_chatter_reliable");
+
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */);
+        writer.init({});
+
+        fastdds::dds::DataWriterQos qos;
+        writer.get_dds_writer()->get_qos(qos);
+        EXPECT_EQ(fastdds::dds::RELIABLE_RELIABILITY_QOS, qos.reliability().kind);
+    }
+
+    // Second writer
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = "chatter";
+        topic.type_name = "ChatterType";
+        topic.topic_qos.endpoint_profile_name.set_value("profile_chatter_besteffort");
+
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */);
+        writer.init({});
+
+        fastdds::dds::DataWriterQos qos;
+        writer.get_dds_writer()->get_qos(qos);
+        EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
+    }
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
+}
+
 int main(
         int argc,
         char** argv)

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -31,18 +31,49 @@
 #include <ddspipe_participants/testing/entities/mock_entities.hpp>
 #include <ddspipe_participants/testing/random_values.hpp>
 #include <ddspipe_participants/reader/auxiliar/BlankReader.hpp>
+#include <ddspipe_participants/reader/dds/SimpleReader.hpp>
 #include <ddspipe_participants/writer/auxiliar/BlankWriter.hpp>
+#include <ddspipe_participants/writer/dds/SimpleWriter.hpp>
 #include <ddspipe_participants/xml/XmlHandler.hpp>
 #include <ddspipe_participants/xml/XmlHandlerConfiguration.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
+
+#include <ddspipe_participants/types/dds/TopicDataType.hpp>
 
 using namespace eprosima;
 using namespace eprosima::ddspipe;
 
 namespace test {
 
+class TestableWriter : public participants::dds::SimpleWriter
+{
+public:
+
+    using SimpleWriter::SimpleWriter;
+
+    fastdds::dds::DataWriter* get_dds_writer()
+    {
+        return writer_;
+    }
+
+};
+
+class TestableReader : public participants::dds::SimpleReader
+{
+public:
+
+    using SimpleReader::SimpleReader;
+
+    fastdds::dds::DataReader* get_dds_reader()
+    {
+        return reader_;
+    }
+
+};
+
 constexpr const unsigned int N_THREADS = 2;
 
-} // test
+} // namespace test
 
 /**
  * Test to check default participant configuration values.
@@ -250,8 +281,8 @@ TEST(ParticipantsCreationgTest, ddspipe_all_creation_builtin_topic)
  * Test that writer creation falls back correctly depending on whether a matching XML profile exists.
  *
  * CASES:
- * - Topic name matches a loaded XML DataWriter profile  -> writer created via profile (not a BlankWriter)
- * - Topic name has no matching XML profile              -> writer created via fallback QoS (not a BlankWriter)
+ * - Topic name matches a loaded XML DataWriter profile  -> QoS comes from profile (DYNAMIC history memory policy)
+ * - Topic name has no matching XML profile              -> QoS comes from default (PREALLOCATED_WITH_REALLOC)
  */
 TEST(ParticipantsCreationgTest, writer_topic_profile_lookup)
 {
@@ -261,7 +292,7 @@ TEST(ParticipantsCreationgTest, writer_topic_profile_lookup)
         R"(<?xml version="1.0" encoding="utf-8"?>
         <dds xmlns="http://www.eprosima.com">
             <profiles>
-                <data_writer profile_name="topic_with_profile">
+                <data_writer profile_name="writer_topic_with_profile">
                     <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
                 </data_writer>
             </profiles>
@@ -269,40 +300,76 @@ TEST(ParticipantsCreationgTest, writer_topic_profile_lookup)
     ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
 
     std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
-    std::shared_ptr<core::DiscoveryDatabase> discovery_database(new core::DiscoveryDatabase());
 
-    std::shared_ptr<participants::XmlParticipantConfiguration> conf(
-        new participants::XmlParticipantConfiguration());
-    conf->id = core::types::ParticipantId("TestParticipant");
+    // Create a raw DDS DomainParticipant to back the writer
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
 
-    participants::dds::XmlParticipant participant(conf, payload_pool, discovery_database);
-    participant.init();
+    core::types::ParticipantId part_id("WriterProfileTestPart");
 
-    // Case 1: profile exists for this topic name -> profile path taken
-    core::types::DdsTopic topic_with_profile;
-    topic_with_profile.m_topic_name = "topic_with_profile";
-    topic_with_profile.type_name = "TestType";
+    auto register_type_and_topic = [&](const std::string& topic_name, const std::string& type_name)
+            -> fastdds::dds::Topic*
+            {
+                fastdds::dds::TypeSupport type_support(
+                    new participants::dds::TopicDataType(
+                        payload_pool,
+                        type_name,
+                        fastdds::dds::xtypes::TypeIdentifierPair(),
+                        false));
+                dds_participant->register_type(type_support);
+                return dds_participant->create_topic(
+                    topic_name,
+                    type_name,
+                    dds_participant->get_default_topic_qos());
+            };
 
-    auto writer_with_profile = participant.create_writer(topic_with_profile);
-    EXPECT_NE(nullptr, writer_with_profile);
-    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankWriter*>(writer_with_profile.get()));
+    // Case 1: profile exists -> DYNAMIC_RESERVE_MEMORY_MODE
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = "writer_topic_with_profile";
+        topic.type_name = "WriterProfileType";
 
-    // Case 2: no profile for this topic name -> fallback path taken
-    core::types::DdsTopic topic_without_profile;
-    topic_without_profile.m_topic_name = "topic_without_profile";
-    topic_without_profile.type_name = "TestType";
+        auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
+        ASSERT_NE(nullptr, dds_topic);
 
-    auto writer_without_profile = participant.create_writer(topic_without_profile);
-    EXPECT_NE(nullptr, writer_without_profile);
-    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankWriter*>(writer_without_profile.get()));
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic);
+        writer.init({});
+
+        fastdds::dds::DataWriterQos qos;
+        writer.get_dds_writer()->get_qos(qos);
+        EXPECT_EQ(fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE, qos.endpoint().history_memory_policy);
+    }
+
+    // Case 2: no profile -> PREALLOCATED_WITH_REALLOC_MEMORY_MODE (Fast DDS default)
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = "writer_topic_without_profile";
+        topic.type_name = "WriterNoProfileType";
+
+        auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
+        ASSERT_NE(nullptr, dds_topic);
+
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic);
+        writer.init({});
+
+        fastdds::dds::DataWriterQos qos;
+        writer.get_dds_writer()->get_qos(qos);
+        EXPECT_EQ(fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
+                qos.endpoint().history_memory_policy);
+    }
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
 }
 
 /**
  * Test that reader creation falls back correctly depending on whether a matching XML profile exists.
  *
  * CASES:
- * - Topic name matches a loaded XML DataReader profile  -> reader created via profile (not a BlankReader)
- * - Topic name has no matching XML profile              -> reader created via fallback QoS (not a BlankReader)
+ * - Topic name matches a loaded XML DataReader profile  -> QoS comes from profile (DYNAMIC history memory policy)
+ * - Topic name has no matching XML profile              -> QoS comes from default (PREALLOCATED_WITH_REALLOC)
  */
 TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
 {
@@ -311,7 +378,7 @@ TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
         R"(<?xml version="1.0" encoding="utf-8"?>
         <dds xmlns="http://www.eprosima.com">
             <profiles>
-                <data_reader profile_name="topic_with_reader_profile">
+                <data_reader profile_name="reader_topic_with_profile">
                     <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
                 </data_reader>
             </profiles>
@@ -319,32 +386,68 @@ TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
     ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
 
     std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
-    std::shared_ptr<core::DiscoveryDatabase> discovery_database(new core::DiscoveryDatabase());
 
-    std::shared_ptr<participants::XmlParticipantConfiguration> conf(
-        new participants::XmlParticipantConfiguration());
-    conf->id = core::types::ParticipantId("TestReaderParticipant");
+    // Create a raw DDS DomainParticipant to back the reader
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
 
-    participants::dds::XmlParticipant participant(conf, payload_pool, discovery_database);
-    participant.init();
+    core::types::ParticipantId part_id("ReaderProfileTestPart");
 
-    // Case 1: profile exists for this topic name -> profile path taken
-    core::types::DdsTopic topic_with_profile;
-    topic_with_profile.m_topic_name = "topic_with_reader_profile";
-    topic_with_profile.type_name = "TestType";
+    auto register_type_and_topic = [&](const std::string& topic_name, const std::string& type_name)
+            -> fastdds::dds::Topic*
+            {
+                fastdds::dds::TypeSupport type_support(
+                    new participants::dds::TopicDataType(
+                        payload_pool,
+                        type_name,
+                        fastdds::dds::xtypes::TypeIdentifierPair(),
+                        false));
+                dds_participant->register_type(type_support);
+                return dds_participant->create_topic(
+                    topic_name,
+                    type_name,
+                    dds_participant->get_default_topic_qos());
+            };
 
-    auto reader_with_profile = participant.create_reader(topic_with_profile);
-    EXPECT_NE(nullptr, reader_with_profile);
-    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankReader*>(reader_with_profile.get()));
+    // Case 1: profile exists -> DYNAMIC_RESERVE_MEMORY_MODE
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = "reader_topic_with_profile";
+        topic.type_name = "ReaderProfileType";
 
-    // Case 2: no profile for this topic name -> fallback path taken
-    core::types::DdsTopic topic_without_profile;
-    topic_without_profile.m_topic_name = "topic_without_reader_profile";
-    topic_without_profile.type_name = "TestType";
+        auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
+        ASSERT_NE(nullptr, dds_topic);
 
-    auto reader_without_profile = participant.create_reader(topic_without_profile);
-    EXPECT_NE(nullptr, reader_without_profile);
-    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankReader*>(reader_without_profile.get()));
+        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic);
+        reader.init({}, "");
+
+        fastdds::dds::DataReaderQos qos;
+        reader.get_dds_reader()->get_qos(qos);
+        EXPECT_EQ(fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE, qos.endpoint().history_memory_policy);
+    }
+
+    // Case 2: no profile -> PREALLOCATED_WITH_REALLOC_MEMORY_MODE (Fast DDS default)
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = "reader_topic_without_profile";
+        topic.type_name = "ReaderNoProfileType";
+
+        auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
+        ASSERT_NE(nullptr, dds_topic);
+
+        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic);
+        reader.init({}, "");
+
+        fastdds::dds::DataReaderQos qos;
+        reader.get_dds_reader()->get_qos(qos);
+        EXPECT_EQ(fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
+                qos.endpoint().history_memory_policy);
+    }
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
 }
 
 int main(

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -335,7 +335,8 @@ TEST(ParticipantsCreationgTest, writer_topic_profile_lookup)
         auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
         ASSERT_NE(nullptr, dds_topic);
 
-        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic);
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+                false /* repeater */, true /* yaml_qos_override */, true /* xml_lookup_enabled */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
@@ -352,7 +353,8 @@ TEST(ParticipantsCreationgTest, writer_topic_profile_lookup)
         auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
         ASSERT_NE(nullptr, dds_topic);
 
-        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic);
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+                false /* repeater */, true /* yaml_qos_override */, true /* xml_lookup_enabled */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
@@ -421,7 +423,8 @@ TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
         auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
         ASSERT_NE(nullptr, dds_topic);
 
-        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic);
+        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
+                true /* yaml_qos_override */, true /* xml_lookup_enabled */);
         reader.init({}, "");
 
         fastdds::dds::DataReaderQos qos;
@@ -438,7 +441,8 @@ TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
         auto dds_topic = register_type_and_topic(topic.m_topic_name, topic.type_name);
         ASSERT_NE(nullptr, dds_topic);
 
-        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic);
+        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
+                true /* yaml_qos_override */, true /* xml_lookup_enabled */);
         reader.init({}, "");
 
         fastdds::dds::DataReaderQos qos;
@@ -517,7 +521,8 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */);
+                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */,
+                true /* xml_lookup_enabled */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
@@ -535,7 +540,8 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */);
+                false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */,
+                true /* xml_lookup_enabled */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
@@ -614,7 +620,8 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* yaml_qos_override = XML_STANDALONE */);
+                false /* yaml_qos_override = XML_STANDALONE */,
+                true /* xml_lookup_enabled */);
         reader.init({}, "");
 
         fastdds::dds::DataReaderQos qos;
@@ -632,7 +639,8 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
-                true /* yaml_qos_override = XML_OVERRIDABLE */);
+                true /* yaml_qos_override = XML_OVERRIDABLE */,
+                true /* xml_lookup_enabled */);
         reader.init({}, "");
 
         fastdds::dds::DataReaderQos qos;
@@ -703,7 +711,8 @@ TEST(ParticipantsCreationgTest, writer_xml_qos_not_overridden_when_yaml_unset)
     // Intentionally leave all topic_qos fields unset
 
     test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
-            false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */);
+            false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */,
+            true /* xml_lookup_enabled */);
     writer.init({});
 
     fastdds::dds::DataWriterQos qos;
@@ -776,7 +785,8 @@ TEST(ParticipantsCreationgTest, writer_endpoint_profile_name_override)
         topic.topic_qos.endpoint_profile_name.set_value("profile_chatter_reliable");
 
         test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */);
+                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */,
+                true /* xml_lookup_enabled */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
@@ -792,13 +802,143 @@ TEST(ParticipantsCreationgTest, writer_endpoint_profile_name_override)
         topic.topic_qos.endpoint_profile_name.set_value("profile_chatter_besteffort");
 
         test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */);
+                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */,
+                true /* xml_lookup_enabled */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
         writer.get_dds_writer()->get_qos(qos);
         EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
     }
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
+}
+
+/**
+ * Test that plain DDS writer creation does not use XML endpoint profiles unless endpoint lookup is enabled.
+ */
+TEST(ParticipantsCreationgTest, writer_topic_profile_lookup_not_enabled_by_default)
+{
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_writer profile_name="writer_topic_with_profile_default_mode">
+                    <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+                </data_writer>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
+
+    core::types::ParticipantId part_id("WriterProfileDefaultModeTestPart");
+
+    fastdds::dds::TypeSupport type_support(
+        new participants::dds::TopicDataType(
+            payload_pool,
+            "WriterProfileDefaultModeType",
+            fastdds::dds::xtypes::TypeIdentifierPair(),
+            false));
+    dds_participant->register_type(type_support);
+
+    auto dds_topic = dds_participant->create_topic(
+        "writer_topic_with_profile_default_mode",
+        "WriterProfileDefaultModeType",
+        dds_participant->get_default_topic_qos());
+    ASSERT_NE(nullptr, dds_topic);
+
+    core::types::DdsTopic topic;
+    topic.m_topic_name = "writer_topic_with_profile_default_mode";
+    topic.type_name = "WriterProfileDefaultModeType";
+
+    test::TestableWriter writer(
+        part_id,
+        topic,
+        payload_pool,
+        dds_participant,
+        dds_topic,
+        false /* repeater */,
+        false /* yaml_qos_override */);
+    writer.init({});
+
+    fastdds::dds::DataWriterQos qos;
+    writer.get_dds_writer()->get_qos(qos);
+
+    EXPECT_EQ(
+        fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
+        qos.endpoint().history_memory_policy);
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
+}
+
+/**
+ * Test that plain DDS reader creation does not use XML endpoint profiles unless endpoint lookup is enabled.
+ */
+TEST(ParticipantsCreationgTest, reader_topic_profile_lookup_not_enabled_by_default)
+{
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_reader profile_name="reader_topic_with_profile_default_mode">
+                    <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+                </data_reader>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
+
+    core::types::ParticipantId part_id("ReaderProfileDefaultModeTestPart");
+
+    fastdds::dds::TypeSupport type_support(
+        new participants::dds::TopicDataType(
+            payload_pool,
+            "ReaderProfileDefaultModeType",
+            fastdds::dds::xtypes::TypeIdentifierPair(),
+            false));
+    dds_participant->register_type(type_support);
+
+    auto dds_topic = dds_participant->create_topic(
+        "reader_topic_with_profile_default_mode",
+        "ReaderProfileDefaultModeType",
+        dds_participant->get_default_topic_qos());
+    ASSERT_NE(nullptr, dds_topic);
+
+    core::types::DdsTopic topic;
+    topic.m_topic_name = "reader_topic_with_profile_default_mode";
+    topic.type_name = "ReaderProfileDefaultModeType";
+
+    test::TestableReader reader(
+        part_id,
+        topic,
+        payload_pool,
+        dds_participant,
+        dds_topic,
+        false /* yaml_qos_override */);
+    reader.init({}, "");
+
+    fastdds::dds::DataReaderQos qos;
+    reader.get_dds_reader()->get_qos(qos);
+
+    EXPECT_EQ(
+        fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE,
+        qos.endpoint().history_memory_policy);
 
     fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
 }

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -451,11 +451,11 @@ TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
 }
 
 /**
- * Test that xml_override flag makes YAML QoS take precedence over a matching XML profile.
+ * Test that endpoint_qos_mode controls whether YAML QoS overrides a matching XML profile for writers.
  *
  * CASES:
- * - xml_override = false, profile exists -> QoS comes from XML profile (DYNAMIC history memory policy)
- * - xml_override = true,  profile exists -> QoS comes from YAML (RELIABLE reliability, set via topic_qos)
+ * - XML_STANDALONE, profile exists -> QoS comes from XML profile
+ * - XML_OVERRIDABLE, profile exists -> QoS comes from YAML
  */
 TEST(ParticipantsCreationgTest, writer_xml_override)
 {
@@ -503,14 +503,13 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
                     dds_participant->get_default_topic_qos());
             };
 
-    // Register one type and create the topic once — both cases reuse it
     const std::string topic_name = "writer_override_topic";
     const std::string type_name = "WriterOverrideType";
 
     auto dds_topic = register_type_and_topic(topic_name, type_name);
     ASSERT_NE(nullptr, dds_topic);
 
-    // Case 1: xml_override = false
+    // Case 1: XML_STANDALONE
     {
         core::types::DdsTopic topic;
         topic.m_topic_name = topic_name;
@@ -518,7 +517,7 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* repeater */, false /* xml_override */);
+                false /* repeater */, false /* yaml_qos_override = XML_STANDALONE */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
@@ -528,7 +527,7 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
         EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
     }
 
-    // Case 2: xml_override = true
+    // Case 2: XML_OVERRIDABLE
     {
         core::types::DdsTopic topic;
         topic.m_topic_name = topic_name;
@@ -536,7 +535,7 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* repeater */, true /* xml_override */);
+                false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */);
         writer.init({});
 
         fastdds::dds::DataWriterQos qos;
@@ -549,11 +548,11 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
 }
 
 /**
- * Test that xml_override flag makes YAML QoS take precedence over a matching XML profile for readers.
+ * Test that endpoint_qos_mode controls whether YAML QoS overrides a matching XML profile for readers.
  *
  * CASES:
- * - xml_override = false, profile exists -> QoS comes from XML profile (BEST_EFFORT reliability)
- * - xml_override = true,  profile exists -> QoS comes from YAML (RELIABLE reliability, set via topic_qos)
+ * - XML_STANDALONE, profile exists -> QoS comes from XML profile (BEST_EFFORT reliability)
+ * - XML_OVERRIDABLE, profile exists -> QoS comes from YAML (RELIABLE reliability, set via topic_qos)
  */
 TEST(ParticipantsCreationgTest, reader_xml_override)
 {
@@ -601,14 +600,13 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
                     dds_participant->get_default_topic_qos());
             };
 
-    // Register one type and create the topic once — both cases reuse it
     const std::string topic_name = "reader_override_topic";
     const std::string type_name = "ReaderOverrideType";
 
     auto dds_topic = register_type_and_topic(topic_name, type_name);
     ASSERT_NE(nullptr, dds_topic);
 
-    // Case 1: xml_override = false
+    // Case 1: XML_STANDALONE
     {
         core::types::DdsTopic topic;
         topic.m_topic_name = topic_name;
@@ -616,7 +614,7 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
-                false /* xml_override */);
+                false /* yaml_qos_override = XML_STANDALONE */);
         reader.init({}, "");
 
         fastdds::dds::DataReaderQos qos;
@@ -626,7 +624,7 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
         EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
     }
 
-    // Case 2: xml_override = true
+    // Case 2: XML_OVERRIDABLE
     {
         core::types::DdsTopic topic;
         topic.m_topic_name = topic_name;
@@ -634,7 +632,7 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
-                true /* xml_override */);
+                true /* yaml_qos_override = XML_OVERRIDABLE */);
         reader.init({}, "");
 
         fastdds::dds::DataReaderQos qos;

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -450,6 +450,202 @@ TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
     fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
 }
 
+/**
+ * Test that xml_override flag makes YAML QoS take precedence over a matching XML profile.
+ *
+ * CASES:
+ * - xml_override = false, profile exists -> QoS comes from XML profile (DYNAMIC history memory policy)
+ * - xml_override = true,  profile exists -> QoS comes from YAML (RELIABLE reliability, set via topic_qos)
+ */
+TEST(ParticipantsCreationgTest, writer_xml_override)
+{
+    // Load an XML profile that sets DYNAMIC memory policy and BEST_EFFORT reliability
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_writer profile_name="writer_override_topic">
+                    <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+                    <qos>
+                        <reliability>
+                            <kind>BEST_EFFORT</kind>
+                        </reliability>
+                    </qos>
+                </data_writer>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
+
+    core::types::ParticipantId part_id("WriterOverrideTestPart");
+
+    auto register_type_and_topic = [&](const std::string& topic_name, const std::string& type_name)
+            -> fastdds::dds::Topic*
+            {
+                fastdds::dds::TypeSupport type_support(
+                    new participants::dds::TopicDataType(
+                        payload_pool,
+                        type_name,
+                        fastdds::dds::xtypes::TypeIdentifierPair(),
+                        false));
+                dds_participant->register_type(type_support);
+                return dds_participant->create_topic(
+                    topic_name,
+                    type_name,
+                    dds_participant->get_default_topic_qos());
+            };
+
+    // Register one type and create the topic once — both cases reuse it
+    const std::string topic_name = "writer_override_topic";
+    const std::string type_name = "WriterOverrideType";
+
+    auto dds_topic = register_type_and_topic(topic_name, type_name);
+    ASSERT_NE(nullptr, dds_topic);
+
+    // Case 1: xml_override = false
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = topic_name;
+        topic.type_name = type_name;
+        topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
+
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+                false /* repeater */, false /* xml_override */);
+        writer.init({});
+
+        fastdds::dds::DataWriterQos qos;
+        writer.get_dds_writer()->get_qos(qos);
+
+        EXPECT_EQ(fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE, qos.endpoint().history_memory_policy);
+        EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
+    }
+
+    // Case 2: xml_override = true
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = topic_name;
+        topic.type_name = type_name;
+        topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
+
+        test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+                false /* repeater */, true /* xml_override */);
+        writer.init({});
+
+        fastdds::dds::DataWriterQos qos;
+        writer.get_dds_writer()->get_qos(qos);
+
+        EXPECT_EQ(fastdds::dds::RELIABLE_RELIABILITY_QOS, qos.reliability().kind);
+    }
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
+}
+
+/**
+ * Test that xml_override flag makes YAML QoS take precedence over a matching XML profile for readers.
+ *
+ * CASES:
+ * - xml_override = false, profile exists -> QoS comes from XML profile (BEST_EFFORT reliability)
+ * - xml_override = true,  profile exists -> QoS comes from YAML (RELIABLE reliability, set via topic_qos)
+ */
+TEST(ParticipantsCreationgTest, reader_xml_override)
+{
+    // Load an XML profile that sets DYNAMIC memory policy and BEST_EFFORT reliability
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_reader profile_name="reader_override_topic">
+                    <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+                    <qos>
+                        <reliability>
+                            <kind>BEST_EFFORT</kind>
+                        </reliability>
+                    </qos>
+                </data_reader>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
+
+    core::types::ParticipantId part_id("ReaderOverrideTestPart");
+
+    auto register_type_and_topic = [&](const std::string& topic_name, const std::string& type_name)
+            -> fastdds::dds::Topic*
+            {
+                fastdds::dds::TypeSupport type_support(
+                    new participants::dds::TopicDataType(
+                        payload_pool,
+                        type_name,
+                        fastdds::dds::xtypes::TypeIdentifierPair(),
+                        false));
+                dds_participant->register_type(type_support);
+                return dds_participant->create_topic(
+                    topic_name,
+                    type_name,
+                    dds_participant->get_default_topic_qos());
+            };
+
+    // Register one type and create the topic once — both cases reuse it
+    const std::string topic_name = "reader_override_topic";
+    const std::string type_name = "ReaderOverrideType";
+
+    auto dds_topic = register_type_and_topic(topic_name, type_name);
+    ASSERT_NE(nullptr, dds_topic);
+
+    // Case 1: xml_override = false
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = topic_name;
+        topic.type_name = type_name;
+        topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
+
+        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
+                false /* xml_override */);
+        reader.init({}, "");
+
+        fastdds::dds::DataReaderQos qos;
+        reader.get_dds_reader()->get_qos(qos);
+
+        EXPECT_EQ(fastdds::rtps::DYNAMIC_RESERVE_MEMORY_MODE, qos.endpoint().history_memory_policy);
+        EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
+    }
+
+    // Case 2: xml_override = true
+    {
+        core::types::DdsTopic topic;
+        topic.m_topic_name = topic_name;
+        topic.type_name = type_name;
+        topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
+
+        test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
+                true /* xml_override */);
+        reader.init({}, "");
+
+        fastdds::dds::DataReaderQos qos;
+        reader.get_dds_reader()->get_qos(qos);
+
+        EXPECT_EQ(fastdds::dds::RELIABLE_RELIABILITY_QOS, qos.reliability().kind);
+    }
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
+}
+
 int main(
         int argc,
         char** argv)

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -538,6 +538,7 @@ TEST(ParticipantsCreationgTest, writer_xml_override)
         topic.m_topic_name = topic_name;
         topic.type_name = type_name;
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
+        topic.user_configured_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
                 false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */,
@@ -637,6 +638,7 @@ TEST(ParticipantsCreationgTest, reader_xml_override)
         topic.m_topic_name = topic_name;
         topic.type_name = type_name;
         topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
+        topic.user_configured_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
 
         test::TestableReader reader(part_id, topic, payload_pool, dds_participant, dds_topic,
                 true /* yaml_qos_override = XML_OVERRIDABLE */,
@@ -810,6 +812,76 @@ TEST(ParticipantsCreationgTest, writer_endpoint_profile_name_override)
         writer.get_dds_writer()->get_qos(qos);
         EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
     }
+
+    fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
+}
+
+/**
+ * Regression test for a bug found via FastDDSSpy: discovery derived QoS (topic_qos) must never be
+ * mistaken for an explicit YAML override of an XML profile. Only user_configured_qos should be able
+ * to override the XML profile when yaml_qos_override_ (XML_OVERRIDABLE) is active.
+ */
+TEST(ParticipantsCreationgTest, writer_xml_qos_not_overridden_by_discovered_topic_qos)
+{
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_writer profile_name="writer_discovered_qos_topic">
+                    <qos>
+                        <reliability>
+                            <kind>BEST_EFFORT</kind>
+                        </reliability>
+                        <durability>
+                            <kind>TRANSIENT_LOCAL</kind>
+                        </durability>
+                    </qos>
+                </data_writer>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+
+    auto dds_participant =
+            fastdds::dds::DomainParticipantFactory::get_instance()->create_participant(
+        0,
+        fastdds::dds::PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, dds_participant);
+
+    core::types::ParticipantId part_id("WriterDiscoveredQosTestPart");
+
+    fastdds::dds::TypeSupport type_support(
+        new participants::dds::TopicDataType(
+            payload_pool,
+            "WriterDiscoveredQosType",
+            fastdds::dds::xtypes::TypeIdentifierPair(),
+            false));
+    dds_participant->register_type(type_support);
+    auto dds_topic = dds_participant->create_topic(
+        "writer_discovered_qos_topic",
+        "WriterDiscoveredQosType",
+        dds_participant->get_default_topic_qos());
+    ASSERT_NE(nullptr, dds_topic);
+
+    core::types::DdsTopic topic;
+    topic.m_topic_name = "writer_discovered_qos_topic";
+    topic.type_name = "WriterDiscoveredQosType";
+
+    topic.topic_qos.reliability_qos = core::types::ReliabilityKind::RELIABLE;
+    topic.topic_qos.durability_qos = core::types::DurabilityKind::VOLATILE;
+
+    test::TestableWriter writer(part_id, topic, payload_pool, dds_participant, dds_topic,
+            false /* repeater */, true /* yaml_qos_override = XML_OVERRIDABLE */,
+            true /* xml_lookup_enabled */);
+    writer.init({});
+
+    fastdds::dds::DataWriterQos qos;
+    writer.get_dds_writer()->get_qos(qos);
+
+    EXPECT_EQ(fastdds::dds::BEST_EFFORT_RELIABILITY_QOS, qos.reliability().kind);
+    EXPECT_EQ(fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS, qos.durability().kind);
 
     fastdds::dds::DomainParticipantFactory::get_instance()->delete_participant(dds_participant);
 }

--- a/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
+++ b/ddspipe_participants/test/blackbox/participants_creation/ParticipantsCreationgTest.cpp
@@ -30,6 +30,10 @@
 #include <ddspipe_participants/participant/dds/XmlParticipant.hpp>
 #include <ddspipe_participants/testing/entities/mock_entities.hpp>
 #include <ddspipe_participants/testing/random_values.hpp>
+#include <ddspipe_participants/reader/auxiliar/BlankReader.hpp>
+#include <ddspipe_participants/writer/auxiliar/BlankWriter.hpp>
+#include <ddspipe_participants/xml/XmlHandler.hpp>
+#include <ddspipe_participants/xml/XmlHandlerConfiguration.hpp>
 
 using namespace eprosima;
 using namespace eprosima::ddspipe;
@@ -240,6 +244,107 @@ TEST(ParticipantsCreationgTest, ddspipe_all_creation_builtin_topic)
         );
 
     // Let everything destroy itself
+}
+
+/**
+ * Test that writer creation falls back correctly depending on whether a matching XML profile exists.
+ *
+ * CASES:
+ * - Topic name matches a loaded XML DataWriter profile  -> writer created via profile (not a BlankWriter)
+ * - Topic name has no matching XML profile              -> writer created via fallback QoS (not a BlankWriter)
+ */
+TEST(ParticipantsCreationgTest, writer_topic_profile_lookup)
+{
+    // Load an XML profile whose name matches the topic we will use in the first case
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_writer profile_name="topic_with_profile">
+                    <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+                </data_writer>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+    std::shared_ptr<core::DiscoveryDatabase> discovery_database(new core::DiscoveryDatabase());
+
+    std::shared_ptr<participants::XmlParticipantConfiguration> conf(
+        new participants::XmlParticipantConfiguration());
+    conf->id = core::types::ParticipantId("TestParticipant");
+
+    participants::dds::XmlParticipant participant(conf, payload_pool, discovery_database);
+    participant.init();
+
+    // Case 1: profile exists for this topic name -> profile path taken
+    core::types::DdsTopic topic_with_profile;
+    topic_with_profile.m_topic_name = "topic_with_profile";
+    topic_with_profile.type_name = "TestType";
+
+    auto writer_with_profile = participant.create_writer(topic_with_profile);
+    EXPECT_NE(nullptr, writer_with_profile);
+    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankWriter*>(writer_with_profile.get()));
+
+    // Case 2: no profile for this topic name -> fallback path taken
+    core::types::DdsTopic topic_without_profile;
+    topic_without_profile.m_topic_name = "topic_without_profile";
+    topic_without_profile.type_name = "TestType";
+
+    auto writer_without_profile = participant.create_writer(topic_without_profile);
+    EXPECT_NE(nullptr, writer_without_profile);
+    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankWriter*>(writer_without_profile.get()));
+}
+
+/**
+ * Test that reader creation falls back correctly depending on whether a matching XML profile exists.
+ *
+ * CASES:
+ * - Topic name matches a loaded XML DataReader profile  -> reader created via profile (not a BlankReader)
+ * - Topic name has no matching XML profile              -> reader created via fallback QoS (not a BlankReader)
+ */
+TEST(ParticipantsCreationgTest, reader_topic_profile_lookup)
+{
+    participants::XmlHandlerConfiguration xml_conf;
+    xml_conf.raw.set_value(
+        R"(<?xml version="1.0" encoding="utf-8"?>
+        <dds xmlns="http://www.eprosima.com">
+            <profiles>
+                <data_reader profile_name="topic_with_reader_profile">
+                    <historyMemoryPolicy>DYNAMIC</historyMemoryPolicy>
+                </data_reader>
+            </profiles>
+        </dds>)");
+    ASSERT_EQ(participants::XmlHandler::load_xml(xml_conf), utils::ReturnCode::RETCODE_OK);
+
+    std::shared_ptr<core::PayloadPool> payload_pool(new core::FastPayloadPool());
+    std::shared_ptr<core::DiscoveryDatabase> discovery_database(new core::DiscoveryDatabase());
+
+    std::shared_ptr<participants::XmlParticipantConfiguration> conf(
+        new participants::XmlParticipantConfiguration());
+    conf->id = core::types::ParticipantId("TestReaderParticipant");
+
+    participants::dds::XmlParticipant participant(conf, payload_pool, discovery_database);
+    participant.init();
+
+    // Case 1: profile exists for this topic name -> profile path taken
+    core::types::DdsTopic topic_with_profile;
+    topic_with_profile.m_topic_name = "topic_with_reader_profile";
+    topic_with_profile.type_name = "TestType";
+
+    auto reader_with_profile = participant.create_reader(topic_with_profile);
+    EXPECT_NE(nullptr, reader_with_profile);
+    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankReader*>(reader_with_profile.get()));
+
+    // Case 2: no profile for this topic name -> fallback path taken
+    core::types::DdsTopic topic_without_profile;
+    topic_without_profile.m_topic_name = "topic_without_reader_profile";
+    topic_without_profile.type_name = "TestType";
+
+    auto reader_without_profile = participant.create_reader(topic_without_profile);
+    EXPECT_NE(nullptr, reader_without_profile);
+    EXPECT_EQ(nullptr, dynamic_cast<participants::BlankReader*>(reader_without_profile.get()));
 }
 
 int main(

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -184,7 +184,7 @@ constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration
 constexpr const char* XML_RAW_TAG("raw"); //! Xml RAW as string
 constexpr const char* XML_FILES_TAG("files"); //! XML files
 constexpr const char* XML_PARTICIPANT_PROFILE_TAG("profile"); //! Xml profile to participant
-constexpr const char* XML_OVERRIDE_TAG("xml-override"); //! YAML QoS override of XML profile QoS
+constexpr const char* ENDPOINT_QOS_MODE_TAG("endpoint-qos-mode"); //! YAML QoS override of XML profile QoS
 
 // Old versions tags
 constexpr const char* PARTICIPANT_KIND_TAG_V1("type"); //! Participant Kind

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -185,6 +185,7 @@ constexpr const char* XML_RAW_TAG("raw"); //! Xml RAW as string
 constexpr const char* XML_FILES_TAG("files"); //! XML files
 constexpr const char* XML_PARTICIPANT_PROFILE_TAG("profile"); //! Xml profile to participant
 constexpr const char* ENDPOINT_QOS_MODE_TAG("endpoint-qos-mode"); //! YAML QoS override of XML profile QoS
+constexpr const char* ENDPOINT_PROFILE_NAME_TAG("endpoint-profile-name"); //! XML profile name to use for endpoint QoS lookup
 
 // Old versions tags
 constexpr const char* PARTICIPANT_KIND_TAG_V1("type"); //! Participant Kind

--- a/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
+++ b/ddspipe_yaml/include/ddspipe_yaml/yaml_configuration_tags.hpp
@@ -184,6 +184,7 @@ constexpr const char* XML_TAG("xml"); //! Tag to read xml configuration
 constexpr const char* XML_RAW_TAG("raw"); //! Xml RAW as string
 constexpr const char* XML_FILES_TAG("files"); //! XML files
 constexpr const char* XML_PARTICIPANT_PROFILE_TAG("profile"); //! Xml profile to participant
+constexpr const char* XML_OVERRIDE_TAG("xml-override"); //! YAML QoS override of XML profile QoS
 
 // Old versions tags
 constexpr const char* PARTICIPANT_KIND_TAG_V1("type"); //! Participant Kind

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -171,6 +171,12 @@ void YamlReader::fill(
     {
         fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, PARTICIPANT_QOS_TAG), version);
     }
+
+    // Optional xml-override flag
+    if (YamlReader::is_tag_present(yml, XML_OVERRIDE_TAG))
+    {
+        object.xml_override = get<bool>(yml, XML_OVERRIDE_TAG, version);
+    }
 }
 
 template<>

--- a/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_participants.cpp
@@ -172,11 +172,6 @@ void YamlReader::fill(
         fill<TopicQoS>(object.topic_qos, get_value_in_tag(yml, PARTICIPANT_QOS_TAG), version);
     }
 
-    // Optional xml-override flag
-    if (YamlReader::is_tag_present(yml, XML_OVERRIDE_TAG))
-    {
-        object.xml_override = get<bool>(yml, XML_OVERRIDE_TAG, version);
-    }
 }
 
 template<>
@@ -331,6 +326,26 @@ void YamlReader::fill(
     if (YamlReader::is_tag_present(yml, IS_REPEATER_TAG))
     {
         object.is_repeater = YamlReader::get<bool>(yml, IS_REPEATER_TAG, version);
+    }
+
+    // Optional endpoint QoS mode
+    if (YamlReader::is_tag_present(yml, ENDPOINT_QOS_MODE_TAG))
+    {
+        std::string mode_str = get<std::string>(yml, ENDPOINT_QOS_MODE_TAG, version);
+        if (mode_str == "xml-overridable")
+        {
+            object.endpoint_qos_mode = participants::EndpointQoSMode::XML_OVERRIDABLE;
+        }
+        else if (mode_str == "xml-standalone")
+        {
+            object.endpoint_qos_mode = participants::EndpointQoSMode::XML_STANDALONE;
+        }
+        else
+        {
+            throw eprosima::utils::ConfigurationException(
+                      utils::Formatter() << "Unknown endpoint-qos-mode value: " << mode_str
+                                         << ". Valid values are: xml-standalone, xml-overridable.");
+        }
     }
 }
 

--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -450,6 +450,12 @@ void YamlReader::fill(
     {
         object.downsampling.set_value(get_positive_int(yml, QOS_DOWNSAMPLING_TAG));
     }
+
+    // Endpoint profile name optional
+    if (is_tag_present(yml, ENDPOINT_PROFILE_NAME_TAG))
+    {
+        object.endpoint_profile_name.set_value(get<std::string>(yml, ENDPOINT_PROFILE_NAME_TAG, version));
+    }
 }
 
 /************************


### PR DESCRIPTION
Included support for topic-name profile lookup by adding `create_datawriter_with_profile()` as the default path in CommonWriter.cpp, with fallback to `create_datawriter()` when needed.

Added a new test, `writer_topic_profile_lookup()`, in ParticipantsCreationgTest.cpp to validate the feature, and registered it in CMakeLists.txt.


## DDSPIPE TOOLS
- Fast-DDS-Spy:  https://github.com/eProsima/Fast-DDS-spy/actions/runs/28852357540 🟡(failing the same tests as the nightly, a new PR will be addressed)
- DDS-Record-Replay:  https://github.com/eProsima/DDS-Record-Replay/actions/runs/28852378040 🟢
- DDS-Router: https://github.com/eProsima/DDS-Router/actions/runs/28852419070 🟢
- DDS-Enabler: https://github.com/eProsima/DDS-Enabler/actions/runs/28852423339 🟢