### PR TITLE
[#25493] Fix DiscoveryDatabase endpoint cleanup for inactive updates and shutdown

### DIFF
--- a/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
+++ b/ddspipe_core/include/ddspipe_core/dynamic/DiscoveryDatabase.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <set>
 #include <shared_mutex>
 #include <string>
 #include <thread>
@@ -263,7 +264,7 @@ protected:
     //! Database of endpoints indexed by guid
     std::map<types::Guid, types::Endpoint> entities_;
 
-    //! Database of endpoints indexed by guid
+    //! Database of filtered endpoint GUIDs
     std::set<types::Guid> entities_filter_;
 
     //! Mutex to guard queries to the database

--- a/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
@@ -76,6 +76,12 @@ void DiscoveryDatabase::stop() noexcept
     {
         logDebug(DDSPIPE_DISCOVERY_DATABASE, "Processing thread routine already stopped.");
     }
+
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+        entities_.clear();
+        entities_filter_.clear();
+    }
 }
 
 bool DiscoveryDatabase::topic_exists(
@@ -107,6 +113,7 @@ bool DiscoveryDatabase::add_endpoint_(
 {
     {
         std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+        entities_filter_.erase(new_endpoint.guid);
 
         auto it = entities_.find(new_endpoint.guid);
         if (it != entities_.end())
@@ -151,8 +158,14 @@ bool DiscoveryDatabase::add_endpoint_(
 bool DiscoveryDatabase::update_endpoint_(
         const Endpoint& endpoint_to_update)
 {
+    if (!endpoint_to_update.active)
+    {
+        return erase_endpoint_(endpoint_to_update) == utils::ReturnCode::RETCODE_OK;
+    }
+
     {
         std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+        entities_filter_.erase(endpoint_to_update.guid);
 
         auto it = entities_.find(endpoint_to_update.guid);
         if (it == entities_.end())
@@ -185,14 +198,18 @@ bool DiscoveryDatabase::update_endpoint_(
 utils::ReturnCode DiscoveryDatabase::erase_endpoint_(
         const Endpoint& endpoint_to_erase)
 {
+    bool endpoint_erased = false;
+
     {
         std::unique_lock<std::shared_timed_mutex> lock(mutex_);
 
         EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY_DATABASE, "Erasing Endpoint " << endpoint_to_erase << ".");
 
         auto erased = entities_.erase(endpoint_to_erase.guid);
+        auto filtered_erased = entities_filter_.erase(endpoint_to_erase.guid);
+        endpoint_erased = erased > 0;
 
-        if (erased == 0)
+        if (erased == 0 && filtered_erased == 0)
         {
             throw utils::InconsistencyException(
                       utils::Formatter() <<
@@ -201,10 +218,13 @@ utils::ReturnCode DiscoveryDatabase::erase_endpoint_(
         }
     }
 
-    std::lock_guard<std::mutex> lock(callbacks_mutex_);
-    for (auto erased_endpoint_callback : erased_endpoint_callbacks_)
+    if (endpoint_erased)
     {
-        erased_endpoint_callback(endpoint_to_erase);
+        std::lock_guard<std::mutex> lock(callbacks_mutex_);
+        for (auto erased_endpoint_callback : erased_endpoint_callbacks_)
+        {
+            erased_endpoint_callback(endpoint_to_erase);
+        }
     }
 
     return utils::ReturnCode::RETCODE_OK;
@@ -213,6 +233,7 @@ utils::ReturnCode DiscoveryDatabase::erase_endpoint_(
 void DiscoveryDatabase::add_filtered_endpoint(
         const types::Guid guid)
 {
+    std::unique_lock<std::shared_timed_mutex> lock(mutex_);
     entities_filter_.insert(guid);
 }
 
@@ -237,6 +258,7 @@ void DiscoveryDatabase::erase_endpoint(
 bool DiscoveryDatabase::exists_filtered_endpoint(
         const Guid endpoint_guid)
 {
+    std::shared_lock<std::shared_timed_mutex> lock(mutex_);
     return entities_filter_.find(endpoint_guid) != entities_filter_.end();
 }
 

--- a/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
@@ -160,6 +160,27 @@ bool DiscoveryDatabase::update_endpoint_(
 {
     if (!endpoint_to_update.active)
     {
+        bool filtered_erased = false;
+        bool endpoint_exists = false;
+
+        {
+            std::unique_lock<std::shared_timed_mutex> lock(mutex_);
+            filtered_erased = entities_filter_.erase(endpoint_to_update.guid) > 0;
+            endpoint_exists = entities_.find(endpoint_to_update.guid) != entities_.end();
+        }
+
+        if (!endpoint_exists)
+        {
+            if (filtered_erased)
+            {
+                return true;
+            }
+
+            throw utils::InconsistencyException(
+                      utils::Formatter()
+                          << "Error updating Endpoint in database. Endpoint entry not found." << endpoint_to_update);
+        }
+
         return erase_endpoint_(endpoint_to_update) == utils::ReturnCode::RETCODE_OK;
     }
 
@@ -206,16 +227,17 @@ utils::ReturnCode DiscoveryDatabase::erase_endpoint_(
         EPROSIMA_LOG_INFO(DDSPIPE_DISCOVERY_DATABASE, "Erasing Endpoint " << endpoint_to_erase << ".");
 
         auto erased = entities_.erase(endpoint_to_erase.guid);
-        auto filtered_erased = entities_filter_.erase(endpoint_to_erase.guid);
         endpoint_erased = erased > 0;
 
-        if (erased == 0 && filtered_erased == 0)
+        if (erased == 0)
         {
             throw utils::InconsistencyException(
                       utils::Formatter()
                           << "Error erasing Endpoint " << endpoint_to_erase
                           << " from database. Endpoint entry not found.");
         }
+
+        entities_filter_.erase(endpoint_to_erase.guid);
     }
 
     if (endpoint_erased)

--- a/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
+++ b/ddspipe_core/src/cpp/dynamic/DiscoveryDatabase.cpp
@@ -122,8 +122,8 @@ bool DiscoveryDatabase::add_endpoint_(
             if (it->second.active)
             {
                 throw utils::InconsistencyException(
-                          utils::Formatter() <<
-                              "Error adding Endpoint to database. Endpoint already exists." << new_endpoint);
+                          utils::Formatter()
+                              << "Error adding Endpoint to database. Endpoint already exists." << new_endpoint);
             }
             else
             {
@@ -172,8 +172,8 @@ bool DiscoveryDatabase::update_endpoint_(
         {
             // Entry not found
             throw utils::InconsistencyException(
-                      utils::Formatter() <<
-                          "Error updating Endpoint in database. Endpoint entry not found." << endpoint_to_update);
+                      utils::Formatter()
+                          << "Error updating Endpoint in database. Endpoint entry not found." << endpoint_to_update);
         }
         else
         {
@@ -212,9 +212,9 @@ utils::ReturnCode DiscoveryDatabase::erase_endpoint_(
         if (erased == 0 && filtered_erased == 0)
         {
             throw utils::InconsistencyException(
-                      utils::Formatter() <<
-                          "Error erasing Endpoint " << endpoint_to_erase <<
-                          " from database. Endpoint entry not found.");
+                      utils::Formatter()
+                          << "Error erasing Endpoint " << endpoint_to_erase
+                          << " from database. Endpoint entry not found.");
         }
     }
 
@@ -277,9 +277,9 @@ Endpoint DiscoveryDatabase::get_endpoint(
         }
 
         throw utils::InconsistencyException(
-                  utils::Formatter() <<
-                      "Error retrieving Endpoint with GUID " << endpoint_guid <<
-                      " from database. Endpoint entry not found.");
+                  utils::Formatter()
+                      << "Error retrieving Endpoint with GUID " << endpoint_guid
+                      << " from database. Endpoint entry not found.");
     }
 
     return it->second;

--- a/ddspipe_core/test/unittest/dynamic/CMakeLists.txt
+++ b/ddspipe_core/test/unittest/dynamic/CMakeLists.txt
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 add_subdirectory(allowed_topic_list)
+add_subdirectory(discovery_database)
 # TODO uncomment when ready
 # add_subdirectory(participants_database)

--- a/ddspipe_core/test/unittest/dynamic/discovery_database/CMakeLists.txt
+++ b/ddspipe_core/test/unittest/dynamic/discovery_database/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(TEST_NAME DiscoveryDatabaseTest)
+
+set(TEST_SOURCES
+        DiscoveryDatabaseTest.cpp
+    )
+
+file(
+    GLOB_RECURSE LIBRARY_SOURCES
+        "${PROJECT_SOURCE_DIR}/src/cpp/*.c*"
+        "${PROJECT_SOURCE_DIR}/include/*.h*"
+        "${PROJECT_SOURCE_DIR}/include/*.ipp"
+    )
+
+all_library_sources(
+        "${TEST_SOURCES}"
+        "${LIBRARY_SOURCES}"
+    )
+
+set(TEST_LIST
+        inactive_update_erases_endpoint
+        stop_clears_stored_endpoints
+    )
+
+set(TEST_EXTRA_LIBRARIES
+        fastcdr
+        fastdds
+        cpp_utils
+    )
+
+add_unittest_executable(
+        "${TEST_NAME}"
+        "${TEST_SOURCES}"
+        "${TEST_LIST}"
+        "${TEST_EXTRA_LIBRARIES}"
+    )

--- a/ddspipe_core/test/unittest/dynamic/discovery_database/CMakeLists.txt
+++ b/ddspipe_core/test/unittest/dynamic/discovery_database/CMakeLists.txt
@@ -32,6 +32,8 @@ all_library_sources(
 
 set(TEST_LIST
         inactive_update_erases_endpoint
+        inactive_update_clears_filtered_endpoint
+        erase_does_not_remove_filtered_only_endpoint
         stop_clears_stored_endpoints
     )
 

--- a/ddspipe_core/test/unittest/dynamic/discovery_database/DiscoveryDatabaseTest.cpp
+++ b/ddspipe_core/test/unittest/dynamic/discovery_database/DiscoveryDatabaseTest.cpp
@@ -101,6 +101,91 @@ TEST(DiscoveryDatabaseTest, inactive_update_erases_endpoint)
 }
 
 /**
+ * Test that updating a filtered-only endpoint as inactive clears the filter entry
+ *
+ * STEPS:
+ * - add one filtered endpoint GUID
+ * - update the same GUID as inactive
+ * - verify the filter entry is removed and no erase callback is triggered
+ */
+TEST(DiscoveryDatabaseTest, inactive_update_clears_filtered_endpoint)
+{
+    DiscoveryDatabase discovery_database;
+    discovery_database.start();
+
+    auto endpoint = random_endpoint(6);
+    endpoint.active = false;
+
+    std::atomic<uint32_t> erased_callbacks{0};
+
+    discovery_database.add_endpoint_erased_callback(
+        [&](
+            types::Endpoint)
+        {
+            ++erased_callbacks;
+        });
+
+    discovery_database.add_filtered_endpoint(endpoint.guid);
+    eprosima::utils::sleep_for(test::WAIT_TIME_MS);
+
+    ASSERT_TRUE(discovery_database.exists_filtered_endpoint(endpoint.guid));
+    ASSERT_FALSE(discovery_database.endpoint_exists(endpoint.guid));
+
+    discovery_database.update_endpoint(endpoint);
+    eprosima::utils::sleep_for(test::WAIT_TIME_MS);
+
+    EXPECT_FALSE(discovery_database.exists_filtered_endpoint(endpoint.guid));
+    EXPECT_FALSE(discovery_database.endpoint_exists(endpoint.guid));
+    EXPECT_TRUE(test::get_all_endpoints(discovery_database).empty());
+    EXPECT_EQ(erased_callbacks.load(), 0u);
+    EXPECT_THROW(discovery_database.get_endpoint(endpoint.guid), eprosima::utils::InconsistencyException);
+
+    discovery_database.stop();
+}
+
+/**
+ * Test that erasing a filtered-only endpoint keeps the filter entry untouched
+ *
+ * STEPS:
+ * - add one filtered endpoint GUID
+ * - request an erase for the same GUID
+ * - verify the filter entry remains because there is no stored endpoint to erase
+ */
+TEST(DiscoveryDatabaseTest, erase_does_not_remove_filtered_only_endpoint)
+{
+    DiscoveryDatabase discovery_database;
+    discovery_database.start();
+
+    auto endpoint = random_endpoint(8);
+
+    std::atomic<uint32_t> erased_callbacks{0};
+
+    discovery_database.add_endpoint_erased_callback(
+        [&](
+            types::Endpoint)
+        {
+            ++erased_callbacks;
+        });
+
+    discovery_database.add_filtered_endpoint(endpoint.guid);
+    eprosima::utils::sleep_for(test::WAIT_TIME_MS);
+
+    ASSERT_TRUE(discovery_database.exists_filtered_endpoint(endpoint.guid));
+    ASSERT_FALSE(discovery_database.endpoint_exists(endpoint.guid));
+
+    discovery_database.erase_endpoint(endpoint);
+    eprosima::utils::sleep_for(test::WAIT_TIME_MS);
+
+    EXPECT_TRUE(discovery_database.exists_filtered_endpoint(endpoint.guid));
+    EXPECT_FALSE(discovery_database.endpoint_exists(endpoint.guid));
+    EXPECT_TRUE(test::get_all_endpoints(discovery_database).empty());
+    EXPECT_EQ(erased_callbacks.load(), 0u);
+    EXPECT_EQ(discovery_database.get_endpoint(endpoint.guid), types::Endpoint{});
+
+    discovery_database.stop();
+}
+
+/**
  * Test that stopping the discovery database clears stored endpoints and filtered endpoints
  *
  * STEPS:

--- a/ddspipe_core/test/unittest/dynamic/discovery_database/DiscoveryDatabaseTest.cpp
+++ b/ddspipe_core/test/unittest/dynamic/discovery_database/DiscoveryDatabaseTest.cpp
@@ -1,0 +1,141 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <cstdint>
+
+#include <cpp_utils/testing/gtest_aux.hpp>
+#include <gtest/gtest.h>
+
+#include <cpp_utils/exception/InconsistencyException.hpp>
+#include <cpp_utils/time/time_utils.hpp>
+
+#include <ddspipe_core/dynamic/DiscoveryDatabase.hpp>
+#include <ddspipe_core/testing/random_values.hpp>
+
+using namespace eprosima::ddspipe::core;
+using namespace eprosima::ddspipe::core::testing;
+
+namespace test {
+
+constexpr uint32_t WAIT_TIME_MS = 50;
+
+std::map<types::Guid, types::Endpoint> get_all_endpoints(
+        const DiscoveryDatabase& discovery_database)
+{
+    return discovery_database.get_endpoints(
+        [](
+            const types::Endpoint&)
+        {
+            return true;
+        });
+}
+
+} // namespace test
+
+/**
+ * Test that updating an endpoint as inactive removes it from the discovery database
+ *
+ * STEPS:
+ * - add one active endpoint
+ * - verify it is stored in the database
+ * - update the same endpoint as inactive
+ * - verify it is erased, the erase callback is triggered, and further access fails
+ */
+TEST(DiscoveryDatabaseTest, inactive_update_erases_endpoint)
+{
+    DiscoveryDatabase discovery_database;
+    discovery_database.start();
+
+    auto endpoint = random_endpoint(5);
+    endpoint.active = true;
+
+    std::atomic<uint32_t> updated_callbacks{0};
+    std::atomic<uint32_t> erased_callbacks{0};
+    std::atomic<bool> erased_same_guid{false};
+
+    discovery_database.add_endpoint_updated_callback(
+        [&](
+            types::Endpoint)
+        {
+            ++updated_callbacks;
+        });
+
+    discovery_database.add_endpoint_erased_callback(
+        [&](
+            types::Endpoint erased_endpoint)
+        {
+            erased_same_guid.store(erased_endpoint.guid == endpoint.guid);
+            ++erased_callbacks;
+        });
+
+    discovery_database.add_endpoint(endpoint);
+    eprosima::utils::sleep_for(test::WAIT_TIME_MS);
+
+    ASSERT_TRUE(discovery_database.endpoint_exists(endpoint.guid));
+    ASSERT_EQ(test::get_all_endpoints(discovery_database).size(), 1u);
+
+    endpoint.active = false;
+    discovery_database.update_endpoint(endpoint);
+    eprosima::utils::sleep_for(test::WAIT_TIME_MS);
+
+    EXPECT_FALSE(discovery_database.endpoint_exists(endpoint.guid));
+    EXPECT_TRUE(test::get_all_endpoints(discovery_database).empty());
+    EXPECT_EQ(updated_callbacks.load(), 0u);
+    EXPECT_EQ(erased_callbacks.load(), 1u);
+    EXPECT_TRUE(erased_same_guid.load());
+    EXPECT_THROW(discovery_database.get_endpoint(endpoint.guid), eprosima::utils::InconsistencyException);
+
+    discovery_database.stop();
+}
+
+/**
+ * Test that stopping the discovery database clears stored endpoints and filtered endpoints
+ *
+ * STEPS:
+ * - add one active endpoint and one filtered endpoint
+ * - verify both are stored
+ * - stop the discovery database
+ * - verify both entries are removed from the internal state
+ */
+TEST(DiscoveryDatabaseTest, stop_clears_stored_endpoints)
+{
+    DiscoveryDatabase discovery_database;
+    discovery_database.start();
+
+    auto endpoint = random_endpoint(7);
+    endpoint.active = true;
+    auto filtered_guid = random_guid(11);
+
+    discovery_database.add_endpoint(endpoint);
+    discovery_database.add_filtered_endpoint(filtered_guid);
+    eprosima::utils::sleep_for(test::WAIT_TIME_MS);
+
+    ASSERT_TRUE(discovery_database.endpoint_exists(endpoint.guid));
+    ASSERT_TRUE(discovery_database.exists_filtered_endpoint(filtered_guid));
+
+    discovery_database.stop();
+
+    EXPECT_FALSE(discovery_database.endpoint_exists(endpoint.guid));
+    EXPECT_FALSE(discovery_database.exists_filtered_endpoint(filtered_guid));
+    EXPECT_TRUE(test::get_all_endpoints(discovery_database).empty());
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/ddspipe_participants/include/ddspipe_participants/utils/utils.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/utils/utils.hpp
@@ -46,6 +46,18 @@ core::types::SpecificEndpointQoS specific_qos_of_writer_(
         const core::DiscoveryDatabase& database,
         const core::types::Guid& guid);
 
+/**
+ * @brief Try to get the QoS from a Writer from the \c DiscoveryDatabase .
+ *
+ * @retval true if the writer is stored in the discovery database.
+ * @retval false if the writer is no longer available in the discovery database.
+ */
+DDSPIPE_PARTICIPANTS_DllAPI
+bool try_specific_qos_of_writer_(
+        const core::DiscoveryDatabase& database,
+        const core::types::Guid& guid,
+        core::types::SpecificEndpointQoS& specific_qos) noexcept;
+
 DDSPIPE_PARTICIPANTS_DllAPI
 bool come_from_same_participant_(
         const fastdds::rtps::GUID_t src_guid,

--- a/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/dds/SpecificQoSReader.cpp
@@ -16,7 +16,6 @@
 #include <fastdds/rtps/RTPSDomain.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 
-#include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/Log.hpp>
 
 #include <ddspipe_participants/reader/dds/SpecificQoSReader.hpp>
@@ -57,21 +56,18 @@ void SpecificQoSReader::fill_received_data_(
         return;
     }
 
-    // Find qos of writer
-    try
+    // During teardown it is expected that late samples can outlive writer discovery data
+    if (detail::try_specific_qos_of_writer_(*discovery_database_, data_to_fill.source_guid, data_to_fill.writer_qos))
     {
-        data_to_fill.writer_qos = detail::specific_qos_of_writer_(*discovery_database_, data_to_fill.source_guid);
         logDebug(
             DDSPIPE_SpecificQoSReader,
             "Set QoS " << data_to_fill.writer_qos << " for data from " << data_to_fill.source_guid << ".");
     }
-    catch (const utils::InconsistencyException&)
+    else
     {
-        // Get a message from a writer not in database, this is an error.
-        // Remove data and make as it has not been received.
-        EPROSIMA_LOG_ERROR(
+        logDebug(
             DDSPIPE_SpecificQoSReader,
-            "Received a message from Writer " << data_to_fill.source_guid << " that is not stored in DB.");
+            "Skipping writer QoS lookup for removed writer " << data_to_fill.source_guid << ".");
     }
 }
 

--- a/ddspipe_participants/src/cpp/reader/rtps/SpecificQoSReader.cpp
+++ b/ddspipe_participants/src/cpp/reader/rtps/SpecificQoSReader.cpp
@@ -16,7 +16,6 @@
 #include <fastdds/rtps/RTPSDomain.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 
-#include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/Log.hpp>
 
 #include <ddspipe_participants/reader/rtps/SpecificQoSReader.hpp>
@@ -58,21 +57,18 @@ void SpecificQoSReader::fill_received_data_(
         return;
     }
 
-    // Find qos of writer
-    try
+    // During teardown it is expected that late samples can outlive writer discovery data
+    if (detail::try_specific_qos_of_writer_(*discovery_database_, data_to_fill.source_guid, data_to_fill.writer_qos))
     {
-        data_to_fill.writer_qos = detail::specific_qos_of_writer_(*discovery_database_, data_to_fill.source_guid);
         logDebug(
             DDSPIPE_SpecificQoSReader,
             "Set QoS " << data_to_fill.writer_qos << " for data from " << data_to_fill.source_guid << ".");
     }
-    catch (const utils::InconsistencyException&)
+    else
     {
-        // Get a message from a writer not in database, this is an error.
-        // Remove data and make as it has not been received.
-        EPROSIMA_LOG_ERROR(
+        logDebug(
             DDSPIPE_SpecificQoSReader,
-            "Received a message from Writer " << data_to_fill.source_guid << " that is not stored in DB.");
+            "Skipping writer QoS lookup for removed writer " << data_to_fill.source_guid << ".");
     }
 }
 

--- a/ddspipe_participants/src/cpp/utils/utils.cpp
+++ b/ddspipe_participants/src/cpp/utils/utils.cpp
@@ -58,8 +58,8 @@ core::types::Endpoint create_common_endpoint_from_info_(
     else
     {
         utils::tsnh(
-            utils::Formatter() <<
-                "Invalid ReliabilityQoS value found while parsing DiscoveryInfo for Endpoint creation.");
+            utils::Formatter()
+                << "Invalid ReliabilityQoS value found while parsing DiscoveryInfo for Endpoint creation.");
     }
     // Set Topic with Partitions
     endpoint.topic.topic_qos.use_partitions.set_value(!info.partition.empty());

--- a/ddspipe_participants/src/cpp/utils/utils.cpp
+++ b/ddspipe_participants/src/cpp/utils/utils.cpp
@@ -15,6 +15,7 @@
 #include <fastdds/rtps/builtin/data/PublicationBuiltinTopicData.hpp>
 #include <fastdds/rtps/builtin/data/SubscriptionBuiltinTopicData.hpp>
 
+#include <cpp_utils/exception/InconsistencyException.hpp>
 #include <cpp_utils/utils.hpp>
 
 #include <ddspipe_core/types/data/RtpsPayloadData.hpp>
@@ -154,6 +155,30 @@ core::types::SpecificEndpointQoS specific_qos_of_writer_(
         const core::types::Guid& guid)
 {
     return database.get_endpoint(guid).specific_qos;
+}
+
+bool try_specific_qos_of_writer_(
+        const core::DiscoveryDatabase& database,
+        const core::types::Guid& guid,
+        core::types::SpecificEndpointQoS& specific_qos) noexcept
+{
+    specific_qos = {};
+
+    try
+    {
+        const auto endpoint = database.get_endpoint(guid);
+        if (!endpoint.guid.is_valid())
+        {
+            return false;
+        }
+
+        specific_qos = endpoint.specific_qos;
+        return true;
+    }
+    catch (const utils::InconsistencyException&)
+    {
+        return false;
+    }
 }
 
 bool come_from_same_participant_(


### PR DESCRIPTION
## Description

This PR fixes endpoint cleanup in DiscoveryDatabase so inactive endpoint updates are handled as real erases, and stale endpoint state is not kept after shutdown.

## Changes
- Treat update_endpoint() calls with active == false as an erase operation
- Remove endpoint GUIDs from both: `entities_` / `entities_filter_`
- Only trigger erased-endpoint callbacks when a real stored endpoint was erased
- Clear stored endpoints and filtered GUIDs on DiscoveryDatabase::stop()