### PR TITLE
[#20274] Add missing tests of 'Yaml validator v2'

### DIFF
--- a/ddspipe_yaml/test/unittest/yaml_reader/CMakeLists.txt
+++ b/ddspipe_yaml/test/unittest/yaml_reader/CMakeLists.txt
@@ -17,6 +17,7 @@
 ###################
 
 add_subdirectory(scalar)
+add_subdirectory(participants)
 add_subdirectory(forwarding_routes)
 add_subdirectory(log_configuration)
 add_subdirectory(monitoring)

--- a/ddspipe_yaml/test/unittest/yaml_reader/participants/CMakeLists.txt
+++ b/ddspipe_yaml/test/unittest/yaml_reader/participants/CMakeLists.txt
@@ -1,0 +1,49 @@
+# Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#################################
+# Yaml Reader Participants Test #
+#################################
+
+set(TEST_NAME YamlReaderParticipantsTest)
+
+set(TEST_SOURCES
+        ${PROJECT_SOURCE_DIR}/src/cpp/YamlReader_generic.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/YamlReader_participants.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/YamlReader_types.cpp
+        YamlReaderParticipantsTest.cpp
+    )
+
+set(TEST_LIST
+        read_participant_and_echo_configuration
+        read_simple_participant_optional_fields
+        read_discovery_server_participant_across_versions
+        read_initial_peers_and_xml_participant_configuration
+        xml_handler_configuration_invalid_file_message
+    )
+
+set(TEST_EXTRA_LIBRARIES
+        yaml-cpp
+        fastcdr
+        fastdds
+        cpp_utils
+        ddspipe_core
+        ddspipe_participants
+    )
+
+add_unittest_executable(
+    "${TEST_NAME}"
+    "${TEST_SOURCES}"
+    "${TEST_LIST}"
+    "${TEST_EXTRA_LIBRARIES}")

--- a/ddspipe_yaml/test/unittest/yaml_reader/participants/YamlReaderParticipantsTest.cpp
+++ b/ddspipe_yaml/test/unittest/yaml_reader/participants/YamlReaderParticipantsTest.cpp
@@ -1,0 +1,266 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sstream>
+
+#include <cpp_utils/testing/gtest_aux.hpp>
+#include <gtest/gtest.h>
+
+#include <ddspipe_core/types/dds/CustomTransport.hpp>
+#include <ddspipe_core/types/dds/GuidPrefix.hpp>
+
+#include <ddspipe_participants/configuration/DiscoveryServerParticipantConfiguration.hpp>
+#include <ddspipe_participants/configuration/EchoParticipantConfiguration.hpp>
+#include <ddspipe_participants/configuration/InitialPeersParticipantConfiguration.hpp>
+#include <ddspipe_participants/configuration/ParticipantConfiguration.hpp>
+#include <ddspipe_participants/configuration/SimpleParticipantConfiguration.hpp>
+#include <ddspipe_participants/configuration/XmlParticipantConfiguration.hpp>
+#include <ddspipe_participants/types/address/Address.hpp>
+#include <ddspipe_participants/types/security/tls/TlsConfiguration.hpp>
+#include <ddspipe_participants/xml/XmlHandlerConfiguration.hpp>
+
+#include <ddspipe_yaml/YamlReader.hpp>
+#include <ddspipe_yaml/testing/generate_yaml.hpp>
+#include <ddspipe_yaml/yaml_configuration_tags.hpp>
+
+using namespace eprosima;
+using namespace eprosima::ddspipe;
+using namespace eprosima::ddspipe::yaml;
+using namespace eprosima::ddspipe::yaml::testing;
+
+namespace test {
+
+participants::types::Address make_udp_address(
+        const std::string& ip,
+        uint16_t port)
+{
+    return participants::types::Address(
+        ip,
+        port,
+        port,
+        participants::types::IpVersion::v4,
+        participants::types::TransportProtocol::udp);
+}
+
+participants::types::Address make_tcp_address(
+        const std::string& ip,
+        uint16_t port)
+{
+    return participants::types::Address(
+        ip,
+        port,
+        port,
+        participants::types::IpVersion::v4,
+        participants::types::TransportProtocol::tcp);
+}
+
+Yaml address_sequence(
+        const std::vector<participants::types::Address>& addresses)
+{
+    Yaml yml;
+    for (const auto& address : addresses)
+    {
+        Yaml address_yml;
+        address_to_yaml(address_yml, address);
+        yml.push_back(address_yml);
+    }
+
+    return yml;
+}
+
+Yaml tls_yaml()
+{
+    Yaml yml;
+    yml[TLS_PRIVATE_KEY_TAG] = "server.key";
+    yml[TLS_CERT_TAG] = "server.crt";
+    yml[TLS_DHPARAMS_TAG] = "dh.pem";
+    yml[TLS_PEER_VERIFICATION_TAG] = false;
+    return yml;
+}
+
+} // namespace test
+
+/**
+ * Test that the base participant configuration reads the required id and that
+ * the echo participant reads all its optional boolean flags.
+ */
+TEST(YamlReaderParticipantsTest, read_participant_and_echo_configuration)
+{
+    Yaml participant_yml;
+    participantid_to_yaml(participant_yml, core::types::ParticipantId("base_participant"));
+
+    auto participant = YamlReader::get<participants::ParticipantConfiguration>(participant_yml, LATEST);
+    ASSERT_EQ(participant.id, core::types::ParticipantId("base_participant"));
+
+    Yaml echo_yml = participant_yml;
+    echo_yml[ECHO_DATA_TAG] = true;
+    echo_yml[ECHO_DISCOVERY_TAG] = false;
+    echo_yml[ECHO_VERBOSE_TAG] = true;
+
+    auto echo = YamlReader::get<participants::EchoParticipantConfiguration>(echo_yml, LATEST);
+    ASSERT_EQ(echo.id, core::types::ParticipantId("base_participant"));
+    ASSERT_TRUE(echo.echo_data);
+    ASSERT_FALSE(echo.echo_discovery);
+    ASSERT_TRUE(echo.verbose);
+}
+
+/**
+ * Test that the simple participant configuration reads all optional fields:
+ * domain, whitelist, easy mode ip, transport, ignore flags, and participant QoS.
+ */
+TEST(YamlReaderParticipantsTest, read_simple_participant_optional_fields)
+{
+    Yaml yml;
+    participantid_to_yaml(yml, core::types::ParticipantId("simple_participant"));
+    domain_to_yaml(yml, core::types::DomainId(static_cast<core::types::DomainIdType>(42)));
+    yml[WHITELIST_INTERFACES_TAG].push_back("127.0.0.1");
+    yml[WHITELIST_INTERFACES_TAG].push_back("lo");
+    easy_mode_ip_to_yaml(yml, "192.168.1.50");
+    yml[TRANSPORT_DESCRIPTORS_TRANSPORT_TAG] = TRANSPORT_DESCRIPTORS_UDP_TAG;
+    yml[IGNORE_PARTICIPANT_FLAGS_TAG] = IGNORE_PARTICIPANT_FLAGS_SAME_PROCESS_TAG;
+    yml[PARTICIPANT_QOS_TAG][QOS_RELIABLE_TAG] = true;
+
+    auto participant = YamlReader::get<participants::SimpleParticipantConfiguration>(yml, LATEST);
+
+    ASSERT_EQ(participant.id, core::types::ParticipantId("simple_participant"));
+    ASSERT_EQ(participant.domain.domain_id, 42);
+    ASSERT_EQ(participant.whitelist.size(), 2u);
+    ASSERT_TRUE(participant.whitelist.find("127.0.0.1") != participant.whitelist.end());
+    ASSERT_TRUE(participant.whitelist.find("lo") != participant.whitelist.end());
+    ASSERT_EQ(participant.easy_mode_ip, "192.168.1.50");
+    ASSERT_EQ(participant.transport, core::types::TransportDescriptors::udp_only);
+    ASSERT_EQ(participant.ignore_participant_flags, core::types::IgnoreParticipantFlags::filter_same_process);
+    ASSERT_TRUE(participant.topic_qos.is_reliable());
+}
+
+/**
+ * Test discovery server participant parsing across the versions that differ in
+ * guid-prefix handling, and check optional addresses and TLS configuration.
+ */
+TEST(YamlReaderParticipantsTest, read_discovery_server_participant_across_versions)
+{
+    const auto listening = test::make_udp_address("127.0.0.1", 7400);
+    const auto connection = test::make_tcp_address("192.168.1.20", 7410);
+    const core::types::GuidPrefix guid_prefix("01.0f.00.00.00.00.00.00.00.00.ab.cd");
+
+    // V_1_0 reads the guid directly from the participant root.
+    {
+        Yaml yml;
+        participantid_to_yaml(yml, core::types::ParticipantId("ds_v1"));
+        guid_prefix_to_yaml(yml, guid_prefix);
+
+        auto participant = YamlReader::get<participants::DiscoveryServerParticipantConfiguration>(yml, V_1_0);
+        ASSERT_EQ(participant.id, core::types::ParticipantId("ds_v1"));
+        ASSERT_EQ(participant.discovery_server_guid_prefix, guid_prefix);
+    }
+
+    // V_4_0 uses the dedicated discovery-server-guid tag and parses the optional branches.
+    {
+        Yaml yml;
+        participantid_to_yaml(yml, core::types::ParticipantId("ds_v4"));
+        yml[LISTENING_ADDRESSES_TAG] = test::address_sequence({listening});
+        yml[CONNECTION_ADDRESSES_TAG] = test::address_sequence({connection});
+        yml[TLS_TAG] = test::tls_yaml();
+        discovery_server_guid_prefix_to_yaml(yml, guid_prefix);
+
+        auto participant = YamlReader::get<participants::DiscoveryServerParticipantConfiguration>(yml, V_4_0);
+        ASSERT_EQ(participant.id, core::types::ParticipantId("ds_v4"));
+        ASSERT_EQ(participant.listening_addresses.size(), 1u);
+        ASSERT_EQ(participant.connection_addresses.size(), 1u);
+        ASSERT_EQ(*participant.listening_addresses.begin(), listening);
+        ASSERT_EQ(*participant.connection_addresses.begin(), connection);
+        ASSERT_EQ(participant.discovery_server_guid_prefix, guid_prefix);
+        ASSERT_EQ(participant.tls_configuration.kind, participants::types::TlsKind::both);
+        ASSERT_FALSE(participant.tls_configuration.verify_peer);
+        ASSERT_EQ(participant.tls_configuration.private_key_file, "server.key");
+    }
+
+    // V_5_0 keeps the guid optional.
+    {
+        Yaml yml;
+        participantid_to_yaml(yml, core::types::ParticipantId("ds_v5"));
+
+        auto participant = YamlReader::get<participants::DiscoveryServerParticipantConfiguration>(yml, V_5_0);
+        ASSERT_EQ(participant.id, core::types::ParticipantId("ds_v5"));
+        ASSERT_EQ(participant.discovery_server_guid_prefix, core::types::GuidPrefix());
+    }
+}
+
+/**
+ * Test that the initial peers and xml participant configurations read their
+ * participant-specific optional fields correctly.
+ */
+TEST(YamlReaderParticipantsTest, read_initial_peers_and_xml_participant_configuration)
+{
+    const auto listening = test::make_udp_address("10.0.0.1", 11811);
+    const auto connection = test::make_tcp_address("10.0.0.2", 11812);
+
+    {
+        Yaml yml;
+        participantid_to_yaml(yml, core::types::ParticipantId("initial_peers"));
+        yml[LISTENING_ADDRESSES_TAG] = test::address_sequence({listening});
+        yml[CONNECTION_ADDRESSES_TAG] = test::address_sequence({connection});
+        yml[TLS_TAG] = test::tls_yaml();
+        repeater_to_yaml(yml, true);
+
+        auto participant = YamlReader::get<participants::InitialPeersParticipantConfiguration>(yml, LATEST);
+        ASSERT_EQ(participant.id, core::types::ParticipantId("initial_peers"));
+        ASSERT_TRUE(participant.is_repeater);
+        ASSERT_EQ(participant.listening_addresses.size(), 1u);
+        ASSERT_EQ(participant.connection_addresses.size(), 1u);
+        ASSERT_EQ(*participant.listening_addresses.begin(), listening);
+        ASSERT_EQ(*participant.connection_addresses.begin(), connection);
+        ASSERT_EQ(participant.tls_configuration.kind, participants::types::TlsKind::both);
+    }
+
+    {
+        Yaml yml;
+        participantid_to_yaml(yml, core::types::ParticipantId("xml_participant"));
+        yml[XML_PARTICIPANT_PROFILE_TAG] = "participant_profile";
+        repeater_to_yaml(yml, true);
+
+        auto participant = YamlReader::get<participants::XmlParticipantConfiguration>(yml, LATEST);
+        ASSERT_EQ(participant.id, core::types::ParticipantId("xml_participant"));
+        ASSERT_TRUE(participant.is_repeater);
+        ASSERT_TRUE(participant.participant_profile.is_set());
+        ASSERT_EQ(participant.participant_profile.get_reference(), "participant_profile");
+    }
+}
+
+/**
+ * Test that the XML handler configuration reports the updated missing-file
+ * validation message when a configured XML file is not accessible.
+ */
+TEST(YamlReaderParticipantsTest, xml_handler_configuration_invalid_file_message)
+{
+    participants::XmlHandlerConfiguration conf;
+    conf.files.insert("./missing_xml_handler_configuration_test_file.xml");
+
+    utils::Formatter error_msg;
+    std::ostringstream ss;
+
+    ASSERT_FALSE(conf.is_valid(error_msg));
+    ss << error_msg;
+    ASSERT_EQ(
+        ss.str(),
+        "File ./missing_xml_handler_configuration_test_file.xml does not exist or does not have read access. ");
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/ddspipe_yaml/test/unittest/yaml_reader/scalar/CMakeLists.txt
+++ b/ddspipe_yaml/test/unittest/yaml_reader/scalar/CMakeLists.txt
@@ -32,6 +32,9 @@ set(TEST_LIST
         get_scalar_string
         get_scalar_from_tag
         get_scalar_negative_cases
+        get_positive_and_nonnegative_numbers_from_tag
+        get_list_and_set_helpers
+        get_timestamp
     )
 
 set(TEST_EXTRA_LIBRARIES

--- a/ddspipe_yaml/test/unittest/yaml_reader/scalar/YamlReaderScalarTest.cpp
+++ b/ddspipe_yaml/test/unittest/yaml_reader/scalar/YamlReaderScalarTest.cpp
@@ -16,8 +16,10 @@
 #include <gtest/gtest.h>
 
 #include <cpp_utils/exception/ConfigurationException.hpp>
+#include <cpp_utils/time/time_utils.hpp>
 
 #include <ddspipe_yaml/YamlReader.hpp>
+#include <ddspipe_yaml/yaml_configuration_tags.hpp>
 
 using namespace eprosima;
 using namespace eprosima::ddspipe::yaml;
@@ -331,6 +333,113 @@ TEST(YamlReaderScalarTest, get_scalar_negative_cases)
         yml["2"] = 4;
         ASSERT_TRUE(yml.IsMap());
         ASSERT_THROW(YamlReader::get_scalar<int>(yml), eprosima::utils::ConfigurationException);
+    }
+}
+// TODO. danip
+/**
+ * Check reading nonnegative and positive numeric values from tagged yaml nodes
+ */
+TEST(YamlReaderScalarTest, get_positive_and_nonnegative_numbers_from_tag)
+{
+    // int values
+    {
+        Yaml yml;
+        yml["nonnegative"] = 0;
+        yml["positive"] = 7;
+        yml["negative"] = -1;
+
+        ASSERT_EQ(YamlReader::get_nonnegative_int(yml, "nonnegative"), 0u);
+        ASSERT_EQ(YamlReader::get_positive_int(yml, "positive"), 7u);
+        ASSERT_THROW(YamlReader::get_nonnegative_int(yml, "negative"), eprosima::utils::ConfigurationException);
+        ASSERT_THROW(YamlReader::get_positive_int(yml, "nonnegative"), eprosima::utils::ConfigurationException);
+
+        ASSERT_THROW(YamlReader::get_positive_int(yml, "missing"), eprosima::utils::ConfigurationException);
+    }
+
+    // float values
+    {
+        Yaml yml;
+        yml["nonnegative"] = 0.0f;
+        yml["positive"] = 2.5f;
+        yml["negative"] = -0.25f;
+
+        ASSERT_FLOAT_EQ(YamlReader::get_nonnegative_float(yml, "nonnegative"), 0.0f);
+        ASSERT_FLOAT_EQ(YamlReader::get_positive_float(yml, "positive"), 2.5f);
+        ASSERT_THROW(YamlReader::get_nonnegative_float(yml, "negative"), eprosima::utils::ConfigurationException);
+        ASSERT_THROW(YamlReader::get_positive_float(yml, "nonnegative"), eprosima::utils::ConfigurationException);
+
+        ASSERT_THROW(YamlReader::get_positive_float(yml, "missing"), eprosima::utils::ConfigurationException);
+    }
+}
+
+/**
+ * Check yaml list helpers for success and wrapped error paths
+ */
+TEST(YamlReaderScalarTest, get_list_and_set_helpers)
+{
+    // sequence success
+    {
+        Yaml yml;
+        yml.push_back(1);
+        yml.push_back(2);
+        yml.push_back(3);
+
+        std::list<int> result = YamlReader::get_list<int>(yml, LATEST);
+        ASSERT_EQ(result, std::list<int>({1, 2, 3}));
+    }
+
+    // list under tag failure wraps nested exception
+    {
+        Yaml yml;
+        yml["values"] = 5;
+        ASSERT_THROW(YamlReader::get_list<int>(yml, "values", LATEST), eprosima::utils::ConfigurationException);
+    }
+
+    // set conversion removes duplicates
+    {
+        Yaml yml;
+        yml["values"].push_back("alpha");
+        yml["values"].push_back("beta");
+        yml["values"].push_back("alpha");
+
+        std::set<std::string> result = YamlReader::get_set<std::string>(yml, "values", LATEST);
+        ASSERT_EQ(result.size(), 2u);
+        ASSERT_TRUE(result.find("alpha") != result.end());
+        ASSERT_TRUE(result.find("beta") != result.end());
+    }
+}
+
+/**
+ * Check timestamp parsing with optional units and failing cases
+ */
+TEST(YamlReaderScalarTest, get_timestamp)
+{
+    // valid timestamp with optional subsecond units
+    {
+        Yaml yml;
+        yml[TIMESTAMP_DATETIME_TAG] = "2026-01-02_03-04-05";
+        yml[TIMESTAMP_MILLISECONDS_TAG] = 6;
+        yml[TIMESTAMP_MICROSECONDS_TAG] = 7;
+        yml[TIMESTAMP_NANOSECONDS_TAG] = 8;
+
+        const auto expected_base = utils::string_to_timestamp("2026-01-02_03-04-05", "%Y-%m-%d_%H-%M-%S", true);
+        const auto expected = std::chrono::time_point_cast<utils::Timestamp::duration>(
+            expected_base + std::chrono::milliseconds(6) + std::chrono::microseconds(7) + std::chrono::nanoseconds(8));
+
+        ASSERT_EQ(YamlReader::get<utils::Timestamp>(yml, LATEST), expected);
+    }
+
+    // missing required datetime
+    {
+        Yaml yml;
+        ASSERT_THROW(YamlReader::get<utils::Timestamp>(yml, LATEST), eprosima::utils::ConfigurationException);
+    }
+
+    // malformed datetime
+    {
+        Yaml yml;
+        yml[TIMESTAMP_DATETIME_TAG] = "bad-datetime";
+        ASSERT_THROW(YamlReader::get<utils::Timestamp>(yml, LATEST), eprosima::utils::ConfigurationException);
     }
 }
 

--- a/ddspipe_yaml/test/unittest/yaml_validator/CMakeLists.txt
+++ b/ddspipe_yaml/test/unittest/yaml_validator/CMakeLists.txt
@@ -37,6 +37,9 @@ set(TEST_LIST
         validation_with_invalid_yaml_file
         validation_is_correct
         validation_edge_cases
+        schema_loading_error_paths_preserve_previous_schema
+        validation_reports_invalid_ip_formats
+        validation_supports_nulls_and_root_level_error_output
     )
 
 set(TEST_EXTRA_LIBRARIES

--- a/ddspipe_yaml/test/unittest/yaml_validator/YamlValidatorTest.cpp
+++ b/ddspipe_yaml/test/unittest/yaml_validator/YamlValidatorTest.cpp
@@ -29,13 +29,16 @@ using namespace eprosima;
 using namespace eprosima::ddspipe::yaml;
 
 namespace test {
-// Paths and files to test the constructors
+// Valid schema file used by the happy-path constructor and validation tests
 std::string valid_schema_path = "./valid_draft07_schema.json";
 
+// Invalid constructor inputs:
+// 1) wrong relative path, 2) malformed JSON file, 3) valid JSON but invalid draft-07 schema
 std::string invalid_schema_path_1 = "./test_yaml_files/valid_draft07_schema.json";
 std::string invalid_schema_path_2 = "./invalid_json_schema.json";
 std::string invalid_schema_path_3 = "./invalid_draft07_schema.json";
 
+// Minimal valid draft-07 schema used when the validator is constructed from a raw string
 std::string valid_schema_string =
         R"(
 {
@@ -57,6 +60,7 @@ std::string valid_schema_string =
 }
 )";
 
+// Structurally invalid draft-07 schema: "properties" must be an object, not an array
 std::string invalid_schema_string =
         R"(
 {
@@ -65,15 +69,27 @@ std::string invalid_schema_string =
 }
 )";
 
-// Invalid yaml file/node
+// Malformed JSON string used to trigger the parsing-error path in set_schema(FROM_STRING, ...)
+std::string malformed_schema_string =
+        R"(
+{
+    "$schema":"http://json-schema.org/draft-07/schema#",
+    "type":"object",
+)";
+
+// Valid YAML instance used as the main schema-validation input.
 Yaml valid_yml = YamlManager::load_file("./test_yaml_files/valid_test.yaml");
+
+// Missing child node extracted from a valid file to exercise the YAML-to-JSON conversion failure path
 Yaml invalid_yml = valid_yml["missing_key"];
 
-// Vectors with the valid and invalid YAML files
+// Files expected to pass validation with valid_draft07_schema.json
 std::vector<std::string> valid_files = {
     "./test_yaml_files/valid_test.yaml"
 };
 
+// Files expected to fail validation for different reasons: wrong version, negative integer,
+// wrong array type, invalid object contents, and unexpected additional property
 std::vector<std::string> invalid_files = {
     "./test_yaml_files/invalid_version.yaml",
     "./test_yaml_files/invalid_uint.yaml",
@@ -82,7 +98,8 @@ std::vector<std::string> invalid_files = {
     "./test_yaml_files/invalid_new_property.yaml"
 };
 
-// Test additional edge cases
+// Schema used to exercise scalar conversion edge cases:
+// quoted values that must remain strings, large numeric values, and custom format checks
 std::string edge_cases_schema_string =
         R"(
 {
@@ -139,6 +156,52 @@ std::string edge_cases_schema_string =
 }
 )";
 
+// Schema restricted to the custom IPv4 and IPv6 format validators
+std::string ip_format_schema_string =
+        R"(
+{
+    "$schema":"http://json-schema.org/draft-07/schema#",
+    "type":"object",
+    "additionalProperties":false,
+    "properties":{
+        "string-ipv4":{
+            "type":"string",
+            "format":"v4"
+        },
+        "string-ipv6":{
+            "type":"string",
+            "format":"v6"
+        }
+    }
+}
+)";
+
+// Schema used to verify YAML null nodes are converted to JSON null values
+std::string nullable_schema_string =
+        R"(
+{
+    "$schema":"http://json-schema.org/draft-07/schema#",
+    "type":"object",
+    "additionalProperties":false,
+    "properties":{
+        "nullable":{
+            "type":"null"
+        }
+    }
+}
+)";
+
+// Root-level integer schema used to trigger validation errors on the YAML root itself
+std::string root_integer_schema_string =
+        R"(
+{
+    "$schema":"http://json-schema.org/draft-07/schema#",
+    "type":"integer"
+}
+)";
+
+// YAML fixture covering scalar conversion edge cases:
+// quoted scalars, large integers, and large floating-point values
 Yaml edge_cases_types_yml = YAML::Load(
     "quoted-int: \"123\"\n"
     "quoted-float: \"123.456\"\n"
@@ -153,11 +216,27 @@ Yaml edge_cases_types_yml = YAML::Load(
     "large-float-2: 1.7976931348623157e308\n"   // std::numeric_limits<double>::max()
     );
 
+// YAML fixture with valid IPv4/IPv6 values plus an unsupported custom format,
+// which should validate successfully while emitting a warning
 Yaml edge_cases_format_yml = YAML::Load(
     "string-ipv4: 192.168.1.1\n"
     "string-ipv6: 2001:db8:85a3::8a2e:370:7334\n" //001:0db8:85a3:0000:0000:8a2e:0370:7334\n"
     "string-undefined-format: abc.123.def.456\n"
     );
+
+// YAML fixture with invalid IPv4/IPv6 values to exercise format-validation failures
+Yaml invalid_ip_format_yml = YAML::Load(
+    "string-ipv4: 999.999.999.999\n"
+    "string-ipv6: not-an-ipv6\n"
+    );
+
+// YAML fixture containing an explicit null value.
+Yaml nullable_yml = YAML::Load(
+    "nullable: ~\n"
+    );
+
+// Root scalar that violates root_integer_schema_string and produces a root-level validation error
+Yaml root_scalar_string_yml = YAML::Load("not-an-integer");
 } // namespace test
 
 
@@ -294,6 +373,67 @@ TEST(YamlValidatorTest, validation_edge_cases)
         eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Kind::Error); // restore verbosity
     }
 
+}
+
+/**
+ * Test invalid IPv4 and IPv6 values are reported as validation errors
+ */
+TEST(YamlValidatorTest, validation_reports_invalid_ip_formats)
+{
+    YamlValidator validator = YamlValidator(YamlValidator::InputType::FROM_STRING, test::ip_format_schema_string);
+
+    testing::internal::CaptureStderr();
+    ASSERT_FALSE(validator.validate_YAML(test::invalid_ip_format_yml));
+    std::string output = testing::internal::GetCapturedStderr();
+
+    ASSERT_NE(output.find("/string-ipv4"), std::string::npos);
+    ASSERT_NE(output.find("/string-ipv6"), std::string::npos);
+    ASSERT_NE(output.find("valid IPv4 address"), std::string::npos);
+    ASSERT_NE(output.find("valid IPv6 address"), std::string::npos);
+}
+
+/**
+ * Test additional schema-loading error paths and ensure a failed schema update
+ * does not replace the current valid schema
+ */
+TEST(YamlValidatorTest, schema_loading_error_paths_preserve_previous_schema)
+{
+    YamlValidator validator = YamlValidator(YamlValidator::InputType::FROM_FILE, test::valid_schema_path);
+
+    ASSERT_TRUE(validator.validate_YAML(test::valid_yml, false));
+
+    ASSERT_THROW(
+        validator.set_schema(YamlValidator::InputType::FROM_STRING, test::malformed_schema_string),
+        utils::ConfigurationException);
+
+    ASSERT_THROW(
+        validator.set_schema(static_cast<YamlValidator::InputType>(99), test::valid_schema_string),
+        utils::ConfigurationException);
+
+    ASSERT_TRUE(validator.validate_YAML(test::valid_yml, false));
+}
+
+/**
+ * Test null YAML values are converted correctly and root-level validation
+ * errors are displayed with the root marker
+ */
+TEST(YamlValidatorTest, validation_supports_nulls_and_root_level_error_output)
+{
+    {
+        YamlValidator validator = YamlValidator(YamlValidator::InputType::FROM_STRING, test::nullable_schema_string);
+        ASSERT_TRUE(validator.validate_YAML(test::nullable_yml, false));
+    }
+
+    {
+        YamlValidator validator = YamlValidator(YamlValidator::InputType::FROM_STRING, test::root_integer_schema_string);
+
+        testing::internal::CaptureStderr();
+        ASSERT_FALSE(validator.validate_YAML(test::root_scalar_string_yml));
+        std::string output = testing::internal::GetCapturedStderr();
+
+        ASSERT_NE(output.find("YAML VALIDATION FAILED"), std::string::npos);
+        ASSERT_NE(output.find("/  (root of the YAML file)"), std::string::npos);
+    }
 }
 
 int main(

--- a/ddspipe_yaml/test/unittest/yaml_validator/YamlValidatorTest.cpp
+++ b/ddspipe_yaml/test/unittest/yaml_validator/YamlValidatorTest.cpp
@@ -425,7 +425,8 @@ TEST(YamlValidatorTest, validation_supports_nulls_and_root_level_error_output)
     }
 
     {
-        YamlValidator validator = YamlValidator(YamlValidator::InputType::FROM_STRING, test::root_integer_schema_string);
+        YamlValidator validator = YamlValidator(YamlValidator::InputType::FROM_STRING,
+                        test::root_integer_schema_string);
 
         testing::internal::CaptureStderr();
         ASSERT_FALSE(validator.validate_YAML(test::root_scalar_string_yml));


### PR DESCRIPTION
## Description

This PR adds the missing test of the PR **[Feature/yaml validator v2](https://github.com/eProsima/DDS-Pipe/pull/187)**

---


## `ddspipe_yaml/src/cpp/YamlValidator.cpp`

https://app.codecov.io/gh/eProsima/DDS-Pipe/pull/187/blob/ddspipe_yaml/src/cpp/YamlValidator.cpp

### These paths are covered in:
`ddspipe_yaml/test/unittest/yaml_validator/YamlValidatorTest.cpp`

- `validation_reports_invalid_ip_formats` -> `format_checker()`
- `schema_loading_error_paths_preserve_previous_schema` - > `set_schema()`
- `validation_supports_nulls_and_root_level_error_output` -> validate_YAML()

## `ddspipe_yaml/include/ddspipe_yaml/impl/YamlReader.ipp` and `ddspipe_yaml/src/cpp/YamlReader_generic.cpp`

https://app.codecov.io/gh/eProsima/DDS-Pipe/pull/187/blob/ddspipe_yaml/include/ddspipe_yaml/impl/YamlReader.ipp
https://app.codecov.io/gh/eProsima/DDS-Pipe/pull/187/blob/ddspipe_yaml/src/cpp/YamlReader_generic.cpp

### These paths are covered in:
`ddspipe_yaml/test/unittest/yaml_reader/scalar/YamlReaderScalarTest.cpp`

- `get_positive_and_nonnegative_numbers_from_tag`
  Covers ->
  `get<unsigned int>`
  `get<float>`
  `get_nonnegative_int`
  `get_positive_int`
  `get_nonnegative_float`
  `get_positive_float`
  including success cases, negative-value failures, zero-not-positive failures, and wrapped missing-tag failures.
- `get_list_and_set_helpers`
  Covers ->
  `get_list<T>(yml, version)`
  `get_list<T>(yml, tag, version)`
  `get_set<T>(...)`
  including correct sequence parsing, wrapped tag errors, and duplicate removal in set conversion.
- `get_timestamp`
  Covers ->
  `get<utils::Timestamp>`
  including optional milliseconds/microseconds/nanoseconds, missing required datetime, and invalid datetime parsing.

## `ddspipe_yaml/src/cpp/YamlReader_participants.cpp`

https://app.codecov.io/gh/eProsima/DDS-Pipe/pull/187/blob/ddspipe_yaml/src/cpp/YamlReader_participants.cpp

### This file did not had any test. The following file covers the file.
- `ddspipe_yaml/test/unittest/yaml_reader/participants/YamlReaderParticipantsTest.cpp`

## `ddspipe_participants/src/cpp/xml/XmlHandlerConfiguration.cpp`

### That exact change is covered in:
`ddspipe_yaml/test/unittest/yaml_reader/participants/YamlReaderParticipantsTest.cpp`

- `xml_handler_configuration_invalid_file_message` -> `is_valid()`


