### PR TITLE
[#25513] Solve tools Flaky tests

### DIFF
--- a/ddspipe_core/include/ddspipe_core/interface/IWriter.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IWriter.hpp
@@ -19,6 +19,7 @@
 #include <cpp_utils/ReturnCode.hpp>
 
 #include <ddspipe_core/interface/IRoutingData.hpp>
+#include <ddspipe_core/types/dds/GuidPrefix.hpp>
 
 namespace eprosima {
 namespace ddspipe {
@@ -94,6 +95,33 @@ public:
     DDSPIPE_CORE_DllAPI
     virtual void update_topic_partitions(
             const std::map<std::string, std::string>& partition_name) = 0;
+
+    /**
+     * @brief Wait until this Writer has matched a Reader belonging to the participant identified by
+     * \c reader_participant_guid_prefix, or until \c timeout_ms milliseconds have elapsed.
+     *
+     * Needed for RPC reply routing: reply topics use VOLATILE durability, so a reply written before
+     * the destination client's reply reader is matched on the writer side is silently dropped. As
+     * ROS 2 service clients never retry, that hangs the client forever. Gating the reply write on
+     * this method closes the discovery race (a client's \c wait_for_service only proves the match
+     * from the reader side).
+     *
+     * @param reader_participant_guid_prefix  GuidPrefix of the participant whose reader must match.
+     * @param timeout_ms                      Maximum time to wait, in milliseconds.
+     *
+     * @return \c true if a matching reader is present within the timeout, \c false otherwise.
+     *
+     * @note Default implementation returns \c true: writers that do not track matching are assumed
+     *       ready and never block the caller.
+     */
+    virtual bool wait_reader_matched(
+            const types::GuidPrefix& reader_participant_guid_prefix,
+            const unsigned int timeout_ms) const noexcept
+    {
+        static_cast<void>(reader_participant_guid_prefix);
+        static_cast<void>(timeout_ms);
+        return true;
+    }
 };
 
 } /* namespace core */

--- a/ddspipe_core/include/ddspipe_core/interface/IWriter.hpp
+++ b/ddspipe_core/include/ddspipe_core/interface/IWriter.hpp
@@ -122,6 +122,7 @@ public:
         static_cast<void>(timeout_ms);
         return true;
     }
+
 };
 
 } /* namespace core */

--- a/ddspipe_core/src/cpp/communication/rpc/RpcBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/rpc/RpcBridge.cpp
@@ -128,8 +128,9 @@ void RpcBridge::enable() noexcept
             catch (const utils::InitializationException& e)
             {
                 EPROSIMA_LOG_ERROR(DDSPIPE_RPCBRIDGE,
-                        "Error while creating endpoints in RpcBridge for service " << rpc_topic_ <<
-                        ". Error code:" << e.what() << ".");
+                        "Error while creating endpoints in RpcBridge for service " << rpc_topic_
+                                                                                   << ". Error code:" << e.what()
+                                                                                   << ".");
                 return;
             }
         }
@@ -242,8 +243,8 @@ void RpcBridge::data_available_(
     if (enabled_)
     {
         logDebug(
-            DDSPIPE_RPCBRIDGE, "RpcBridge " << *this <<
-                " has data ready to be sent in reader " << reader_guid << " .");
+            DDSPIPE_RPCBRIDGE, "RpcBridge " << *this
+                                            << " has data ready to be sent in reader " << reader_guid << " .");
 
         // Protected by internal RTPS Reader mutex, as called within \c onNewCacheChangeAdded callback
         // This method is also called from Reader's \c enable_ , so Reader's mutex must also be taken there beforehand
@@ -252,13 +253,14 @@ void RpcBridge::data_available_(
         {
             task.first = true;
             thread_pool_->emit(task.second);
-            logDebug(DDSPIPE_RPCBRIDGE, "RpcBridge " << *this <<
-                    " - " << reader_guid << " send callback to queue.");
+            logDebug(DDSPIPE_RPCBRIDGE, "RpcBridge " << *this
+                                                     << " - " << reader_guid << " send callback to queue.");
         }
         else
         {
-            logDebug(DDSPIPE_RPCBRIDGE, "RpcBridge " << *this <<
-                    " - " << reader_guid << " callback NOT sent (task already queued).");
+            logDebug(DDSPIPE_RPCBRIDGE, "RpcBridge " << *this
+                                                     << " - " << reader_guid
+                                                     << " callback NOT sent (task already queued).");
         }
     }
 }
@@ -269,8 +271,8 @@ void RpcBridge::transmit_(
     // Avoid being disabled while transmitting
     std::shared_lock<std::shared_timed_mutex> lock(on_transmission_mutex_);
 
-    logDebug(DDSPIPE_RPCBRIDGE, "RpcBridge " << *this <<
-            " transmitting for reader " << reader->guid() << " .");
+    logDebug(DDSPIPE_RPCBRIDGE, "RpcBridge " << *this
+                                             << " transmitting for reader " << reader->guid() << " .");
 
     while (true)
     {
@@ -317,8 +319,9 @@ void RpcBridge::transmit_(
         if (RpcTopic::is_request_topic(reader->topic()))
         {
             logDebug(DDSPIPE_RPCBRIDGE,
-                    "RpcBridge for service " << rpc_topic_ <<
-                    " transmitting request from remote endpoint " << rpc_data.source_guid << ".");
+                    "RpcBridge for service " << rpc_topic_
+                                             << " transmitting request from remote endpoint " << rpc_data.source_guid
+                                             << ".");
 
             SampleIdentity reply_related_sample_identity =
                     rpc_data.write_params.get_reference().sample_identity();
@@ -327,9 +330,10 @@ void RpcBridge::transmit_(
             if (reply_related_sample_identity == SampleIdentity::unknown())
             {
                 EPROSIMA_LOG_WARNING(DDSPIPE_RPCBRIDGE,
-                        "RpcBridge for service " << rpc_topic_ <<
-                        " received ill-formed request from remote endpoint " << rpc_data.source_guid <<
-                        ". Ignoring...");
+                        "RpcBridge for service " << rpc_topic_
+                                                 << " received ill-formed request from remote endpoint "
+                                                 << rpc_data.source_guid
+                                                 << ". Ignoring...");
             }
             else
             {
@@ -357,8 +361,8 @@ void RpcBridge::transmit_(
                     if (ret != utils::ReturnCode::RETCODE_OK)
                     {
                         EPROSIMA_LOG_WARNING(DDSPIPE_RPCBRIDGE, "Error writting request in RpcBridge for service "
-                                << rpc_topic_ << ". Error code " << ret <<
-                                ". Skipping data for this writer and continue.");
+                                << rpc_topic_ << ". Error code " << ret
+                                << ". Skipping data for this writer and continue.");
                         continue;
                     }
 
@@ -375,17 +379,18 @@ void RpcBridge::transmit_(
         else if (RpcTopic::is_reply_topic(reader->topic()))
         {
             logDebug(DDSPIPE_RPCBRIDGE,
-                    "RpcBridge for service " << rpc_topic_ <<
-                    " transmitting reply from remote endpoint " << rpc_data.source_guid << ".");
+                    "RpcBridge for service " << rpc_topic_
+                                             << " transmitting reply from remote endpoint " << rpc_data.source_guid
+                                             << ".");
 
             // A Server could be answering a different client in this same DDS Pipe or a remote client
             // Thus, it must be filtered so only replies to this client are processed.
             if (rpc_data.write_params.get_reference().sample_identity().writer_guid() != reader->guid())
             {
                 logDebug(DDSPIPE_RPCBRIDGE,
-                        "RpcBridge for service " << *this << " from reader " << reader->guid() <<
-                        " received response meant for other client: " <<
-                        rpc_data.write_params.get_reference().sample_identity().writer_guid());
+                        "RpcBridge for service " << *this << " from reader " << reader->guid()
+                                                 << " received response meant for other client: "
+                                                 << rpc_data.write_params.get_reference().sample_identity().writer_guid());
             }
             else
             {
@@ -420,8 +425,8 @@ void RpcBridge::transmit_(
                     {
                         EPROSIMA_LOG_WARNING(DDSPIPE_RPCBRIDGE,
                                 "RpcBridge for service " << rpc_topic_ << " writing reply towards participant "
-                                << registry_entry.second.writer_guid().guidPrefix <<
-                                " whose reply reader is not matched yet; reply may be lost.");
+                                                         << registry_entry.second.writer_guid().guidPrefix
+                                                         << " whose reply reader is not matched yet; reply may be lost.");
                     }
 
                     ret = reply_writers_[registry_entry.first]->write(*data);

--- a/ddspipe_core/src/cpp/communication/rpc/RpcBridge.cpp
+++ b/ddspipe_core/src/cpp/communication/rpc/RpcBridge.cpp
@@ -33,6 +33,10 @@ namespace core {
 
 using namespace eprosima::ddspipe::core::types;
 
+//! Maximum time (ms) to wait for the destination reply reader to be matched before writing a reply.
+//! Only reached during the discovery race window; the wait returns immediately once matched.
+static constexpr unsigned int REPLY_MATCH_MAX_WAIT_MS = 1000;
+
 RpcBridge::RpcBridge(
         const RpcTopic& topic,
         const std::shared_ptr<ParticipantsDatabase>& participants_database,
@@ -404,6 +408,21 @@ void RpcBridge::transmit_(
                 {
                     rpc_data.write_params.set_level();
                     rpc_data.write_params.get_reference().related_sample_identity(registry_entry.second);
+
+                    // Reply topics use VOLATILE durability: a reply written before the destination
+                    // client's reply reader has been matched on this writer's side is silently
+                    // dropped. As ROS 2 service clients never retry a request, that would hang the
+                    // client forever. The client's own \c wait_for_service only guarantees the match
+                    // from the reader side, so wait (bounded) for the writer side to match as well
+                    // before writing, closing the discovery race.
+                    if (!reply_writers_[registry_entry.first]->wait_reader_matched(
+                                registry_entry.second.writer_guid().guidPrefix, REPLY_MATCH_MAX_WAIT_MS))
+                    {
+                        EPROSIMA_LOG_WARNING(DDSPIPE_RPCBRIDGE,
+                                "RpcBridge for service " << rpc_topic_ << " writing reply towards participant "
+                                << registry_entry.second.writer_guid().guidPrefix <<
+                                " whose reply reader is not matched yet; reply may be lost.");
+                    }
 
                     ret = reply_writers_[registry_entry.first]->write(*data);
 

--- a/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dds/CommonParticipant.hpp
@@ -319,6 +319,10 @@ protected:
     //! <Topics <Writer_guid, Partitions set>>
     std::map<std::string, std::map<std::string, std::string>> partition_names;
 
+    //! Protects concurrent access to \c partition_names, which is written from the DDS discovery
+    //! thread (add/update/delete/clear_topic_partition) and read from other threads (topic_partitions).
+    mutable std::mutex partition_names_mutex_;
+
     // Filter partitions set
     std::set<std::string> partition_filter_set_;
     // Filter content_topicfilter dict

--- a/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/dynamic_types/SchemaParticipant.hpp
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <map>
+#include <mutex>
+#include <string>
+
 #include <ddspipe_core/dynamic/DiscoveryDatabase.hpp>
 #include <ddspipe_core/efficiency/payload/PayloadPool.hpp>
 #include <ddspipe_core/interface/IParticipant.hpp>
@@ -124,6 +128,10 @@ protected:
 
     //! <Topics <Writer_guid, Partitions set>>
     std::map<std::string, std::map<std::string, std::string>> partition_names;
+
+    //! Protects concurrent access to \c partition_names, which is written from the discovery
+    //! thread (add/update/delete/clear_topic_partition) and read from other threads (topic_partitions).
+    mutable std::mutex partition_names_mutex_;
 };
 
 } /* namespace participants */

--- a/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/participant/rtps/CommonParticipant.hpp
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#include <map>
+#include <mutex>
+#include <string>
+
 #include <cpp_utils/memory/Heritable.hpp>
 
 #include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
@@ -321,6 +325,10 @@ protected:
 
     //! <Topics <Writer_guid, Partitions set>>
     std::map<std::string, std::map<std::string, std::string>> partition_names;
+
+    //! Protects concurrent access to \c partition_names, which is written from the RTPS discovery
+    //! thread (add/update/delete/clear_topic_partition) and read from other threads (topic_partitions).
+    mutable std::mutex partition_names_mutex_;
 
     // Filter partitions set
     std::set<std::string> partition_filter_set_;

--- a/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
+++ b/ddspipe_participants/include/ddspipe_participants/writer/rtps/CommonWriter.hpp
@@ -15,6 +15,9 @@
 #pragma once
 
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <set>
 
 #include <cpp_utils/pool/IPool.hpp>
 #include <cpp_utils/ReturnCode.hpp>
@@ -139,6 +142,16 @@ public:
     void on_offered_incompatible_qos(
             fastdds::rtps::RTPSWriter*,
             eprosima::fastdds::dds::PolicyMask qos) noexcept override;
+
+    /**
+     * @brief Wait (bounded) until a Reader belonging to \c reader_participant_guid_prefix is matched.
+     *
+     * @note Used by RPC bridges to avoid dropping VOLATILE replies on the writer-side discovery race.
+     */
+    DDSPIPE_PARTICIPANTS_DllAPI
+    bool wait_reader_matched(
+            const core::types::GuidPrefix& reader_participant_guid_prefix,
+            const unsigned int timeout_ms) const noexcept override;
 
     /////////////////////
     // STATIC ATTRIBUTES
@@ -313,6 +326,15 @@ protected:
 
     //! Pool Configuration to create the internal History.
     utils::PoolConfiguration pool_configuration_;
+
+    //! GUIDs of the Readers (external to this Participant) currently matched with this Writer
+    std::set<fastdds::rtps::GUID_t> matched_readers_;
+
+    //! Protects \c matched_readers_ and coordinates \c wait_reader_matched
+    mutable std::mutex matched_readers_mutex_;
+
+    //! Notified whenever \c matched_readers_ changes so \c wait_reader_matched can wake up
+    mutable std::condition_variable matched_readers_cv_;
 };
 
 } /* namespace rtps */

--- a/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dds/CommonParticipant.cpp
@@ -115,6 +115,7 @@ core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
 
 std::map<std::string, std::map<std::string, std::string>> CommonParticipant::topic_partitions() const noexcept
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     return partition_names;
 }
 
@@ -578,6 +579,7 @@ bool CommonParticipant::add_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) != partition_names.end())
     {
         // the topic exists
@@ -604,6 +606,7 @@ bool CommonParticipant::update_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) == partition_names.end())
     {
         // the topic dont exists
@@ -627,6 +630,7 @@ bool CommonParticipant::delete_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) == partition_names.end())
     {
         // the topic dont exists
@@ -646,6 +650,7 @@ bool CommonParticipant::delete_topic_partition(
 
 void CommonParticipant::clear_topic_partitions()
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     partition_names.clear();
 }
 

--- a/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/dynamic_types/SchemaParticipant.cpp
@@ -71,6 +71,7 @@ core::types::TopicQoS SchemaParticipant::topic_qos() const noexcept
 
 std::map<std::string, std::map<std::string, std::string>> SchemaParticipant::topic_partitions() const noexcept
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     return partition_names;
 }
 
@@ -104,6 +105,7 @@ bool SchemaParticipant::add_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) != partition_names.end())
     {
         // the topic exists
@@ -130,6 +132,7 @@ bool SchemaParticipant::update_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) == partition_names.end())
     {
         // the topic dont exists
@@ -153,6 +156,7 @@ bool SchemaParticipant::delete_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) == partition_names.end())
     {
         // the topic dont exists
@@ -172,6 +176,7 @@ bool SchemaParticipant::delete_topic_partition(
 
 void SchemaParticipant::clear_topic_partitions()
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     partition_names.clear();
 }
 

--- a/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
+++ b/ddspipe_participants/src/cpp/participant/rtps/CommonParticipant.cpp
@@ -352,6 +352,7 @@ core::types::TopicQoS CommonParticipant::topic_qos() const noexcept
 
 std::map<std::string, std::map<std::string, std::string>> CommonParticipant::topic_partitions() const noexcept
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     return partition_names;
 }
 
@@ -574,6 +575,7 @@ bool CommonParticipant::add_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) != partition_names.end())
     {
         // the topic exists
@@ -600,6 +602,7 @@ bool CommonParticipant::update_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) == partition_names.end())
     {
         // the topic dont exists
@@ -623,6 +626,7 @@ bool CommonParticipant::delete_topic_partition(
         const std::string& writer_guid,
         const std::string& partition)
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     if (partition_names.find(topic_name) == partition_names.end())
     {
         // the topic dont exists
@@ -642,6 +646,7 @@ bool CommonParticipant::delete_topic_partition(
 
 void CommonParticipant::clear_topic_partitions()
 {
+    std::lock_guard<std::mutex> lock(partition_names_mutex_);
     partition_names.clear();
 }
 

--- a/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
+++ b/ddspipe_participants/src/cpp/writer/rtps/CommonWriter.cpp
@@ -116,6 +116,19 @@ void CommonWriter::on_writer_matched(
 {
     if (!come_from_this_participant_(info.remoteEndpointGuid))
     {
+        {
+            std::lock_guard<std::mutex> lock(matched_readers_mutex_);
+            if (info.status == fastdds::rtps::MatchingStatus::MATCHED_MATCHING)
+            {
+                matched_readers_.insert(info.remoteEndpointGuid);
+            }
+            else
+            {
+                matched_readers_.erase(info.remoteEndpointGuid);
+            }
+        }
+        matched_readers_cv_.notify_all();
+
         if (info.status == fastdds::rtps::MatchingStatus::MATCHED_MATCHING)
         {
             EPROSIMA_LOG_INFO(DDSPIPE_RTPS_COMMONWRITER_LISTENER,
@@ -129,6 +142,28 @@ void CommonWriter::on_writer_matched(
                               << info.remoteEndpointGuid);
         }
     }
+}
+
+bool CommonWriter::wait_reader_matched(
+        const core::types::GuidPrefix& reader_participant_guid_prefix,
+        const unsigned int timeout_ms) const noexcept
+{
+    std::unique_lock<std::mutex> lock(matched_readers_mutex_);
+
+    auto reader_from_participant_matched = [this, &reader_participant_guid_prefix]() -> bool
+            {
+                for (const auto& reader_guid : matched_readers_)
+                {
+                    if (reader_guid.guidPrefix == reader_participant_guid_prefix)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+    return matched_readers_cv_.wait_for(
+        lock, std::chrono::milliseconds(timeout_ms), reader_from_participant_matched);
 }
 
 void CommonWriter::on_writer_change_received_by_all(


### PR DESCRIPTION
# Description

Fix Tools Flaky tests. 
- DDS-Record-Replay
- DDS-Router
- DDS-Enabler

## DDS-Record-Replay

While stabilizing the DDS-Record-Replay CI (TSAN) several failures were traced to two distinct problems in this repository.

### 1. `DdsRecorderMonitor` crash when `monitor_status()` runs more than once

`DdsRecorderMonitor::monitor_status()` created the `DdsRecorderStatusMonitorProducer` in a function-local `static` `unique_ptr` and then `std::move`d it into the `StatusMonitorProducer` singleton. Because the variable is `static`, it is initialized only once and is left in a moved-from (null) state after the first call. Any second call — which every monitoring unit test does in its `SetUp()` — dereferenced the null pointer at `ddsrecorder_status_producer->init(...)`, crashing the process:

- **`0xC0000409`** (fatal exit) on Windows,
- **SIGSEGV** on Linux.

The whole test binary crashed on the second test, so CI blamed whichever test happened to be running (e.g. `LogMonitorDdsRecorderStatusTest.mcap_file_creation_failure`).

**Fix:** install the producer through `StatusMonitorProducer::init_instance()` (a no-op once the
singleton exists) and always retrieve/operate on `get_instance()`, re-registering the consumers on
it. This mirrors the `ddspipe_core::Monitor::monitor_status()` pattern and makes the method safe to
call multiple times per process.

### 2. Flaky `ResourceLimitsTest` SQL size assertions

`ResourceLimitsTest.sql_log_rotation` and `sql_max_file_size` intermittently failed with "unacceptable size" (e.g. 112–192 KB vs a 240 KB minimum). Root cause: `wait_for_acknowledgments()` only guarantees that samples reached the recorder's (reliable) reader, **not** that they have been written to disk. Writing is asynchronous, so on slow / loaded CI runners the write pipeline lags, and stopping the recorder while samples are still pending drops them, leaving the output file
smaller than expected.

**Fix:** before stopping the recorder, wait for the recording to catch up. The samples are retained
by the reliable reader (no data loss), so the test polls the on-disk recording (the open
`<file>.tmp~`, plus the SQLite `-wal` sidecar) until it reaches the steady state (log-rotation caps
it at `max-size`) or stops growing (drained), with a generous cap kept below the ctest timeout. This
removes the timing assumption without weakening the assertion — a genuine under-recording still fails.


## DDS-Router

RPC service replies were intermittently lost when routed through the DDS Router, causing ROS 2 service clients to hang forever on a request the server had actually answered. This surfaced as flaky failures in the DDS-Router dockertests:

- `tool.application.ddsrouter.compose.rpc_ros2_services_correct_target`
- `tool.application.ddsrouter.compose.rpc_ros2_services_trivial_multiple`
- `tool.application.ddsrouter.compose.rpc_ros2_services_repeater_with_talker`

### Root cause

Reply topics use `RELIABLE` + `VOLATILE` QoS. A client's `wait_for_service` only proves the reply reader is matched from the **reader** side, so the client starts sending requests while the router's client-facing reply **writer** has not yet matched that client's reply reader on the **writer** side. The router forwards the request, the server answers, and the router writes the reply into that discovery window — being `VOLATILE`, the sample is delivered to no one for that client and then purged. Because ROS 2 service clients never retry a request, the client blocks forever.
