### PR TITLE
 [20274] Remove default `port` value in yaml `address` field

### DIFF
--- a/ddspipe_yaml/src/cpp/YamlReader_types.cpp
+++ b/ddspipe_yaml/src/cpp/YamlReader_types.cpp
@@ -272,7 +272,8 @@ Address YamlReader::get<Address>(
     }
     else
     {
-        port = Address::default_port();
+        throw utils::ConfigurationException(utils::Formatter()
+                      << "Address requires to specify <" << ADDRESS_PORT_TAG << ">.");
     }
 
     // WARNING: This adds logic to the parse of the entity,

--- a/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_defaults.ipp
+++ b/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_defaults.ipp
@@ -32,6 +32,7 @@ using namespace eprosima::ddspipe::yaml::testing;
  *
  * POSITIVE CASES:
  * - empty
+ * - with no port
  * - with ip version ipv6
  */
 TEST(YamlGetEntityAddressTest, get_address_defaults)
@@ -39,6 +40,24 @@ TEST(YamlGetEntityAddressTest, get_address_defaults)
     // empty
     {
         Yaml yml_address;
+
+        Yaml yml;
+        yml["address"] = yml_address;
+
+        // Get participants::types::Address from Yaml
+        ASSERT_THROW(YamlReader::get<participants::types::Address>(yml, "address",
+                LATEST), eprosima::utils::ConfigurationException);
+    }
+
+    // with no port
+    {
+        Yaml yml_address;
+
+        // Add IP with ip-version ipv6
+        add_field_to_yaml(
+            yml_address,
+            YamlField<participants::types::IpType>("::1"),
+            ADDRESS_IP_TAG);
 
         Yaml yml;
         yml["address"] = yml_address;

--- a/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_defaults.ipp
+++ b/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_defaults.ipp
@@ -58,6 +58,12 @@ TEST(YamlGetEntityAddressTest, get_address_defaults)
             YamlField<participants::types::IpType>("::1"),
             ADDRESS_IP_TAG);
 
+        // Add port
+        add_field_to_yaml(
+            yml_address,
+            YamlField<participants::types::PortType>(participants::types::Address::default_port()),
+            ADDRESS_PORT_TAG);
+
         Yaml yml;
         yml["address"] = yml_address;
 

--- a/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_domain.ipp
+++ b/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_domain.ipp
@@ -54,6 +54,12 @@ TEST(YamlGetEntityAddressTest, get_address_domain)
             YamlField<std::string>(ADDRESS_IP_VERSION_V4_TAG),
             ADDRESS_IP_VERSION_TAG);
 
+        // Add port
+        add_field_to_yaml(
+            yml_address,
+            YamlField<participants::types::PortType>(participants::types::Address::default_port()),
+            ADDRESS_PORT_TAG);
+
         Yaml yml;
         yml["address"] = yml_address;
 
@@ -74,6 +80,12 @@ TEST(YamlGetEntityAddressTest, get_address_domain)
             yml_address,
             YamlField<participants::types::IpType>("localhost"),
             ADDRESS_DNS_TAG);
+
+        // Add port
+        add_field_to_yaml(
+            yml_address,
+            YamlField<participants::types::PortType>(participants::types::Address::default_port()),
+            ADDRESS_PORT_TAG);
 
         Yaml yml;
         yml["address"] = yml_address;

--- a/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_ip.ipp
+++ b/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_get_address_ip.ipp
@@ -60,6 +60,12 @@ TEST(YamlGetEntityAddressTest, get_address_ip)
                 YamlField<std::string>(ADDRESS_IP_VERSION_V4_TAG),
                 ADDRESS_IP_VERSION_TAG);
 
+            // Add port
+            add_field_to_yaml(
+                yml_address,
+                YamlField<participants::types::PortType>(participants::types::Address::default_port()),
+                ADDRESS_PORT_TAG);
+
             Yaml yml;
             yml["address"] = yml_address;
 
@@ -95,6 +101,12 @@ TEST(YamlGetEntityAddressTest, get_address_ip)
                 yml_address,
                 YamlField<std::string>(ADDRESS_IP_VERSION_V6_TAG),
                 ADDRESS_IP_VERSION_TAG);
+
+            // Add port
+            add_field_to_yaml(
+                yml_address,
+                YamlField<participants::types::PortType>(participants::types::Address::default_port()),
+                ADDRESS_PORT_TAG);
 
             Yaml yml;
             yml["address"] = yml_address;

--- a/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_ip_and_domain.ipp
+++ b/ddspipe_yaml/test/unittest/entities/address/test_units/YamlGetEntityAddressTest_ip_and_domain.ipp
@@ -56,6 +56,12 @@ TEST(YamlGetEntityAddressTest, ip_and_domain)
         ddspipe::yaml::testing::YamlField<participants::types::IpType>(ip_value),
         ADDRESS_IP_TAG);
 
+    // Add port
+    ddspipe::yaml::testing::add_field_to_yaml(
+        yml_address,
+        ddspipe::yaml::testing::YamlField<participants::types::PortType>(participants::types::Address::default_port()),
+        ADDRESS_PORT_TAG);
+
     Yaml yml;
     yml[ADDRESS_TRANSPORT_TAG] = yml_address;
 


### PR DESCRIPTION
As part of the PR https://github.com/eProsima/DDS-Router/pull/543, a few changes are needed in the Pipe to enforce the requirement of having a `port` tag as part of every element of `listening-addresses` and  `connection-addresses`, in the Yaml configuration of the Discovery Server and Initial Peers participants.

The changes consist on throwing an exception when no `port` tag is present instead of assigning the default value, and updating the involved tests to account for this.